### PR TITLE
Updated documentation for modifying machine pools

### DIFF
--- a/docs/modify-cluster.md
+++ b/docs/modify-cluster.md
@@ -1,4 +1,4 @@
-# Creating and modifying machine pools on your cluster
+# Using machine pools on your cluster
 
 ## Prerequisites
 
@@ -13,17 +13,82 @@ You may need to perform any of the following administrative tasks to create or m
 
 If you need to create a machine pool, use the `create_machine_pool` [Terraform module](../examples/create_machine_pool/README.md).
 
+1. Export the number of replicas for your machine pool:
+    ```
+    export TF_VAR_replica=<integer>
+    ```
+1. Export the ID of the cluster where you want to create a machine pool. This ID can be found with the `rosa list cluster` command:
+    ```
+    export TF_VAR_cluster_id=<cluster_ID_string>
+    ```
+1. Export the name of your new machine pool:
+    ```
+    export TF_VAR_name=<name_of_machine_pool>
+    ```
+1. Export the machine type of your machine pool:
+    ```
+    export TF_VAR_machine_type=<machine_type>
+    ```
+1. **Optional**: Export a label by using a key-value pair with commas separating each label
+    ````
+    export TF_VAR_labels='{ test="first-label" }'
+1. Run `terraform apply` to update the machine pools:
+    ```
+    terraform apply
+    ```
+1. Your machine pools should be updated.
 ### Changing replica count
 
 The replica count specifies how many compute nodes you want to provision. Using the `create_machine_pool` [Terraform module](../examples/create_machine_pool/README.md), you can change the replica count with the `replica` variable.
-```
-export TF_VAR_replica=<integer>
-```
 
