### PR TITLE
Fix a minor space indentation issue

### DIFF
--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
@@ -58,9 +58,9 @@ variable "replicas" {
 }
 
 variable "autoscaling_enabled" {
-    description = "Enables autoscaling. This variable requires you to set a maximum and minimum replicas range using the `max_replicas` and `min_replicas` variables."
-    type        = string
-	default     = "false"
+  description = "Enables autoscaling. This variable requires you to set a maximum and minimum replicas range using the `max_replicas` and `min_replicas` variables."
+  type        = string
+  default     = "false"
 }
 
 variable "min_replicas" {


### PR DESCRIPTION
Fix a space indentation issue on example OIDC managed cluster [variable.tf](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/examples/create_rosa_cluster/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/variables.tf#L61) 