### PR TITLE
Refactoring the cluster properties validator

### DIFF
--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -2187,9 +2187,9 @@ func propertiesValidators() []tfsdk.AttributeValidator {
 				}
 				if !propertiesState.Null && !propertiesState.Unknown {
 					for k := range propertiesState.Elems {
-						if k == propertyRosaTfVersion || k == propertyRosaTfCommit {
+						if _, isDefaultKey := OCMProperties[k]; isDefaultKey {
 							errHead := "Invalid property key."
-							errDesc := fmt.Sprintf("Can not override reserved properties keys. Reserved keys: '%s'/'%s'", propertyRosaTfVersion, propertyRosaTfCommit)
+							errDesc := fmt.Sprintf("Can not override reserved properties keys. %s is a reserved property key", k)
 							resp.Diagnostics.AddError(errHead, errDesc)
 							return
 						}


### PR DESCRIPTION
In the validator, we make sure that the user is not passing a "reserved/default" property key. This was done by checking the key against the 2 options: `rosa_tf_version` and `rosa_tf_commit`.

This refactor will be more future-proof. We can add more reserved properties and not touch the validator in that area.

We now try to get the value of the proposed key from the OCMProperties map. If found, we throw the error.