### PR TITLE
OCM-2666: Remove AWS validations from rosa_cluster resource

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,6 @@ For more information, see the [Terraform documentation](https://developer.hashic
 The following items are limitations with the current release of the Red Hat Cloud Services Terraform provider:
 
 * The latest version is not backward compatible with version 1.0.1.
-* When creating a cluster, the cluster uses AWS credentials configured on your local machine. These credentials provide access to the AWS API for validating your account.
 * When creating a machine pool, you need to specify your replica count. You must define either the `replicas= "<count>"` variable or provide values for the following variables to build the machine pool:
    * `min_replicas = "<count>"`
    * `max_replicas="<count>"`

--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -2581,44 +2581,6 @@ var _ = Describe("rhcs_cluster_rosa_classic - upgrade", func() {
 		"available_upgrades": [],
 		"rosa_enabled": true
 	}`
-	const operIAMList = `{
-		"kind": "OperatorIAMRoleList",
-		"href": "/api/clusters_mgmt/v1/123/sts_operator_roles",
-		"page": 1,
-		"size": 6,
-		"total": 6,
-		"items": [
-		  {
-			"id": "",
-			"name": "ebs-cloud-credentials",
-			"role_arn": ""
-		  },
-		  {
-			"id": "",
-			"role_arn": ""
-		  },
-		  {
-			"id": "",
-			"name": "aws-cloud-credentials",
-			"role_arn": ""
-		  },
-		  {
-			"id": "",
-			"name": "cloud-credential-operator-iam-ro-creds",
-			"role_arn": ""
-		  },
-		  {
-			"id": "",
-			"name": "installer-cloud-credentials",
-			"role_arn": ""
-		  },
-		  {
-			"id": "",
-			"name": "cloud-credentials",
-			"role_arn": ""
-		  }
-		]
-	}`
 	const upgradePoliciesEmpty = `{
 		"kind": "UpgradePolicyList",
 		"page": 1,
@@ -2724,11 +2686,6 @@ var _ = Describe("rhcs_cluster_rosa_classic - upgrade", func() {
 			CombineHandlers(
 				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions/openshift-v4.10.1"),
 				RespondWithJSON(http.StatusOK, v4_10_1Info),
-			),
-			// Validate roles
-			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/sts_operator_roles"),
-				RespondWithJSON(http.StatusOK, operIAMList),
 			),
 			// Look for existing upgrade policies
 			CombineHandlers(
@@ -2846,11 +2803,6 @@ var _ = Describe("rhcs_cluster_rosa_classic - upgrade", func() {
 				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions/openshift-v4.10.1"),
 				RespondWithJSON(http.StatusOK, v4_10_1Info),
 			),
-			// Validate roles
-			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/sts_operator_roles"),
-				RespondWithJSON(http.StatusOK, operIAMList),
-			),
 			// Look for existing upgrade policies
 			CombineHandlers(
 				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies"),
@@ -2967,11 +2919,6 @@ var _ = Describe("rhcs_cluster_rosa_classic - upgrade", func() {
 				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions/openshift-v4.10.1"),
 				RespondWithJSON(http.StatusOK, v4_10_1Info),
 			),
-			// Validate roles
-			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/sts_operator_roles"),
-				RespondWithJSON(http.StatusOK, operIAMList),
-			),
 			// Look for existing upgrade policies
 			CombineHandlers(
 				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies"),
@@ -3043,11 +2990,6 @@ var _ = Describe("rhcs_cluster_rosa_classic - upgrade", func() {
 			CombineHandlers(
 				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions/openshift-v4.10.1"),
 				RespondWithJSON(http.StatusOK, v4_10_1Info),
-			),
-			// Validate roles
-			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/sts_operator_roles"),
-				RespondWithJSON(http.StatusOK, operIAMList),
 			),
 			// Look for existing upgrade policies
 			CombineHandlers(
@@ -3298,11 +3240,6 @@ var _ = Describe("rhcs_cluster_rosa_classic - upgrade", func() {
 				CombineHandlers(
 					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions/openshift-v4.10.1"),
 					RespondWithJSON(http.StatusOK, v4_10_1Info),
-				),
-				// Validate roles
-				CombineHandlers(
-					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/sts_operator_roles"),
-					RespondWithJSON(http.StatusOK, operIAMList),
 				),
 				// Look for existing upgrade policies
 				CombineHandlers(


### PR DESCRIPTION
This change is done in order to avoid the requirement to have valid AWS credentials in the local machine, in which the terraform executed. This change include:
* Remove the relevant code from the provider
* changing the subsystem accordingly to the change
* Removing limitation from docs