+To change the replica count within your default machine pool, run these commands in the same Terraform module where you created your cluster. See the [Cluster with Managed OIDC configurations](examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md) and [Cluster with Unmanaged OIDC configurations](examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md) for examples. To set the replica count on an additional machine pool, export the machine pool name with `export TF_VAR_name=<name_of_machine_pool> `first. See [Creating a machine pool for an existing OpenShift cluster](examples/create_machine_pool/README.md) for examples.
+
+1. Export the new replica count:
+    ```
+    export TF_VAR_replica=<integer>
+    ```
+1. Run `terraform apply` to update the machine pools.
+    ```
+    terraform apply
+    ```
+1. Your machine pools should be updated.
 ### Autoscaling 
 
 You may enable or disable autoscaling on your machine pools. You must set either the minimum or maximum replica count variable for Terraform. The autoscaling will not exceed whichever value you set. For more information, see [About autoscaling nodes on a cluster](https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#rosa-nodes-about-autoscaling-nodes) in the Red Hat Customer Portal.
 
+To enable autoscaling within your default machine pool, run these commands in the same Terraform module where you created your cluster. See the [Cluster with Managed OIDC configurations](examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md) and [Cluster with Unmanaged OIDC configurations](examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md) for examples. To enable autoscaling on an additional machine pool, export the machine pool name with `export TF_VAR_name=<name_of_machine_pool> `first. See [Creating a machine pool for an existing OpenShift cluster](examples/create_machine_pool/README.md) for examples.
+1. Unset the environmental variable for `replicas` to be able to enable autoscaling:
+    ```
+    unset TF_VAR_replicas
+
+1. Export the following variables for a maximum and minimum replica count as well as enabling autoscaling:
+    > **IMPORTANT**: You must specify a maximum and minimum replica count when enabling autoscaling.
+    ````
+    export TF_VAR_autoscaling_enabled=<true|false>
+    ````
+    ````
+    export TF_VAR_min_replicas=<integer>
+    ````
+    ````
+    export TF_VAR_max_replicas=<integer>
+2. Run `terraform apply` to update the machine pools:
+    ```
+    terraform apply
+    ```
+3. Your machine pools should be updated to enable or disable autoscaling.
 ### Changing labels on machine pools
 
 You may add or edit labels on compute nodes. For more information, see [Adding node labels to a machine pool](https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#rosa-adding-node-labels_rosa-managing-worker-nodes) in the Red Hat Customer Portal.
+
+To add labels to your default machine pool, run these commands in the same Terraform module where you created your cluster. See the [Cluster with Managed OIDC configurations](examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/README.md) and [Cluster with Unmanaged OIDC configurations](examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/README.md) for examples. To add labels to an additional machine pool, export the machine pool name with `export TF_VAR_name=<name_of_machine_pool> `first. See [Creating a machine pool for an existing OpenShift cluster](examples/create_machine_pool/README.md) for examples.
+
+1. Export your label by using a key-value pair with commas separating each label:
+    ````
+    export TF_VAR_labels='{ test="first-label" }'
+2. Run `terraform apply` to update the machine pools:
+    ```
+    terraform apply
+    ```
+3. Your machine pools should be updated with your provided label.
+### Deleting a machine pool
+You can use the `terraform destroy` command to delete additional machine pools. You should specify the desired machine pool with the `name` variable.

--- a/docs/resources/machine_pool.md
+++ b/docs/resources/machine_pool.md
@@ -23,11 +23,11 @@ Machine pool.
 
 ### Optional
 
-- `autoscaling_enabled` (Boolean) Enables autoscaling.
-- `labels` (Map of String) Labels for machine pool. Format should be a comma-separated list of 'key = value'. This list will overwrite any modifications made to node labels on an ongoing basis..
-- `max_replicas` (Number) Max replicas.
-- `max_spot_price` (Number) Max Spot price.
-- `min_replicas` (Number) Min replicas.
+- `autoscaling_enabled` (Boolean) Enables autoscaling. This variable requires you to set a maximum and minimum replicas range using the `max_replicas` and `min_replicas` variables.
+- `labels` (Map of String) Labels for the machine pool. Format should be a comma-separated list of 'key = value'. This list will overwrite any modifications made to node labels on an ongoing basis.
+- `max_replicas` (Number) The maximum number of replicas for autoscaling functionality.
+- `max_spot_price` (Number) Maximum Spot price.
+- `min_replicas` (Number) The minimum number of replicas for autoscaling.
 - `replicas` (Number) The number of machines of the pool
 - `taints` (Attributes List) Taints for machine pool. Format should be a comma-separated list of 'key=value:ScheduleType'. This list will overwrite any modifications made to node taints on an ongoing basis. (see [below for nested schema](#nestedatt--taints))
 - `use_spot_instances` (Boolean) Use Spot Instances.

--- a/examples/create_machine_pool/README.md
+++ b/examples/create_machine_pool/README.md
@@ -9,8 +9,6 @@ This Terraform example creates a **machine pool** for an existing ROSA cluster. 
 * You have an offline OpenShift Cluster Manager token. This token can be generated in the [Red Hat Hybrid Cloud Console](https://console.redhat.com/openshift/token).
 * You have installed Terraform. See the [Terraform page](https://developer.hashicorp.com/terraform/downloads) for the latest version.
 * You have already created an OpenShift Cluster Manager cluster.
-
-
 ## Creating machine pools
 
 1. To run the `terraform apply` you need to set up some variables. This guide uses environmental variables. For more on Terraform variables, see [Managing Variables](https://developer.hashicorp.com/terraform/enterprise/workspaces/variables/managing-variables) in the Terraform documentation.
@@ -76,11 +74,9 @@ This Terraform example creates a **machine pool** for an existing ROSA cluster. 
 ## Resource clean up
 
 After you are done with the resources you created, you should not delete them manually, but instead, use the `destroy` command. Run the following to delete all of your created resources:
-  
 ```
 terraform destroy
 ```
-
 After the command is complete, your resources are deleted.
 
 > **NOTE**: If you manually delete a resource, you create unresolvable issues within your environment.

--- a/examples/create_machine_pool/main.tf
+++ b/examples/create_machine_pool/main.tf
@@ -29,8 +29,12 @@ provider "rhcs" {
 }
 
 resource "rhcs_machine_pool" "machine_pool" {
-  cluster      = var.cluster_id
-  name         = var.name
-  machine_type = var.machine_type
-  replicas     = var.replicas
+  cluster             = var.cluster_id
+  name                = var.name
+  machine_type        = var.machine_type
+  replicas            = var.replicas
+  autoscaling_enabled = var.autoscaling_enabled
+  min_replicas        = var.min_replicas
+  max_replicas        = var.max_replicas
+  labels              = var.labels
 }

--- a/examples/create_machine_pool/variables.tf
+++ b/examples/create_machine_pool/variables.tf
@@ -26,4 +26,29 @@ variable "machine_type" {
 variable "replicas" {
   description = "The amount of the machine created in this machine pool."
   type        = number
+  default     = null
+}
+
+variable "autoscaling_enabled" {
+    description = "Enables autoscaling. This variable requires you to set a maximum and minimum replicas range using the `max_replicas` and `min_replicas` variables."
+    type        = string
+	default     = "false"
+}
+
+variable "min_replicas" {
+  description = "The minimum number of replicas for autoscaling."
+  type        = number
+  default     = null
+}
+
+variable "max_replicas" {
+  description = "The maximum number of replicas not exceeded by the autoscaling functionality."
+  type        = number
+  default     = null
+}
+
+variable "labels" {
+  description = "Labels for the machine pool. Format should be a comma-separated list of 'key = value'. This list will overwrite any modifications made to node labels on an ongoing basis."
+  type        = map(string)
+  default     = null    
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -61,11 +61,15 @@ data "aws_caller_identity" "current" {
 }
 
 resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
-  name               = var.cluster_name
-  cloud_region       = var.cloud_region
-  aws_account_id     = data.aws_caller_identity.current.account_id
-  availability_zones = var.availability_zones
-  version            = var.openshift_version
+  name                = var.cluster_name
+  cloud_region        = var.cloud_region
+  aws_account_id      = data.aws_caller_identity.current.account_id
+  availability_zones  = var.availability_zones
+  replicas            = var.replicas
+  autoscaling_enabled = var.autoscaling_enabled
+  min_replicas        = var.min_replicas
+  max_replicas        = var.max_replicas
+  version             = var.openshift_version
   properties = {
     rosa_creator_arn = data.aws_caller_identity.current.arn
   }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
@@ -50,3 +50,27 @@ variable "openshift_version" {
   type        = string
   default     = "4.13.0"
 }
+
+variable "replicas" {
+  description = "The amount of the machine created in this machine pool."
+  type        = number
+  default     = null
+}
+
+variable "autoscaling_enabled" {
+    description = "Enables autoscaling. This variable requires you to set a maximum and minimum replicas range using the `max_replicas` and `min_replicas` variables."
+    type        = string
+	default     = "false"
+}
+
+variable "min_replicas" {
+  description = "The minimum number of replicas for autoscaling."
+  type        = number
+  default     = null
+}
+
+variable "max_replicas" {
+  description = "The maximum number of replicas not exceeded by the autoscaling functionality."
+  type        = number
+  default     = null
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -63,13 +63,17 @@ data "aws_caller_identity" "current" {
 }
 
 resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
-  name               = var.cluster_name
-  cloud_region       = var.cloud_region
-  aws_account_id     = data.aws_caller_identity.current.account_id
-  availability_zones = var.availability_zones
-  version            = var.openshift_version
+  name                = var.cluster_name
+  cloud_region        = var.cloud_region
+  aws_account_id      = data.aws_caller_identity.current.account_id
+  availability_zones  = var.availability_zones
+  replicas            = var.replicas
+  autoscaling_enabled = var.autoscaling_enabled
+  min_replicas        = var.min_replicas
+  max_replicas        = var.max_replicas
+  version             = var.openshift_version
   properties = {
-    rosa_creator_arn = data.aws_caller_identity.current.arn
+    rosa_creator_arn  = data.aws_caller_identity.current.arn
   }
   sts = local.sts_roles
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
@@ -55,3 +55,27 @@ variable "openshift_version" {
   type        = string
   default     = "4.13.0"
 }
+
+variable "replicas" {
+  description = "The amount of the machine created in this machine pool."
+  type        = number
+  default     = null
+}
+
+variable "autoscaling_enabled" {
+    description = "Enables autoscaling. This variable requires you to set a maximum and minimum replicas range using the `max_replicas` and `min_replicas` variables."
+    type        = string
+	default     = "false"
+}
+
+variable "min_replicas" {
+  description = "The minimum number of replicas for autoscaling."
+  type        = number
+  default     = null
+}
+
+variable "max_replicas" {
+  description = "The maximum number of replicas not exceeded by the autoscaling functionality."
+  type        = number
+  default     = null
+}

--- a/provider/machine_pool_resource.go
+++ b/provider/machine_pool_resource.go
@@ -96,17 +96,17 @@ func (t *MachinePoolResourceType) GetSchema(ctx context.Context) (result tfsdk.S
 				},
 			},
 			"autoscaling_enabled": {
-				Description: "Enables autoscaling.",
+				Description: "Enables autoscaling. This variable requires you to set a maximum and minimum replicas range using the `max_replicas` and `min_replicas` variables.",
 				Type:        types.BoolType,
 				Optional:    true,
 			},
 			"min_replicas": {
-				Description: "Min replicas.",
+				Description: "The minimum number of replicas for autoscaling.",
 				Type:        types.Int64Type,
 				Optional:    true,
 			},
 			"max_replicas": {
-				Description: "Max replicas.",
+				Description: "The maximum number of replicas for autoscaling functionality.",
 				Type:        types.Int64Type,
 				Optional:    true,
 			},
@@ -135,8 +135,8 @@ func (t *MachinePoolResourceType) GetSchema(ctx context.Context) (result tfsdk.S
 				Optional: true,
 			},
 			"labels": {
-				Description: "Labels for machine pool. Format should be a comma-separated list of 'key = value'." +
-					" This list will overwrite any modifications made to node labels on an ongoing basis..",
+				Description: "Labels for the machine pool. Format should be a comma-separated list of 'key = value'." +
+					" This list will overwrite any modifications made to node labels on an ongoing basis.",
 				Type: types.MapType{
 					ElemType: types.StringType,
 				},


### PR DESCRIPTION
Updated the Terraform documentation to show how to create machine pools, change the replica count, and enable autoscaling.