### PR TITLE
OCM-2415: Fixing the example of list_versions usage

### DIFF
--- a/ci/e2e/account_roles_files/main.tf
+++ b/ci/e2e/account_roles_files/main.tf
@@ -18,9 +18,11 @@ provider "rhcs" {
 
 data "rhcs_policies" "all_policies" {}
 
+data "rhcs_versions" "all" {}
+
 module "create_account_roles" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.10"
+  version = "0.0.11"
 
   create_operator_roles = false
   create_oidc_provider  = false
@@ -28,7 +30,8 @@ module "create_account_roles" {
 
   account_role_prefix    = var.account_role_prefix
   ocm_environment        = var.ocm_environment
-  rosa_openshift_version = "${split(".", var.openshift_version)[0]}.${split(".", var.openshift_version)[1]}"
+  rosa_openshift_version = var.openshift_version
   account_role_policies  = data.rhcs_policies.all_policies.account_role_policies
   operator_role_policies = data.rhcs_policies.all_policies.operator_role_policies
+  all_versions           = data.rhcs_versions.all
 }

--- a/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -42,7 +42,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.10"
+  version = "0.0.11"
 
   create_operator_roles = true
   create_oidc_provider  = true

--- a/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/ci/e2e/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -39,7 +39,7 @@ resource "rhcs_rosa_oidc_config_input" "oidc_input" {
 # Create the OIDC config resources on AWS
 module "oidc_config_input_resources" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.10"
+  version = "0.0.11"
 
   create_oidc_config_resources = true
 
@@ -66,7 +66,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.10"
+  version = "0.0.11"
 
   create_operator_roles = true
   create_oidc_provider  = true

--- a/examples/create_account_roles/main.tf
+++ b/examples/create_account_roles/main.tf
@@ -34,9 +34,11 @@ provider "rhcs" {
 
 data "rhcs_policies" "all_policies" {}
 
+data "rhcs_versions" "all" {}
+
 module "create_account_roles" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.10"
+  version = "0.0.11"
 
   create_operator_roles = false
   create_oidc_provider  = false
@@ -47,6 +49,7 @@ module "create_account_roles" {
   rosa_openshift_version = var.openshift_version
   account_role_policies  = data.rhcs_policies.all_policies.account_role_policies
   operator_role_policies = data.rhcs_policies.all_policies.operator_role_policies
+  all_versions            = data.rhcs_versions.all
   path                   = var.path
   tags                   = var.tags
 }

--- a/examples/create_rosa_sts_cluster/classic_sts/cluster/main.tf
+++ b/examples/create_rosa_sts_cluster/classic_sts/cluster/main.tf
@@ -74,7 +74,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.10"
+  version = "0.0.11"
 
   create_operator_roles = true
   create_oidc_provider  = true

--- a/examples/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
+++ b/examples/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
@@ -47,7 +47,7 @@ module "oidc_config_input_resources" {
   count = var.managed ? 0 : 1
 
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.10"
+  version = "0.0.11"
 
   create_oidc_config_resources = true
 
@@ -73,7 +73,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
 
 module "operator_roles_and_oidc_provider" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.10"
+  version = "0.0.11"
 
   create_operator_roles = true
   create_oidc_provider  = true

--- a/examples/list_versions/main.tf
+++ b/examples/list_versions/main.tf
@@ -24,12 +24,9 @@ terraform {
 }
 
 provider "rhcs" {
+  token = var.token
+  url   = var.url
 }
 
 data "rhcs_versions" "all" {
-}
-
-output "versions" {
-  description = "OpenShift versions"
-  value       = data.rhcs_versions.all
 }

--- a/examples/list_versions/output.tf
+++ b/examples/list_versions/output.tf
@@ -1,0 +1,4 @@
+output "versions" {
+  description = "OpenShift versions"
+  value       = data.rhcs_versions.all
+}

--- a/examples/list_versions/variables.tf
+++ b/examples/list_versions/variables.tf
@@ -1,0 +1,9 @@
+variable token {
+  type = string
+  sensitive = true
+}
+
+variable url {
+    type = string
+    default = "https://api.stage.openshift.com"
+}

--- a/tests/tf-manifests/aws/account-roles/main.tf
+++ b/tests/tf-manifests/aws/account-roles/main.tf
@@ -20,7 +20,7 @@ data "rhcs_policies" "all_policies"{}
 
 module "create_account_roles"{
   source = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.11"
 
   create_operator_roles = false
   create_oidc_provider = false

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -61,7 +61,7 @@ resource "rhcs_rosa_oidc_config_input" "oidc_input" {
 module "oidc_config_input_resources" {
   count = var.oidc_config=="un-managed"?1:0
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.11"
 
   create_oidc_config_resources = var.oidc_config=="un-managed"
 
@@ -90,7 +90,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
 module "operator_roles_and_oidc_provider" {
   count = var.oidc_config==null?0:1
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.11"
 
   create_operator_roles = true
   create_oidc_provider  = true
@@ -175,7 +175,7 @@ resource "rhcs_cluster_wait" "rosa_cluster" {
 
 module "operator_roles" {
   source  = "terraform-redhat/rosa-sts/aws"
-  version = "0.0.9"
+  version = "0.0.11"
 
   create_operator_roles = true
   create_oidc_provider  = var.oidc_config==null?true:false


### PR DESCRIPTION
This PR is updating the examples file:
1. To include the `all_versions` variable while creating account roles using the module
2.  To include the most updated version of the module

This PR is depends on : https://github.com/terraform-redhat/terraform-aws-rosa-sts/pull/24
