### PR TITLE
OCM-2769: change to explicit aws credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /dist/
 terraform.tfstate*
 /playground/*
+/vendor
 terraform-provider-rhcs

--- a/ci/e2e/account_roles_files/main.tf
+++ b/ci/e2e/account_roles_files/main.tf
@@ -16,6 +16,12 @@ provider "rhcs" {
   url   = var.url
 }
 
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
+}
+
 data "rhcs_policies" "all_policies" {}
 
 module "create_account_roles" {

--- a/ci/e2e/account_roles_files/variables.tf
+++ b/ci/e2e/account_roles_files/variables.tf
@@ -3,19 +3,32 @@ variable ocm_environment {
     default = "staging"
 }
 
+variable token {
+    type = string
+}
+
+variable url {
+    type = string
+}
+
+variable aws_access_key {
+    type = string
+}
+
+variable aws_secret_key {
+    type = string
+}
+
+variable aws_region {
+    type = string
+    default = "us-east-1"
+}
+
 variable openshift_version {
     type = string
     default = "4.13"
 }
 
 variable account_role_prefix {
-    type = string
-}
-
-variable token {
-    type = string
-}
-
-variable url {
     type = string
 }

--- a/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -31,6 +31,12 @@ provider "rhcs" {
   url   = var.url
 }
 
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
+}
+
 resource "rhcs_rosa_oidc_config" "oidc_config" {
   managed = true
 }

--- a/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/variables.tf
@@ -8,15 +8,11 @@ variable url {
     default = "https://api.stage.openshift.com"
 }
 
-variable operator_role_prefix {
+variable aws_access_key {
     type = string
 }
 
-variable account_role_prefix {
-    type = string
-}
-
-variable cluster_name {
+variable aws_secret_key {
     type = string
 }
 
@@ -28,6 +24,18 @@ variable aws_region {
 variable aws_availability_zones {
     type      = list(string)
     default = ["us-east-1a"]
+}
+
+variable operator_role_prefix {
+    type = string
+}
+
+variable account_role_prefix {
+    type = string
+}
+
+variable cluster_name {
+    type = string
 }
 
 variable replicas {

--- a/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -36,6 +36,12 @@ resource "rhcs_rosa_oidc_config_input" "oidc_input" {
   region = var.aws_region
 }
 
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
+}
+
 # Create the OIDC config resources on AWS
 module "oidc_config_input_resources" {
   source  = "terraform-redhat/rosa-sts/aws"

--- a/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/variables.tf
@@ -20,6 +20,14 @@ variable cluster_name {
     type = string
 }
 
+variable aws_access_key {
+    type = string
+}
+
+variable aws_secret_key {
+    type = string
+}
+
 variable aws_region {
     type = string
     default = "us-east-1"

--- a/ci/e2e/terraform_provider_ocm_files/main.tf
+++ b/ci/e2e/terraform_provider_ocm_files/main.tf
@@ -16,6 +16,12 @@ provider "rhcs" {
   url   = var.url
 }
 
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
+}
+
 locals {
   sts_roles = {
     role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",

--- a/ci/e2e/terraform_provider_ocm_files/variables.tf
+++ b/ci/e2e/terraform_provider_ocm_files/variables.tf
@@ -20,6 +20,14 @@ variable cluster_name {
     type = string
 }
 
+variable aws_access_key {
+    type = string
+}
+
+variable aws_secret_key {
+    type = string
+}
+
 variable aws_region {
     type = string
     default = "us-east-1"

--- a/ci/setup_prow_env.sh
+++ b/ci/setup_prow_env.sh
@@ -23,32 +23,40 @@ if [ -z "${GATEWAY_URL:-}" ]; then
 fi
 echo "[INFO] OCM gateway url: ${GATEWAY_URL}"
 
-OCM_TOKEN=$(cat "${CLUSTER_PROFILE_DIR}/ocm-token")
-if [ -z "${OCM_TOKEN:-}" ]; then
-    error_exit "missing mandatory variable \$OCM_TOKEN"
-fi
-
-
 CLUSTER_NAME_FILE="${SHARED_DIR}/cluster-name"
 if [[ ! -f "${CLUSTER_NAME_FILE}" ]]; then
     echo "rhcsci-$(mktemp -u XXXXX | tr '[:upper:]' '[:lower:]')" > "${CLUSTER_NAME_FILE}"
 fi
 CLUSTER_NAME=$(cat "${CLUSTER_NAME_FILE}")
 
-CLOUD_PROVIDER_REGION=${LEASED_RESOURCE}
+set +x
 
-# Configure aws
-AWSCRED="${CLUSTER_PROFILE_DIR}/.awscred"
-if [[ -f "${AWSCRED}" ]]; then
-    export AWS_SHARED_CREDENTIALS_FILE="${AWSCRED}"
-    export AWS_DEFAULT_REGION="${CLOUD_PROVIDER_REGION}"
-else
-    error_exit "Did not find compatible cloud provider cluster_profile"
+OCM_TOKEN=$(cat "${CLUSTER_PROFILE_DIR}/ocm-token")
+if [ -z "${OCM_TOKEN:-}" ]; then
+    error_exit "missing mandatory variable \$OCM_TOKEN"
 fi
-
-export TERRAFORM_D_DIR=/root # location of .terraform.d folder
 export TF_VAR_token=${OCM_TOKEN}
 
+#Expose aws credentials as explicit TF_VAR format, and do not use .awscred file
+#Take it from prow vault mounted at /var/run/..
+TF_VAR_aws_access_key=$(cat /var/run/aws-key/aws-key)
+export TF_VAR_aws_access_key
+TF_VAR_aws_secret_key=$(cat /var/run/aws-secret/aws-secret)
+export TF_VAR_aws_secret_key
+
+#next 4 lines to be removed once above is stable and not deleted
+TF_VAR_aws_access_key=$(cat ${CLUSTER_PROFILE_DIR}/.awscred | awk '/\[default\]/{line=1; next} line && /^\[/{exit} line' | grep aws_access_key_id     | awk -F '=' '{print $2}'| sed 's/ //g')
+export TF_VAR_aws_access_key
+TF_VAR_aws_secret_key=$(cat ${CLUSTER_PROFILE_DIR}/.awscred | awk '/\[default\]/{line=1; next} line && /^\[/{exit} line' | grep aws_secret_access_key | awk -F '=' '{print $2}'| sed 's/ //g')
+export TF_VAR_aws_secret_key
+
+set -x
+
+CLOUD_PROVIDER_REGION=${LEASED_RESOURCE}
+export AWS_DEFAULT_REGION="${CLOUD_PROVIDER_REGION}"
+export TF_VAR_aws_region="${CLOUD_PROVIDER_REGION}"
+
+export TERRAFORM_D_DIR=/root # location of .terraform.d folder
 WORK_DIR=${SHARED_DIR}/work
 STATE_ARCHIVE="${SHARED_DIR}/${ARCHIVE_NAME}.tar.gz" 
 TFVARS_FILE="${WORK_DIR}/terraform.tfvars"


### PR DESCRIPTION
PR for using  explicit aws_key/secret in main.tf of ci/e2e/*
#relates to https://issues.redhat.com/browse/OCM-2459