### PR TITLE
OCM-2637: [BREAKING] htpasswd IDP user list

### DIFF
--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -82,8 +82,16 @@ Optional:
 
 Required:
 
+- `users` (Attributes List) A list of htpasswd user credentials (see [below for nested schema](#nestedatt--htpasswd--users))
+
+<a id="nestedatt--htpasswd--users"></a>
+### Nested Schema for `htpasswd.users`
+
+Required:
+
 - `password` (String, Sensitive) User password.
-- `username` (String) User name.
+- `username` (String) User username.
+
 
 
 <a id="nestedatt--ldap"></a>

--- a/examples/create_identity_provider/htpasswd/README.md
+++ b/examples/create_identity_provider/htpasswd/README.md
@@ -13,13 +13,9 @@ Using htpasswd authentication in OpenShift Container Platform allows you to iden
 ## Applying the Terraform plan
 
 1. You need to either create a `terraform.tfvars` file in this directory or add the following items to your existing `*.tfvars` file. You may also export these variables as environmental variables with the following commands:
-      1.  This value sets the username for logging into your application.
+      1.  This value sets the user list for logging into your application.
           ```
-          export TF_VAR_htpasswd_username=<user-name-to-login>
-          ```
-      1.  This value is the password for the account that you are creating.   
-          ```
-          export TF_VAR_htpasswd_password=<password-for-user-name>
+          export TF_VAR_users=[{\"username\":\"<user-name-to-login>\",\"password\":\"<password-for-user-name>\"},...]
           ```
       1.  This variable should be your full [OpenShift Cluster Manager offline token](https://console.redhat.com/openshift/token) that you generated in the prerequisites.  
           ```

--- a/examples/create_identity_provider/htpasswd/main.tf
+++ b/examples/create_identity_provider/htpasswd/main.tf
@@ -32,8 +32,7 @@ resource "rhcs_identity_provider" "htpasswd_idp" {
   cluster = var.cluster_id
   name    = "htpasswd"
   htpasswd = {
-    username = var.htpasswd_username
-    password = var.htpasswd_password
+    users = var.htpasswd_users
   }
 }
 

--- a/examples/create_identity_provider/htpasswd/variables.tf
+++ b/examples/create_identity_provider/htpasswd/variables.tf
@@ -16,11 +16,10 @@ variable "url" {
 }
 
 # IDP Variables
-variable "htpasswd_username" {
-  type        = string
-  description = "Username"
-}
-variable "htpasswd_password" {
-  type        = string
-  description = "Password"
+variable "htpasswd_users" {
+  type = list(object({
+    username = string
+    password = string
+  }))
+  description = "htpasswd user list"
 }

--- a/provider/identity_provider_resource.go
+++ b/provider/identity_provider_resource.go
@@ -333,17 +333,18 @@ func (r *IdentityProviderResource) Read(ctx context.Context, request tfsdk.ReadR
 		if state.HTPasswd == nil {
 			state.HTPasswd = &idps.HTPasswdIdentityProvider{}
 		}
-		username, ok := htpasswdObject.GetUsername()
-		if ok {
-			state.HTPasswd.Username = types.String{
-				Value: username,
-			}
-		}
-		password, ok := htpasswdObject.GetPassword()
-		if ok {
-			state.HTPasswd.Password = types.String{
-				Value: password,
-			}
+		if users, ok := htpasswdObject.GetUsers(); ok {
+			users.Each(func(item *cmv1.HTPasswdUser) bool {
+				state.HTPasswd.Users = append(state.HTPasswd.Users, idps.HTPasswdUser{
+					Username: types.String{
+						Value: item.Username(),
+					},
+					Password: types.String{
+						Value: item.Password(),
+					},
+				})
+				return true
+			})
 		}
 	case gitlabObject != nil:
 		if state.Gitlab == nil {

--- a/provider/idps/htpasswd.go
+++ b/provider/idps/htpasswd.go
@@ -12,15 +12,29 @@ import (
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
 )
 
-type HTPasswdIdentityProvider struct {
+type HTPasswdUser struct {
 	Username types.String `tfsdk:"username"`
 	Password types.String `tfsdk:"password"`
 }
 
+type HTPasswdIdentityProvider struct {
+	Users []HTPasswdUser `tfsdk:"users"`
+}
+
 func HtpasswdSchema() tfsdk.NestedAttributes {
 	return tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+		"users": {
+			Description: "A list of htpasswd user credentials",
+			Attributes:  HTPasswdUserList(),
+			Required:    true,
+		},
+	})
+}
+
+func HTPasswdUserList() tfsdk.NestedAttributes {
+	return tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
 		"username": {
-			Description: "User name.",
+			Description: "User username.",
 			Type:        types.StringType,
 			Required:    true,
 		},
@@ -30,17 +44,22 @@ func HtpasswdSchema() tfsdk.NestedAttributes {
 			Required:    true,
 			Sensitive:   true,
 		},
+	}, tfsdk.ListNestedAttributesOptions{
+		MinItems: 1,
 	})
 }
-
 func CreateHTPasswdIDPBuilder(ctx context.Context, state *HTPasswdIdentityProvider) *cmv1.HTPasswdIdentityProviderBuilder {
 	builder := cmv1.NewHTPasswdIdentityProvider()
-	if !state.Username.Null {
-		builder.Username(state.Username.Value)
+	userListBuilder := cmv1.NewHTPasswdUserList()
+	userList := []*cmv1.HTPasswdUserBuilder{}
+	for _, user := range state.Users {
+		userBuilder := &cmv1.HTPasswdUserBuilder{}
+		userBuilder.Username(user.Username.Value)
+		userBuilder.Password(user.Password.Value)
+		userList = append(userList, userBuilder)
 	}
-	if !state.Password.Null {
-		builder.Password(state.Password.Value)
-	}
+	userListBuilder.Items(userList...)
+	builder.Users(userListBuilder)
 	return builder
 }
 
@@ -48,7 +67,7 @@ func HTPasswdValidators() []tfsdk.AttributeValidator {
 	errSumm := "Invalid HTPasswd IDP resource configuration"
 	return []tfsdk.AttributeValidator{
 		&common.AttributeValidator{
-			Desc: "Validate username",
+			Desc: "Validate users list length",
 			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
 				state := &HTPasswdIdentityProvider{}
 				diag := req.Config.GetAttribute(ctx, req.AttributePath, state)
@@ -56,16 +75,13 @@ func HTPasswdValidators() []tfsdk.AttributeValidator {
 					// No attribute to validate
 					return
 				}
-
-				if !common.IsStringAttributeEmpty(state.Username) {
-					if err := ValidateHTPasswdUsername(state.Username.Value); err != nil {
-						resp.Diagnostics.AddError(errSumm, err.Error())
-					}
+				if len(state.Users) < 1 {
+					resp.Diagnostics.AddError(errSumm, "Must provide at least one user.")
 				}
 			},
 		},
 		&common.AttributeValidator{
-			Desc: "Validate password",
+			Desc: "Validate username/password",
 			Validator: func(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
 				state := &HTPasswdIdentityProvider{}
 				diag := req.Config.GetAttribute(ctx, req.AttributePath, state)
@@ -74,9 +90,16 @@ func HTPasswdValidators() []tfsdk.AttributeValidator {
 					return
 				}
 
-				if !common.IsStringAttributeEmpty(state.Password) {
-					if err := ValidateHTPasswdPassword(state.Password.Value); err != nil {
-						resp.Diagnostics.AddError(errSumm, err.Error())
+				for i, user := range state.Users {
+					if err := ValidateHTPasswdUsername(user.Username.Value); err != nil {
+						errMsg := fmt.Sprintf("Invalid username @ index %d. Error: %s", i, err.Error())
+						resp.Diagnostics.AddError(errSumm, errMsg)
+						return
+					}
+					if err := ValidateHTPasswdPassword(user.Password.Value); err != nil {
+						errMsg := fmt.Sprintf("Invalid password @ index %d. Error: %s", i, err.Error())
+						resp.Diagnostics.AddError(errSumm, errMsg)
+						return
 					}
 				}
 			},


### PR DESCRIPTION
This commit changes the way the user is passing user credentials into htpasswd IDP resource.

Before this commit, a single username and password was passed. 
This commit/PR moves to `users`, a list of user credentials.

Updated docs and examples as well.