### PR TITLE
Update README.md for using new binary image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,3 +121,7 @@ apply_folder: install
 .PHONY: destroy_folder
 destroy_folder: install
 	bash ./ci/destroy_folder.sh
+
+.PHONY: binary
+binary:
+	podman run --pull=always --rm registry.ci.openshift.org/ci/rhcs-tf-bin:latest cat /root/terraform-provider-ocm > ~/terraform-provider-ocm && chmod +x ~/terraform-provider-ocm

--- a/Makefile
+++ b/Makefile
@@ -124,4 +124,4 @@ destroy_folder: install
 
 .PHONY: binary
 binary:
-	podman run --pull=always --rm registry.ci.openshift.org/ci/rhcs-tf-bin:latest cat /root/terraform-provider-ocm > ~/terraform-provider-ocm && chmod +x ~/terraform-provider-ocm
+	podman run --pull=always --rm registry.ci.openshift.org/ci/rhcs-tf-bin:latest cat /root/terraform-provider-rhcs > ~/terraform-provider-rhcs && chmod +x ~/terraform-provider-rhcs

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you want to build a local Red Hat Cloud Services provider to develop improvem
 ### Testing binary
 If you want to locally test the provider binary without building from sources, you can pull the `latest` binary container image and copy the binary file to your local by running `make binary` or the whole background command if you need to make custom changes:
 ```
-    podman run --pull=always --rm registry.ci.openshift.org/ci/rhcs-tf-bin:latest cat /root/terraform-provider-ocm > ~/terraform-provider-ocm && chmod +x ~/terraform-provider-ocm
+    podman run --pull=always --rm registry.ci.openshift.org/ci/rhcs-tf-bin:latest cat /root/terraform-provider-rhcs > ~/terraform-provider-rhcs && chmod +x ~/terraform-provider-rhcs
 ```
 You can also use specific commit images by substituting `latest` for the desired commit SHA.
 Binary image only runs on AMD64 architectures up to now.

--- a/README.md
+++ b/README.md
@@ -94,12 +94,9 @@ If you want to build a local Red Hat Cloud Services provider to develop improvem
     }
 
 ### Testing binary
-If you want to locally test the provider binary without building from sources, you can pull the `latest` container image and copy the binary from the directory:
-    
-    <HOME>/.terraform.d/plugins/terraform.local/local/rhcs/<VERSION>/<TARGET_ARCH>
-    
-Paste it to your local using the following example: 
-
-    podman run --pull=always --rm registry.ci.openshift.org/ci/rhcs-tf-e2e:latest cat /root/.terraform.d/plugins/terraform.local/local/rhcs/1.0.5/linux_amd64/terraform-provider-rhcs > ~/terraform-provider-rhcs && chmod +x ~/terraform-provider-rhcs
-    
+If you want to locally test the provider binary without building from sources, you can pull the `latest` binary container image and copy the binary file to your local by running `make binary` or the whole background command if you need to make custom changes:
+```
+    podman run --pull=always --rm registry.ci.openshift.org/ci/rhcs-tf-bin:latest cat /root/terraform-provider-ocm > ~/terraform-provider-ocm && chmod +x ~/terraform-provider-ocm
+```
 You can also use specific commit images by substituting `latest` for the desired commit SHA.
+Binary image only runs on AMD64 architectures up to now.


### PR DESCRIPTION
Leave e2e image to e2e tests and use new ocm-tf-bin image for testing binary.
