### PR TITLE
OCM-2360: Add support for importing a classic cluster

### DIFF
--- a/subsystem/main_test.go
+++ b/subsystem/main_test.go
@@ -242,6 +242,11 @@ func (r *TerraformRunner) Destroy() int {
 	return r.Run("destroy", "-auto-approve")
 }
 
+// Import runs the `import` command.
+func (r *TerraformRunner) Import(args ...string) int {
+	return r.Run(append([]string{"import"}, args...)...)
+}
+
 // State returns the reads the Terraform state and returns the result of parsing
 // it as a JSON document.
 func (r *TerraformRunner) State() interface{} {


### PR DESCRIPTION
Adds support for running `terraform import` to pull in a cluster.

**Usage:**
Add a minimal definition of the cluster to the `.tf` file:
```
resource "rhcs_cluster_rosa_classic" "mycluster" { }
```
Run import on that resource, passing the cluster's id:
```console
$ terraform import rhcs_cluster_rosa_classic.mycluster 24q7p8vthmm5erql10nn3qovq45juhsk
rhcs_cluster_rosa_classic.mycluster: Importing from ID "24q7p8vthmm5erql10nn3qovq45juhsk"...
data.rhcs_policies.all_policies: Reading...
rhcs_cluster_rosa_classic.mycluster: Import prepared!
  Prepared rhcs_cluster_rosa_classic for import
rhcs_cluster_rosa_classic.mycluster: Refreshing state... [id=24q7p8vthmm5erql10nn3qovq45juhsk]
data.rhcs_policies.all_policies: Read complete after 1s
data.aws_caller_identity.current: Reading...
data.aws_caller_identity.current: Read complete after 0s [id=765374464689]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```