### PR TITLE
Allow using empty default value (null) for availability_zones

### DIFF
--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -307,6 +307,7 @@ func (t *ClusterRosaClassicResourceType) GetSchema(ctx context.Context) (result 
 				},
 				Optional: true,
 				PlanModifiers: []tfsdk.AttributePlanModifier{
+					tfsdk.UseStateForUnknown(),
 					ValueCannotBeChangedModifier(),
 				},
 			},


### PR DESCRIPTION
We must allow null default values in order to allow using modules for this provider.

When created a module, which sets the `availability_zones = null`
I got an error during destroy that this attribute can't be changed