### PR TITLE
OCM-2702: Add ldflag section to build in goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,9 @@ builds:
   - amd64
   - arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
+  ldflags:
+  - -X github.com/terraform-redhat/terraform-provider-rhcs/build.Version={{.Version}}
+  - -X github.com/terraform-redhat/terraform-provider-rhcs/build.Commit={{.Commit}}
 archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'


### PR DESCRIPTION
This is done in order to add the build properties (version and commit)