### PR TITLE
OCM-3042: Default MachinePool should be manipulated via machine_pool resource

### DIFF
--- a/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
@@ -199,18 +199,16 @@ func (r *ClusterRosaClassicResource) Schema(ctx context.Context, req resource.Sc
 				},
 			},
 			"autoscaling_enabled": schema.BoolAttribute{
-				Description: "Enables autoscaling.",
+				Description: "Enable autoscaling for the initial worker pool. (only valid during cluster creation)",
 				Optional:    true,
 			},
 			"min_replicas": schema.Int64Attribute{
-				Description: "Minimum replicas of worker nodes in a machine pool.",
+				Description: "Minimum replicas of worker nodes in a machine pool. (only valid during cluster creation)",
 				Optional:    true,
-				Computed:    true,
 			},
 			"max_replicas": schema.Int64Attribute{
-				Description: "Maximum replicas of worker nodes in a machine pool.",
+				Description: "Maximum replicas of worker nodes in a machine pool. (only valid during cluster creation)",
 				Optional:    true,
-				Computed:    true,
 			},
 			"api_url": schema.StringAttribute{
 				Description: "URL of the API server.",
@@ -237,24 +235,18 @@ func (r *ClusterRosaClassicResource) Schema(ctx context.Context, req resource.Sc
 			},
 			"replicas": schema.Int64Attribute{
 				Description: "Number of worker/compute nodes to provision. Single zone clusters need at least 2 nodes, " +
-					"multizone clusters need at least 3 nodes.",
+					"multizone clusters need at least 3 nodes. (only valid during cluster creation)",
 				Optional: true,
-				Computed: true,
 			},
 			"compute_machine_type": schema.StringAttribute{
 				Description: "Identifies the machine type used by the default/initial worker nodes, " +
 					"for example `m5.xlarge`. Use the `rhcs_machine_types` data " +
-					"source to find the possible values.",
+					"source to find the possible values. (only valid during cluster creation)",
 				Optional: true,
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"default_mp_labels": schema.MapAttribute{
 				Description: "This value is the default/initial machine pool labels. Format should be a comma-separated list of '{\"key1\"=\"value1\", \"key2\"=\"value2\"}'. " +
-					"This list overwrites any modifications made to node labels on an ongoing basis. ",
+					"(only valid during cluster creation)",
 				ElementType: types.StringType,
 				Optional:    true,
 			},
@@ -275,7 +267,7 @@ func (r *ClusterRosaClassicResource) Schema(ctx context.Context, req resource.Sc
 			},
 			"kms_key_arn": schema.StringAttribute{
 				Description: "The key ARN is the Amazon Resource Name (ARN) of a AWS Key Management Service (KMS) Key. It is a unique, " +
-					"fully qualified identifier for the AWS KMS Key. A key ARN includes the AWS account, Region, and the key ID" + 
+					"fully qualified identifier for the AWS KMS Key. A key ARN includes the AWS account, Region, and the key ID" +
 					"(optional).",
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
@@ -476,7 +468,6 @@ func (r *ClusterRosaClassicResource) Schema(ctx context.Context, req resource.Sc
 			},
 		},
 	}
-	return
 }
 
 func (r *ClusterRosaClassicResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -1065,19 +1056,8 @@ func (r *ClusterRosaClassicResource) Update(ctx context.Context, request resourc
 	}
 
 	clusterBuilder := cmv1.NewCluster()
-	clusterBuilder, _, err := updateNodes(ctx, state, plan, clusterBuilder)
-	if err != nil {
-		response.Diagnostics.AddError(
-			"Can't update cluster",
-			fmt.Sprintf(
-				"Can't update cluster nodes for cluster with identifier: `%s`, %v",
-				state.ID.ValueString(), err,
-			),
-		)
-		return
-	}
 
-	clusterBuilder, err = updateProxy(state, plan, clusterBuilder)
+	clusterBuilder, err := updateProxy(state, plan, clusterBuilder)
 	if err != nil {
 		response.Diagnostics.AddError(
 			"Can't update cluster",
@@ -1138,11 +1118,6 @@ func (r *ClusterRosaClassicResource) Update(ctx context.Context, request resourc
 		return
 	}
 
-	// update the autoscaling enabled with the plan value (important for nil and false cases)
-	state.AutoScalingEnabled = plan.AutoScalingEnabled
-
-	// update the Replicas with the plan value (important for nil and zero value cases)
-	state.Replicas = plan.Replicas
 	object := update.Body()
 
 	// Update the state:
@@ -1348,52 +1323,6 @@ func updateProxy(state, plan *ClusterRosaClassicState, clusterBuilder *cmv1.Clus
 	return clusterBuilder, nil
 }
 
-func updateNodes(ctx context.Context, state, plan *ClusterRosaClassicState, clusterBuilder *cmv1.ClusterBuilder) (*cmv1.ClusterBuilder, bool, error) {
-	// Send request to update the cluster:
-	shouldUpdateNodes := false
-	clusterNodesBuilder := cmv1.NewClusterNodes()
-	compute, ok := common.ShouldPatchInt(state.Replicas, plan.Replicas)
-	if ok {
-		clusterNodesBuilder = clusterNodesBuilder.Compute(int(compute))
-		shouldUpdateNodes = true
-	}
-	if common.HasValue(plan.AutoScalingEnabled) && plan.AutoScalingEnabled.ValueBool() {
-		// autoscaling enabled
-		autoscaling := cmv1.NewMachinePoolAutoscaling()
-
-		if common.HasValue(plan.MaxReplicas) {
-			autoscaling = autoscaling.MaxReplicas(int(plan.MaxReplicas.ValueInt64()))
-		}
-		if common.HasValue(plan.MinReplicas) {
-			autoscaling = autoscaling.MinReplicas(int(plan.MinReplicas.ValueInt64()))
-		}
-		clusterNodesBuilder = clusterNodesBuilder.AutoscaleCompute(autoscaling)
-		shouldUpdateNodes = true
-	} else {
-		if common.HasValue(plan.MaxReplicas) || common.HasValue(plan.MinReplicas) {
-			return nil, false, fmt.Errorf("Can't update MaxReplica and/or MinReplica of cluster when autoscaling is not enabled")
-		}
-	}
-
-	// MP labels update
-	if common.HasValue(plan.DefaultMPLabels) {
-		if labelsPlan, ok := common.ShouldPatchMap(state.DefaultMPLabels, plan.DefaultMPLabels); ok {
-			labels := map[string]string{}
-			for k, v := range labelsPlan.Elements() {
-				labels[k] = v.(types.String).ValueString()
-			}
-			clusterNodesBuilder.ComputeLabels(labels)
-			shouldUpdateNodes = true
-		}
-	}
-
-	if shouldUpdateNodes {
-		clusterBuilder = clusterBuilder.Nodes(clusterNodesBuilder)
-	}
-
-	return clusterBuilder, shouldUpdateNodes, nil
-}
-
 func (r *ClusterRosaClassicResource) Delete(ctx context.Context, request resource.DeleteRequest,
 	response *resource.DeleteResponse) {
 	tflog.Debug(ctx, "begin delete()")
@@ -1494,18 +1423,7 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 	state.APIURL = types.StringValue(object.API().URL())
 	state.ConsoleURL = types.StringValue(object.Console().URL())
 	state.Domain = types.StringValue(fmt.Sprintf("%s.%s", object.Name(), object.DNS().BaseDomain()))
-	state.Replicas = types.Int64Value(int64(object.Nodes().Compute()))
-	state.ComputeMachineType = types.StringValue(object.Nodes().ComputeMachineType().ID())
 	state.BaseDNSDomain = types.StringValue(object.DNS().BaseDomain())
-	labels, ok := object.Nodes().GetComputeLabels()
-	if ok {
-		mapValue, err := common.ConvertStringMapToMapType(labels)
-		if err != nil {
-			return err
-		} else {
-			state.DefaultMPLabels = mapValue
-		}
-	}
 
 	disableUserWorkload, ok := object.GetDisableUserWorkloadMonitoring()
 	if ok && disableUserWorkload {
@@ -1515,25 +1433,6 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 	isFips, ok := object.GetFIPS()
 	if ok && isFips {
 		state.FIPS = types.BoolValue(true)
-	}
-	autoScaleCompute, ok := object.Nodes().GetAutoscaleCompute()
-	if ok {
-		var maxReplicas, minReplicas int
-		state.AutoScalingEnabled = types.BoolValue(true)
-
-		maxReplicas, ok = autoScaleCompute.GetMaxReplicas()
-		if ok {
-			state.MaxReplicas = types.Int64Value(int64(maxReplicas))
-		}
-
-		minReplicas, ok = autoScaleCompute.GetMinReplicas()
-		if ok {
-			state.MinReplicas = types.Int64Value(int64(minReplicas))
-		}
-	} else {
-		// autoscaling not enabled - initialize the MaxReplica and MinReplica
-		state.MaxReplicas = types.Int64Null()
-		state.MinReplicas = types.Int64Null()
 	}
 
 	if azs, ok := object.Nodes().GetAvailabilityZones(); ok {

--- a/provider/clusterrosaclassic/cluster_rosa_classic_resource_test.go
+++ b/provider/clusterrosaclassic/cluster_rosa_classic_resource_test.go
@@ -22,9 +22,10 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"github.com/terraform-redhat/terraform-provider-rhcs/provider/proxy"
 	"net/http"
 	"testing"
+
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/proxy"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -249,7 +250,6 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 			Expect(clusterState.APIURL.ValueString()).To(Equal(apiUrl))
 			Expect(clusterState.ConsoleURL.ValueString()).To(Equal(consoleUrl))
 			Expect(clusterState.Domain.ValueString()).To(Equal(fmt.Sprintf("%s.%s", clusterName, baseDomain)))
-			Expect(clusterState.ComputeMachineType.ValueString()).To(Equal(machineType))
 
 			Expect(clusterState.AvailabilityZones.Elements()).To(HaveLen(1))
 			azs, err := common.StringListToArray(context.Background(), clusterState.AvailabilityZones)

--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -43,6 +43,10 @@ import (
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
 )
 
+// This is a magic name to trigger special handling for the cluster's default
+// machine pool
+const defaultMachinePoolName = "worker"
+
 var machinepoolNameRE = regexp.MustCompile(
 	`^[a-z]([-a-z0-9]*[a-z0-9])?$`,
 )
@@ -251,6 +255,13 @@ func (r *MachinePoolResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// The default machine pool is created automatically when the cluster is created.
+	// We want to import it instead of creating it.
+	if machinepoolName == defaultMachinePoolName {
+		r.magicImport(ctx, state, resp)
+		return
+	}
+
 	// Create the machine pool:
 	resource := r.collection.Cluster(state.Cluster.ValueString())
 	builder := cmv1.NewMachinePool().ID(state.ID.ValueString()).InstanceType(state.MachineType.ValueString())
@@ -373,6 +384,59 @@ func (r *MachinePoolResource) Create(ctx context.Context, req resource.CreateReq
 	resp.Diagnostics.Append(diags...)
 }
 
+// This handles the "magic" import of the default machine pool, allowing the
+// user to include it in their config w/o having to specifically `terraform
+// import` it.
+func (r *MachinePoolResource) magicImport(ctx context.Context, state *MachinePoolState, resp *resource.CreateResponse) {
+	machinepoolName := state.Name.ValueString()
+	existingState := &MachinePoolState{
+		ID:      types.StringValue(machinepoolName),
+		Cluster: state.Cluster,
+		Name:    types.StringValue(machinepoolName),
+	}
+	state.ID = types.StringValue(machinepoolName)
+
+	notFound, diags := r.readState(ctx, existingState)
+	if notFound {
+		// We disallow creating a machine pool with the default name. This
+		// case can only happen if the default machine pool was deleted and
+		// the user tries to recreate it.
+		diags.AddError(
+			"Can't create machine pool",
+			fmt.Sprintf(
+				"Can't create machine pool for cluster '%s': "+
+					"the default machine pool '%s' was deleted and a new machine pool with that name may not be created. "+
+					"Please use a different name.",
+				state.Cluster.ValueString(),
+				machinepoolName,
+			),
+		)
+	}
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = r.doUpdate(ctx, existingState, state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// the 1AZ-related settings don't apply to the default machine pool
+	if state.MultiAvailabilityZone.IsUnknown() {
+		state.MultiAvailabilityZone = types.BoolNull()
+	}
+	if state.AvailabilityZone.IsUnknown() {
+		state.AvailabilityZone = types.StringNull()
+	}
+	if state.SubnetID.IsUnknown() {
+		state.SubnetID = types.StringNull()
+	}
+
+	// Save the state:
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
 func (r *MachinePoolResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// Get the current state:
 	state := &MachinePoolState{}
@@ -444,13 +508,27 @@ func (r *MachinePoolResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	diags = r.doUpdate(ctx, state, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Save the state:
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolState, plan *MachinePoolState) (diags diag.Diagnostics) {
+	diags = diag.Diagnostics{}
+
 	resource := r.collection.Cluster(state.Cluster.ValueString()).
 		MachinePools().
 		MachinePool(state.ID.ValueString())
 	_, err := resource.Get().SendContext(ctx)
 
 	if err != nil {
-		resp.Diagnostics.AddError(
+		diags.AddError(
 			"Cannot find machine pool",
 			fmt.Sprintf(
 				"Cannot find machine pool with identifier '%s' for "+
@@ -465,7 +543,7 @@ func (r *MachinePoolResource) Update(ctx context.Context, req resource.UpdateReq
 
 	_, ok := common.ShouldPatchString(state.MachineType, plan.MachineType)
 	if ok {
-		resp.Diagnostics.AddError(
+		diags.AddError(
 			"Cannot update machine pool",
 			fmt.Sprintf(
 				"Cannot update machine pool for cluster '%s', machine type cannot be updated",
@@ -486,7 +564,7 @@ func (r *MachinePoolResource) Update(ctx context.Context, req resource.UpdateReq
 
 	autoscalingEnabled, errMsg := getAutoscaling(plan, mpBuilder)
 	if errMsg != "" {
-		resp.Diagnostics.AddError(
+		diags.AddError(
 			"Cannot update machine pool",
 			fmt.Sprintf(
 				"Cannot update machine pool for cluster '%s, %s ", state.Cluster.ValueString(), errMsg,
@@ -496,7 +574,7 @@ func (r *MachinePoolResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	if (autoscalingEnabled && computeNodesEnabled) || (!autoscalingEnabled && !computeNodesEnabled) {
-		resp.Diagnostics.AddError(
+		diags.AddError(
 			"Cannot update machine pool",
 			fmt.Sprintf(
 				"Cannot update machine pool for cluster '%s: either autoscaling or compute nodes should be enabled", state.Cluster.ValueString(),
@@ -527,7 +605,7 @@ func (r *MachinePoolResource) Update(ctx context.Context, req resource.UpdateReq
 
 	machinePool, err := mpBuilder.Build()
 	if err != nil {
-		resp.Diagnostics.AddError(
+		diags.AddError(
 			"Cannot update machine pool",
 			fmt.Sprintf(
 				"Cannot update machine pool for cluster '%s: %v ", state.Cluster.ValueString(), err,
@@ -539,7 +617,7 @@ func (r *MachinePoolResource) Update(ctx context.Context, req resource.UpdateReq
 		MachinePools().
 		MachinePool(state.ID.ValueString()).Update().Body(machinePool).SendContext(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(
+		diags.AddError(
 			"Failed to update machine pool",
 			fmt.Sprintf(
 				"Failed to update machine pool '%s'  on cluster '%s': %v",
@@ -551,10 +629,14 @@ func (r *MachinePoolResource) Update(ctx context.Context, req resource.UpdateReq
 
 	object := update.Body()
 
+	// update the autoscaling enabled with the plan value (important for nil and false cases)
+	state.AutoScalingEnabled = plan.AutoScalingEnabled
+	// update the Replicas with the plan value (important for nil and zero value cases)
+	state.Replicas = plan.Replicas
+
 	// Save the state:
-	r.populateState(object, plan)
-	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
+	r.populateState(object, state)
+	return
 }
 
 // Validate the machine pool's settings that pertain to availability zones.
@@ -794,9 +876,11 @@ func (r *MachinePoolResource) populateState(object *cmv1.MachinePool, state *Mac
 	// if the other (AZ/subnet) value is set. We don't need to set
 	// MultiAvailibilityZone here, because it's set in the validation function
 	// during create.
+	state.MultiAvailabilityZone = types.BoolValue(true)
 	azs := object.AvailabilityZones()
 	if len(azs) == 1 {
 		state.AvailabilityZone = types.StringValue(azs[0])
+		state.MultiAvailabilityZone = types.BoolValue(false)
 	} else {
 		state.AvailabilityZone = types.StringValue("")
 	}
@@ -804,6 +888,7 @@ func (r *MachinePoolResource) populateState(object *cmv1.MachinePool, state *Mac
 	subnets := object.Subnets()
 	if len(subnets) == 1 {
 		state.SubnetID = types.StringValue(subnets[0])
+		state.MultiAvailabilityZone = types.BoolValue(false)
 	} else {
 		state.SubnetID = types.StringValue("")
 	}

--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -381,19 +382,37 @@ func (r *MachinePoolResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	// Find the machine pool:
-	resource := r.collection.Cluster(state.Cluster.ValueString()).
-		MachinePools().
-		MachinePool(state.ID.ValueString())
-	get, err := resource.Get().SendContext(ctx)
-	if err != nil && get.Status() == http.StatusNotFound {
+	notFound, diags := r.readState(ctx, state)
+	if notFound {
+		// If we can't find the machine pool, it was deleted. Remove if from the
+		// state and don't return an error so the TF apply() will automatically
+		// recreate it.
 		tflog.Warn(ctx, fmt.Sprintf("machine pool (%s) of cluster (%s) not found, removing from state",
 			state.ID.ValueString(), state.Cluster.ValueString(),
 		))
 		resp.State.RemoveResource(ctx)
 		return
+	}
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func (r *MachinePoolResource) readState(ctx context.Context, state *MachinePoolState) (poolNotFound bool, diags diag.Diagnostics) {
+	diags = diag.Diagnostics{}
+
+	resource := r.collection.Cluster(state.Cluster.ValueString()).
+		MachinePools().
+		MachinePool(state.ID.ValueString())
+	get, err := resource.Get().SendContext(ctx)
+	if err != nil && get.Status() == http.StatusNotFound {
+		poolNotFound = true
+		return
 	} else if err != nil {
-		resp.Diagnostics.AddError(
+		diags.AddError(
 			"Failed to fetch machine pool",
 			fmt.Sprintf(
 				"Failed to fetch machine pool with identifier %s for cluster %s. Response code: %v",
@@ -404,11 +423,8 @@ func (r *MachinePoolResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	object := get.Body()
-
-	// Save the state:
 	r.populateState(object, state)
-	diags = resp.State.Set(ctx, state)
-	resp.Diagnostics.Append(diags...)
+	return
 }
 
 func (r *MachinePoolResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -519,8 +519,8 @@ func (r *MachinePoolResource) Update(ctx context.Context, req resource.UpdateReq
 	resp.Diagnostics.Append(diags...)
 }
 
-func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolState, plan *MachinePoolState) (diags diag.Diagnostics) {
-	diags = diag.Diagnostics{}
+func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolState, plan *MachinePoolState) diag.Diagnostics {
+	diags := diag.Diagnostics{}
 
 	resource := r.collection.Cluster(state.Cluster.ValueString()).
 		MachinePools().
@@ -536,7 +536,7 @@ func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolSt
 				state.ID.ValueString(), state.Cluster.ValueString(), err,
 			),
 		)
-		return
+		return diags
 	}
 
 	mpBuilder := cmv1.NewMachinePool().ID(state.ID.ValueString())
@@ -550,7 +550,7 @@ func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolSt
 				state.Cluster.ValueString(),
 			),
 		)
-		return
+		return diags
 	}
 
 	computeNodesEnabled := false
@@ -570,7 +570,7 @@ func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolSt
 				"Cannot update machine pool for cluster '%s, %s ", state.Cluster.ValueString(), errMsg,
 			),
 		)
-		return
+		return diags
 	}
 
 	if (autoscalingEnabled && computeNodesEnabled) || (!autoscalingEnabled && !computeNodesEnabled) {
@@ -580,7 +580,7 @@ func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolSt
 				"Cannot update machine pool for cluster '%s: either autoscaling or compute nodes should be enabled", state.Cluster.ValueString(),
 			),
 		)
-		return
+		return diags
 	}
 
 	patchLabels, shouldPatchLabels := common.ShouldPatchMap(state.Labels, plan.Labels)
@@ -611,7 +611,7 @@ func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolSt
 				"Cannot update machine pool for cluster '%s: %v ", state.Cluster.ValueString(), err,
 			),
 		)
-		return
+		return diags
 	}
 	update, err := r.collection.Cluster(state.Cluster.ValueString()).
 		MachinePools().
@@ -624,7 +624,7 @@ func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolSt
 				state.ID.ValueString(), state.Cluster.ValueString(), err,
 			),
 		)
-		return
+		return diags
 	}
 
 	object := update.Body()
@@ -636,7 +636,7 @@ func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolSt
 
 	// Save the state:
 	r.populateState(object, state)
-	return
+	return diags
 }
 
 // Validate the machine pool's settings that pertain to availability zones.

--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -779,19 +779,48 @@ func (r *MachinePoolResource) Delete(ctx context.Context, req resource.DeleteReq
 		MachinePool(state.ID.ValueString())
 	_, err := resource.Delete().SendContext(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Cannot delete machine pool",
-			fmt.Sprintf(
-				"Cannot delete machine pool with identifier '%s' for "+
-					"cluster '%s': %v",
-				state.ID.ValueString(), state.Cluster.ValueString(), err,
-			),
-		)
-		return
+		// We can't delete the pool, see if it's the last one:
+		numPools, err2 := r.countPools(ctx, state.Cluster.ValueString())
+		if numPools == 1 && err2 == nil {
+			// It's the last one, issue warning instead of error
+			resp.Diagnostics.AddWarning(
+				"Cannot delete machine pool",
+				fmt.Sprintf(
+					"Cannot delete the last machine pool for cluster '%s'. "+
+						"ROSA Classic clusters must have at least one machine pool. "+
+						"It is being removed from the Terraform state only. "+
+						"To resume managing this machine pool, import it again. "+
+						"It will be automatically deleted when the cluster is deleted.",
+					state.Cluster.ValueString(),
+				),
+			)
+			// No return, we want to remove the state
+		} else {
+			// Wasn't the last one, return error
+			resp.Diagnostics.AddError(
+				"Cannot delete machine pool",
+				fmt.Sprintf(
+					"Cannot delete machine pool with identifier '%s' for "+
+						"cluster '%s': %v",
+					state.ID.ValueString(), state.Cluster.ValueString(), err,
+				),
+			)
+			return
+		}
 	}
 
 	// Remove the state:
 	resp.State.RemoveResource(ctx)
+}
+
+// countPools returns the number of machine pools in the given cluster
+func (r *MachinePoolResource) countPools(ctx context.Context, clusterID string) (int, error) {
+	resource := r.collection.Cluster(clusterID).MachinePools()
+	resp, err := resource.List().SendContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return resp.Size(), nil
 }
 
 func (r *MachinePoolResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -1978,7 +1978,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 				Expect(terraform.Apply()).ToNot(BeZero())
 			})
 		})
-		It("Creates cluster with default_mp_labels and update them", func() {
+		It("Creates cluster with default_mp_labels", func() {
 			// Prepare the server:
 			server.AppendHandlers(
 				CombineHandlers(
@@ -2052,96 +2052,8 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 
 			Expect(terraform.Apply()).To(BeZero())
 
-			// apply for update the default_mp_labels
-			// Prepare the server:
-			server.AppendHandlers(
-				CombineHandlers(
-					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
-					RespondWithPatchedJSON(http.StatusOK, template, `[
-					{
-					  "op": "add",
-					  "path": "/aws",
-					  "value": {
-						  "ec2_metadata_http_tokens": "optional",
-						  "sts" : {
-							  "oidc_endpoint_url": "https://127.0.0.2",
-							  "thumbprint": "111111",
-							  "role_arn": "",
-							  "support_role_arn": "",
-							  "instance_iam_roles" : {
-								"master_role_arn" : "",
-								"worker_role_arn" : ""
-							  },
-							  "operator_role_prefix" : "test"
-						  }
-					  }
-					}]`),
-				),
-				// Update handler and response
-				CombineHandlers(
-					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
-					VerifyJQ(`.nodes.compute_labels.changed_label`, "changed"),
-					RespondWithPatchedJSON(http.StatusOK, template, `[
-					{
-					  "op": "add",
-					  "path": "/aws",
-					  "value": {
-						  "ec2_metadata_http_tokens": "optional",
-						  "sts" : {
-							  "oidc_endpoint_url": "https://127.0.0.2",
-							  "thumbprint": "111111",
-							  "role_arn": "",
-							  "support_role_arn": "",
-							  "instance_iam_roles" : {
-								"master_role_arn" : "",
-								"worker_role_arn" : ""
-							  },
-							  "operator_role_prefix" : "test"
-						  }
-					  }
-					},
-					{
-					  "op": "replace",
-					  "path": "/nodes",
-					  "value": {
-                        "compute_labels": {
-                            "changed_label": "changed"
-                        },
-						"availability_zones": [
-      						"us-west-1a"
-    					],
-						"compute_machine_type": {
-						   "id": "r5.xlarge"
-	    				}
-					  }
-					}
-					]`),
-				),
-			)
-
-			// update the attribute "proxy"
-			terraform.Source(`
-		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
-		    name           = "my-cluster"
-		    cloud_region   = "us-west-1"
-			aws_account_id = "123"
-            default_mp_labels = {
-                changed_label = "changed"
-            }
-			sts = {
-				operator_role_prefix = "test"
-				role_arn = "",
-				support_role_arn = "",
-				instance_iam_roles = {
-					master_role_arn = "",
-					worker_role_arn = "",
-				}
-			}
-		  }
-		`)
-			Expect(terraform.Apply()).To(BeZero(), "Failed to update cluster with changed default_mp_labels")
 			resource := terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
-			Expect(resource).To(MatchJQ(`.attributes.default_mp_labels.changed_label`, "changed"))
+			Expect(resource).To(MatchJQ(`.attributes.default_mp_labels.label_key1`, "label_value1"))
 		})
 
 		It("Except to fail on proxy validators", func() {
@@ -2519,7 +2431,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 			Expect(terraform.Apply()).To(BeZero())
 		})
 
-		It("Creates rosa sts cluster with autoscaling and update the default machine pool", func() {
+		It("Creates rosa sts cluster with autoscaling", func() {
 			// Prepare the server:
 			server.AppendHandlers(
 				CombineHandlers(
@@ -2610,231 +2522,10 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 		  }
 		`)
 			Expect(terraform.Apply()).To(BeZero())
-
-			// apply for update the min_replica from 2 to 3
-			// Prepare the server:
-			server.AppendHandlers(
-				CombineHandlers(
-					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
-					RespondWithPatchedJSON(http.StatusOK, template, `[
-					{
-					  "op": "add",
-					  "path": "/aws",
-					  "value": {
-						  "ec2_metadata_http_tokens": "optional",
-						  "sts" : {
-							  "oidc_endpoint_url": "https://127.0.0.2",
-							  "thumbprint": "111111",
-							  "role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
-							  "support_role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",
-							  "instance_iam_roles" : {
-								"master_role_arn" : "arn:aws:iam::account-id:role/ManagedOpenShift-ControlPlane-Role",
-								"worker_role_arn" : "arn:aws:iam::account-id:role/ManagedOpenShift-Worker-Role"
-							  },
-							  "operator_role_prefix" : "terraform-operator"
-						  }
-					  }
-					},
-					{
-					  "op": "add",
-					  "path": "/nodes",
-					  "value": {
-						"autoscale_compute": {
-							"min_replicas": 2,
-							"max_replicas": 4
-						},
-						"compute_machine_type": {
-							"id": "r5.xlarge"
-						},
-						"compute_labels": {
-							"label_key1": "label_value1",
-				    		"label_key2": "label_value2"
-						},
-                        "availability_zones": [
-							"az"
-						]
-					  }
-					}
-				  ]`),
-				),
-				CombineHandlers(
-					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
-					VerifyJQ(`.nodes.autoscale_compute.kind`, "MachinePoolAutoscaling"),
-					VerifyJQ(`.nodes.autoscale_compute.max_replicas`, float64(4)),
-					VerifyJQ(`.nodes.autoscale_compute.min_replicas`, float64(3)),
-					RespondWithPatchedJSON(http.StatusOK, template, `[
-					{
-					  "op": "add",
-					  "path": "/aws",
-					  "value": {
-						  "ec2_metadata_http_tokens": "optional",
-						  "sts" : {
-							  "oidc_endpoint_url": "https://127.0.0.2",
-							  "thumbprint": "111111",
-							  "role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
-							  "support_role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",
-							  "instance_iam_roles" : {
-								"master_role_arn" : "arn:aws:iam::account-id:role/ManagedOpenShift-ControlPlane-Role",
-								"worker_role_arn" : "arn:aws:iam::account-id:role/ManagedOpenShift-Worker-Role"
-							  },
-							  "operator_role_prefix" : "terraform-operator"
-						  }
-					  }
-					},
-					{
-					  "op": "add",
-					  "path": "/nodes",
-					  "value": {
-						"autoscale_compute": {
-							"min_replicas": 3,
-							"max_replicas": 4
-						},
-						"compute_machine_type": {
-							"id": "r5.xlarge"
-						},
-						"availability_zones": ["az"],
-						"compute_labels": {
-							"label_key1": "label_value1",
-				    		"label_key2": "label_value2"
-						}
-					  }
-					}
-				  ]`),
-				),
-			)
-			// Run the apply command:
-			terraform.Source(`
-		resource "rhcs_cluster_rosa_classic" "my_cluster" {
-			name           = "my-cluster"
-			cloud_region   = "us-west-1"
-			aws_account_id = "123"
-			autoscaling_enabled = "true"
-			min_replicas = "3"
-			max_replicas = "4"
-			default_mp_labels = {
-				"label_key1" = "label_value1",
-				"label_key2" = "label_value2"
-			}
-			sts = {
-				role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
-				support_role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",
-				instance_iam_roles = {
-				  master_role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-ControlPlane-Role",
-				  worker_role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Worker-Role"
-				},
-				"operator_role_prefix" : "terraform-operator"
-			}
-		  }
-		`)
-			Expect(terraform.Apply()).To(BeZero())
-
-			// apply for update the autoscaling group to compute nodes
-			// Prepare the server:
-			server.AppendHandlers(
-				CombineHandlers(
-					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
-					RespondWithPatchedJSON(http.StatusOK, template, `[
-					{
-					  "op": "add",
-					  "path": "/aws",
-					  "value": {
-						  "ec2_metadata_http_tokens": "optional",
-						  "sts" : {
-							  "oidc_endpoint_url": "https://127.0.0.2",
-							  "thumbprint": "111111",
-							  "role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
-							  "support_role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",
-							  "instance_iam_roles" : {
-								"master_role_arn" : "arn:aws:iam::account-id:role/ManagedOpenShift-ControlPlane-Role",
-								"worker_role_arn" : "arn:aws:iam::account-id:role/ManagedOpenShift-Worker-Role"
-							  },
-							  "operator_role_prefix" : "terraform-operator"
-						  }
-					  }
-					},
-					{
-					  "op": "add",
-					  "path": "/nodes",
-					  "value": {
-						"autoscale_compute": {
-							"min_replicas": 3,
-							"max_replicas": 4
-						},
-						"availability_zones": ["az"],
-						"compute_machine_type": {
-							"id": "r5.xlarge"
-						},
-						"compute_labels": {
-							"label_key1": "label_value1",
-				    		"label_key2": "label_value2"
-						}
-					  }
-					}
-				  ]`),
-				),
-				CombineHandlers(
-					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
-					VerifyJQ(`.nodes.compute`, float64(4)),
-					RespondWithPatchedJSON(http.StatusOK, template, `[
-					{
-					  "op": "add",
-					  "path": "/aws",
-					  "value": {
-						  "ec2_metadata_http_tokens": "optional",
-						  "sts" : {
-							  "oidc_endpoint_url": "https://127.0.0.2",
-							  "thumbprint": "111111",
-							  "role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
-							  "support_role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",
-							  "instance_iam_roles" : {
-								"master_role_arn" : "arn:aws:iam::account-id:role/ManagedOpenShift-ControlPlane-Role",
-								"worker_role_arn" : "arn:aws:iam::account-id:role/ManagedOpenShift-Worker-Role"
-							  },
-							  "operator_role_prefix" : "terraform-operator"
-						  }
-					  }
-					},
-					{
-					  "op": "add",
-					  "path": "/nodes",
-					  "value": {
-						"compute": 4,
-						"availability_zones": ["az"],
-						"compute_machine_type": {
-							"id": "r5.xlarge"
-						},
-						"compute_labels": {
-							"label_key1": "label_value1",
-				    		"label_key2": "label_value2"
-						}
-					  }
-					}
-				  ]`),
-				),
-			)
-			// Run the apply command:
-			terraform.Source(`
-		resource "rhcs_cluster_rosa_classic" "my_cluster" {
-			name           = "my-cluster"
-			cloud_region   = "us-west-1"
-			aws_account_id = "123"
-			replicas = 4
-			default_mp_labels = {
-				"label_key1" = "label_value1",
-				"label_key2" = "label_value2"
-			}
-			sts = {
-				role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
-				support_role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",
-				instance_iam_roles = {
-				  master_role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-ControlPlane-Role",
-				  worker_role_arn = "arn:aws:iam::account-id:role/ManagedOpenShift-Worker-Role"
-				},
-				"operator_role_prefix" : "terraform-operator"
-			}
-		  }
-		`)
-			Expect(terraform.Apply()).To(BeZero())
+			resource := terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(`.attributes.autoscaling_enabled`, true))
+			Expect(resource).To(MatchJQ(`.attributes.min_replicas`, 2.0))
+			Expect(resource).To(MatchJQ(`.attributes.max_replicas`, 4.0))
 		})
 
 		It("Creates rosa sts cluster with OIDC Configuration ID", func() {

--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -2103,6 +2103,203 @@ var _ = Describe("Machine pool creation for non exist cluster", func() {
 		  }
 		`)
 		Expect(terraform.Apply()).NotTo(BeZero())
+	})
+})
 
+var _ = Describe("Day-1 machine pool (worker)", func() {
+	BeforeEach(func() {
+		// The first thing that the provider will do for any operation on machine pools
+		// is check that the cluster is ready, so we always need to prepare the server to
+		// respond to that:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, `{
+					  "id": "123",
+					  "name": "my-cluster",
+					  "multi_az": false,
+					  "nodes": {
+						"availability_zones": [
+						  "us-east-1a"
+						]
+					  },
+					  "state": "ready"
+				}`),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, `{
+					  "id": "123",
+					  "name": "my-cluster",
+					  "multi_az": false,
+					  "nodes": {
+						"availability_zones": [
+						  "us-east-1a"
+						]
+					  },
+					  "state": "ready"
+				}`),
+			),
+		)
+	})
+
+	It("cannot be created", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			// Get is for the Read function
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker"),
+				RespondWithJSON(http.StatusNotFound, `
+					{
+						"kind": "Error",
+						"id": "404",
+						"href": "/api/clusters_mgmt/v1/errors/404",
+						"code": "CLUSTERS-MGMT-404",
+						"reason": "Machine pool with id 'worker' not found.",
+						"operation_id": "df359e0c-b1d3-4feb-9b58-50f7a20d0096"
+					}`),
+			),
+		)
+		terraform.Source(`
+			  resource "rhcs_machine_pool" "worker" {
+				cluster      = "123"
+			    name         = "worker"
+			    machine_type = "r5.xlarge"
+			    replicas     = 2
+			  }
+			`)
+		Expect(terraform.Apply()).NotTo(BeZero())
+	})
+
+	It("is automatically imported and updates applied", func() {
+		// Import automatically "Create()", and update the # of replicas: 2 -> 4
+		// Prepare the server:
+		server.AppendHandlers(
+			// Get is for the Read function
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker"),
+				RespondWithJSON(http.StatusOK, `
+					{
+						"id": "worker",
+						"kind": "MachinePool",
+						"href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker",
+						"replicas": 2,
+						"instance_type": "r5.xlarge"
+					}`),
+			),
+			// Get is for the read during update
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker"),
+				RespondWithJSON(http.StatusOK, `
+					{
+						"id": "worker",
+						"kind": "MachinePool",
+						"href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker",
+						"replicas": 2,
+						"instance_type": "r5.xlarge"
+					}`),
+			),
+			// Patch is for the update
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker"),
+				VerifyJSON(`{
+					  "kind": "MachinePool",
+					  "id": "worker",
+					  "replicas": 4
+					}`),
+				RespondWithJSON(http.StatusOK, `
+					{
+					  "id": "worker",
+					  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker",
+					  "kind": "MachinePool",
+					  "instance_type": "r5.xlarge",
+					  "replicas": 4
+					}`),
+			),
+		)
+		terraform.Source(`
+			resource "rhcs_machine_pool" "worker" {
+			  cluster      = "123"
+			  name         = "worker"
+			  machine_type = "r5.xlarge"
+			  replicas     = 4
+			}
+		`)
+		Expect(terraform.Apply()).To(BeZero())
+		resource := terraform.Resource("rhcs_machine_pool", "worker")
+		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
+		Expect(resource).To(MatchJQ(".attributes.name", "worker"))
+		Expect(resource).To(MatchJQ(".attributes.id", "worker"))
+		Expect(resource).To(MatchJQ(".attributes.replicas", 4.0))
+	})
+
+	It("can update labels", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			// Get is for the Read function
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker"),
+				RespondWithJSON(http.StatusOK, `
+						{
+							"id": "worker",
+							"kind": "MachinePool",
+							"href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker",
+							"replicas": 2,
+							"instance_type": "r5.xlarge"
+						}`),
+			),
+			// Get is for the read during update
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker"),
+				RespondWithJSON(http.StatusOK, `
+						{
+							"id": "worker",
+							"kind": "MachinePool",
+							"href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker",
+							"replicas": 2,
+							"instance_type": "r5.xlarge"
+						}`),
+			),
+			// Patch is for the update
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker"),
+				VerifyJSON(`{
+					  "kind": "MachinePool",
+						  "id": "worker",
+						  "labels": {
+						    "label_key1": "label_value1"
+						  },
+						  "replicas": 2
+						}`),
+				RespondWithJSON(http.StatusOK, `
+						{
+						  "id": "worker",
+						  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/worker",
+						  "kind": "MachinePool",
+						  "instance_type": "r5.xlarge",
+						  "labels": {
+						    "label_key1": "label_value1"
+						  },
+						  "replicas": 2
+						}`),
+			),
+		)
+		terraform.Source(`
+			resource "rhcs_machine_pool" "worker" {
+				cluster      = "123"
+				name         = "worker"
+				machine_type = "r5.xlarge"
+				replicas     = 2
+				labels = {
+					"label_key1" = "label_value1"
+				}
+			}
+			`)
+		Expect(terraform.Apply()).To(BeZero())
+		resource := terraform.Resource("rhcs_machine_pool", "worker")
+		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
+		Expect(resource).To(MatchJQ(".attributes.name", "worker"))
+		Expect(resource).To(MatchJQ(".attributes.id", "worker"))
+		Expect(resource).To(MatchJQ(`.attributes.labels | length`, 1))
 	})
 })


### PR DESCRIPTION
Supersedes #227

- [x] "worker" pool can be specified at cluster creation and it automatically imports the default worker pool
- [x] Modifying the "worker" pool adjusts the default pool
- [x] Default pool can be deleted by removing the "worker" pool
- [x] Once "worker" pool is deleted, it can't be recreated