### PR TITLE
OCM-2636: Enable importing machine pools

### DIFF
--- a/provider/machine_pool_resource.go
+++ b/provider/machine_pool_resource.go
@@ -705,19 +705,19 @@ func (r *MachinePoolResource) Delete(ctx context.Context, request tfsdk.DeleteRe
 
 func (r *MachinePoolResource) ImportState(ctx context.Context, request tfsdk.ImportResourceStateRequest,
 	response *tfsdk.ImportResourceStateResponse) {
-	// To import a machine pool, we need to know the cluster ID and the machine pool name
+	// To import a machine pool, we need to know the cluster ID and the machine pool ID
 	fields := strings.Split(request.ID, ",")
 	if len(fields) != 2 || fields[0] == "" || fields[1] == "" {
 		response.Diagnostics.AddError(
 			"Invalid import identifier",
-			"Machine pool to import should be specified as <cluster_id>,<machine_pool_name>",
+			"Machine pool to import should be specified as <cluster_id>,<machine_pool_id>",
 		)
 		return
 	}
 	clusterID := fields[0]
-	machinePoolName := fields[1]
+	machinePoolID := fields[1]
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, tftypes.NewAttributePath().WithAttributeName("cluster"), clusterID)...)
-	response.Diagnostics.Append(response.State.SetAttribute(ctx, tftypes.NewAttributePath().WithAttributeName("id"), machinePoolName)...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, tftypes.NewAttributePath().WithAttributeName("id"), machinePoolID)...)
 }
 
 // populateState copies the data from the API object to the Terraform state.

--- a/provider/value_cannot_be_changed_modifier.go
+++ b/provider/value_cannot_be_changed_modifier.go
@@ -73,7 +73,8 @@ func (m valueCannotBeChangedModifier) Modify(ctx context.Context, req tfsdk.Modi
 
 	// the attribute value was changes
 	tflog.Debug(ctx, "attribute plan was changed")
-	resp.Diagnostics.AddAttributeError(req.AttributePath, "Value cannot be changed", "This attribute is blocked for updating")
-	return
-
+	resp.Diagnostics.AddAttributeError(req.AttributePath,
+		"Value cannot be changed",
+		fmt.Sprintf("%s is blocked for updating", req.AttributePath),
+	)
 }


### PR DESCRIPTION
Tested importing:
- 1AZ cluster, 1AZ pool
- mAZ cluster, 1AZ pool
- mAZ cluster, mAZ pool

Note: I removed the verification that replicas is a multiple of 3 in the case of mAZ pools. OCM provides this validation separately. The reason for the removal from the TF code is that it was causing a problem during updates after state import wrt the 1AZ optional fields for mAZ clusters. It would have required additional API queries to read the cluster object.