### PR TITLE
OCM-2361: Support generated account_role_prefix

### DIFF
--- a/ci/e2e/account_roles_files/main.tf
+++ b/ci/e2e/account_roles_files/main.tf
@@ -20,7 +20,7 @@ data "rhcs_policies" "all_policies" {}
 
 module "create_account_roles" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.10"
 
   create_operator_roles = false
   create_oidc_provider  = false

--- a/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -42,7 +42,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.10"
 
   create_operator_roles = true
   create_oidc_provider  = true

--- a/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -39,7 +39,7 @@ resource "rhcs_rosa_oidc_config_input" "oidc_input" {
 # Create the OIDC config resources on AWS
 module "oidc_config_input_resources" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.10"
 
   create_oidc_config_resources = true
 
@@ -66,7 +66,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.10"
 
   create_operator_roles = true
   create_oidc_provider  = true

--- a/examples/create_account_roles/README.md
+++ b/examples/create_account_roles/README.md
@@ -21,18 +21,18 @@ it also updated in the operator role policies.
 
    Run the following commands to export your variables. Provide your values in lieu of the brackets. Note that any values declared in the `variables.tf` are the default values if you do not export a superseding value.
         
-    1. Your account-role prefix prepends to all of your created roles. This value cannot end with a hyphen (-).
-        ```
-        export TF_VAR_account_role_prefix=<account_role_prefix>
-        ```
-    2.  This variable should be your full [OpenShift Cluster Manager offline token](https://console.redhat.com/openshift/token) that you generated in the prerequisites.  
+    1.  This variable should be your full [OpenShift Cluster Manager offline token](https://console.redhat.com/openshift/token) that you generated in the prerequisites.  
         ```
         export TF_VAR_token=<ocm_offline_token>
         ```
-    3.  This value should always point to `https://api.openshift.com`.  
+    2.  This value should always point to `https://api.openshift.com`.  
         ```
         export TF_VAR_url=https://api.openshift.com
         ```
+    3.  **Optional**: You can set the account-role prefix with this variable. This value cannot end with a hyphen (-). If the value is empty, the module generates a string that starts with `account-role-` and concatenates it with a random string of length 4.
+       ```    
+       export TF_VAR_account_role_prefix=<account_role_prefix>
+       ```
     4.  **Optional**: You can set the desired OpenShift version with this variable. The default is available from the ROSA CLI with `rosa list version |grep yes`. This should be in the format of x.y.z, such as 4.13.2
         ```    
         export TF_VAR_openshift_version=<choose_openshift_version>

--- a/examples/create_account_roles/main.tf
+++ b/examples/create_account_roles/main.tf
@@ -36,7 +36,7 @@ data "rhcs_policies" "all_policies" {}
 
 module "create_account_roles" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.10"
 
   create_operator_roles = false
   create_oidc_provider  = false

--- a/examples/create_account_roles/output.tf
+++ b/examples/create_account_roles/output.tf
@@ -1,0 +1,3 @@
+output "account_role_prefix" {
+  value = module.create_account_roles.account_role_prefix
+}

--- a/examples/create_account_roles/variables.tf
+++ b/examples/create_account_roles/variables.tf
@@ -9,7 +9,8 @@ variable "openshift_version" {
 }
 
 variable "account_role_prefix" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "token" {
@@ -33,4 +34,3 @@ variable "tags" {
   type        = map(string)
   default     = null
 }
-

--- a/examples/create_rosa_sts_cluster/classic_sts/cluster/main.tf
+++ b/examples/create_rosa_sts_cluster/classic_sts/cluster/main.tf
@@ -74,7 +74,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = ">=0.0.5"
+  version = "0.0.10"
 
   create_operator_roles = true
   create_oidc_provider  = true

--- a/examples/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
+++ b/examples/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
@@ -47,7 +47,7 @@ module "oidc_config_input_resources" {
   count = var.managed ? 0 : 1
 
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.10"
 
   create_oidc_config_resources = true
 
@@ -73,7 +73,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.10"
 
   create_operator_roles = true
   create_oidc_provider  = true


### PR DESCRIPTION
This PR depends on that [PR](https://github.com/terraform-redhat/terraform-aws-rosa-sts/pull/22)
This PR allows supplying of an empty string for account_role_prefix. 
If the user supplies an empty string for the `account_role_prefix` variable, the module terraform-aws-rosa-sts will generate account_role_prefix and will use it in order to create the roles. 