### PR TITLE
OCM-2645: Recreate cluster if it was deleted from other client

### DIFF
--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -381,6 +381,151 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 		Expect(resource).To(MatchJQ(".attributes.current_version", "openshift-4.8.0"))
 	})
 
+	It("Creates basic cluster - and reconcile on a 404", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, versionListPage1),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				VerifyJQ(`.name`, "my-cluster"),
+				VerifyJQ(`.cloud_provider.id`, "aws"),
+				VerifyJQ(`.region.id`, "us-west-1"),
+				VerifyJQ(`.product.id`, "rosa"),
+				VerifyJQ(`.properties.rosa_tf_version`, build.Version),
+				VerifyJQ(`.properties.rosa_tf_commit`, build.Commit),
+				RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.2",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"master_role_arn" : "",
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/nodes",
+					  "value": {
+						"compute": 3,
+						"compute_machine_type": {
+							"id": "r5.xlarge"
+						}
+					  }
+					}]`),
+			),
+		)
+
+		// Run the apply command:
+		terraform.Source(`
+		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+		    name           = "my-cluster"
+		    cloud_region   = "us-west-1"
+			aws_account_id = "123"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+		  }
+		`)
+		Expect(terraform.Apply()).To(BeZero())
+		resource := terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+		Expect(resource).To(MatchJQ(".attributes.current_version", "openshift-4.8.0"))
+		Expect(resource).To(MatchJQ(".attributes.id", "123")) // cluster has id 123
+
+		// Prepare the server for reconcile
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusNotFound, "{}"),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, versionListPage1),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				VerifyJQ(`.name`, "my-cluster"),
+				VerifyJQ(`.cloud_provider.id`, "aws"),
+				VerifyJQ(`.region.id`, "us-west-1"),
+				VerifyJQ(`.product.id`, "rosa"),
+				VerifyJQ(`.properties.rosa_tf_version`, build.Version),
+				VerifyJQ(`.properties.rosa_tf_commit`, build.Commit),
+				RespondWithPatchedJSON(http.StatusCreated, template, `[
+                    {
+                      "op": "replace",
+                      "path": "/id",
+                      "value": "1234"
+                    },
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.2",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"master_role_arn" : "",
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/nodes",
+					  "value": {
+						"compute": 3,
+						"compute_machine_type": {
+							"id": "r5.xlarge"
+						}
+					  }
+					}]`),
+			),
+		)
+
+		// Run the apply command:
+		terraform.Source(`
+		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+		    name           = "my-cluster"
+		    cloud_region   = "us-west-1"
+			aws_account_id = "123"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+		  }
+		`)
+		Expect(terraform.Apply()).To(BeZero())
+		resource = terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+		Expect(resource).To(MatchJQ(".attributes.current_version", "openshift-4.8.0"))
+		Expect(resource).To(MatchJQ(".attributes.id", "1234")) // reconciled cluster has id of 1234
+	})
+
 	It("Creates basic cluster with properties", func() {
 		prop_key := "my_prop_key"
 		prop_val := "my_prop_val"

--- a/subsystem/cluster_waiter_test.go
+++ b/subsystem/cluster_waiter_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Cluster creation", func() {
 	}`
 
 	Context("Create cluster waiter resource", func() {
-		BeforeEach(func() {
+		It("Create cluster waiter without a timeout", func() {
 			// Prepare the server:
 			server.AppendHandlers(
 				CombineHandlers(
@@ -113,9 +113,6 @@ var _ = Describe("Cluster creation", func() {
 					RespondWithJSON(http.StatusOK, templateReadyState),
 				),
 			)
-		})
-
-		It("Create cluster waiter without a timeout", func() {
 			terraform.Source(`
 				resource "rhcs_cluster_wait" "rosa_cluster" {
 				  cluster = "123"
@@ -133,11 +130,22 @@ var _ = Describe("Cluster creation", func() {
 				}
 			`)
 
-			// it should return a warning so exit code will be "0":
-			Expect(terraform.Apply()).To(BeZero())
+			// it should throw an error so exit code will not be "0":
+			Expect(terraform.Apply()).ToNot(BeZero())
 		})
 
 		It("Create cluster with a positive timeout", func() {
+			// Prepare the server:
+			server.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithJSON(http.StatusOK, templateReadyState),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithJSON(http.StatusOK, templateReadyState),
+				),
+			)
 			terraform.Source(`
 				resource "rhcs_cluster_wait" "rosa_cluster" {
 				  cluster = "123"


### PR DESCRIPTION
This PR adds the ability to reconcile a cluster that was created by TF, but then was removed via a different method, Not via terraform.

In this case, And if the user still has the cluster resource in his `.tf` files. Upon an `apply`, the provider will re-create the cluster.

Before this PR, the provider would have error out, since it could not find the cluster defined in the state.

Note: This PR also modifies the `cluster_waiter`. This is because we now do need to update the resource if the cluster id has changed. Also moved the timeout validation into a `validator` **this will now throw an error** if the user has set the `timeout` to a negative number. Unlike it worked before, printing a warning and using the default value.

The polling (`cluster_waiter`) was also moved to a new function, so both `Create` and `Update` can call.