### PR TITLE
OCM-2641, OCM-17: Specify worker disk size for machine pools

### DIFF
--- a/docs/resources/cluster_rosa_classic.md
+++ b/docs/resources/cluster_rosa_classic.md
@@ -61,6 +61,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
 - `base_dns_domain` (String) Base DNS domain name previously reserved and matching the hosted zone name of the private Route 53 hosted zone associated with intended shared VPC, e.g., '1vo8.p1.openshiftapps.com'.
 - `channel_group` (String) Name of the channel group where you select the OpenShift cluster version, for example 'stable'. For ROSA, only 'stable' is supported.
 - `compute_machine_type` (String) Identifies the machine type used by the default/initial worker nodes, for example `m5.xlarge`. Use the `rhcs_machine_types` data source to find the possible values.
+- `worker_disk_size` (Number) Compute node root disk size, in GiB. (only valid during cluster creation)
 - `default_mp_labels` (Map of String) This value is the default/initial machine pool labels. Format should be a comma-separated list of '{"key1"="value1", "key2"="value2"}'. This list overwrites any modifications made to node labels on an ongoing basis.
 - `destroy_timeout` (Number) This value sets the maximum duration in minutes to allow for destroying resources. Default value is 60 minutes.
 - `disable_scp_checks` (Boolean) Enables you to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics.

--- a/docs/resources/cluster_rosa_classic.md
+++ b/docs/resources/cluster_rosa_classic.md
@@ -61,7 +61,6 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
 - `base_dns_domain` (String) Base DNS domain name previously reserved and matching the hosted zone name of the private Route 53 hosted zone associated with intended shared VPC, e.g., '1vo8.p1.openshiftapps.com'.
 - `channel_group` (String) Name of the channel group where you select the OpenShift cluster version, for example 'stable'. For ROSA, only 'stable' is supported.
 - `compute_machine_type` (String) Identifies the machine type used by the default/initial worker nodes, for example `m5.xlarge`. Use the `rhcs_machine_types` data source to find the possible values.
-- `worker_disk_size` (Number) Compute node root disk size, in GiB. (only valid during cluster creation)
 - `default_mp_labels` (Map of String) This value is the default/initial machine pool labels. Format should be a comma-separated list of '{"key1"="value1", "key2"="value2"}'. This list overwrites any modifications made to node labels on an ongoing basis.
 - `destroy_timeout` (Number) This value sets the maximum duration in minutes to allow for destroying resources. Default value is 60 minutes.
 - `disable_scp_checks` (Boolean) Enables you to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics.
@@ -89,6 +88,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
 - `upgrade_acknowledgements_for` (String) Indicates acknowledgement of agreements required to upgrade the cluster version between minor versions (e.g. a value of "4.12" indicates acknowledgement of any agreements required to upgrade to OpenShift 4.12.z from 4.11 or before).
 - `version` (String) Desired version of OpenShift for the cluster, for example '4.11.0'. If version is greater than the currently running version, an upgrade will be scheduled.
 - `wait_for_create_complete` (Boolean) Wait until the cluster is either in a ready state or in an error state. The waiter has a timeout of 60 minutes, with the default value set to false
+- `worker_disk_size` (Number) Compute node root disk size, in GiB. (only valid during cluster creation)
 
 ### Read-Only
 

--- a/docs/resources/machine_pool.md
+++ b/docs/resources/machine_pool.md
@@ -35,6 +35,7 @@ resource "rhcs_machine_pool" "machine_pool" {
 
 - `autoscaling_enabled` (Boolean) Enables autoscaling. If `true`, this variable requires you to set a maximum and minimum replicas range using the `max_replicas` and `min_replicas` variables.
 - `availability_zone` (String) Select the availability zone in which to create a single AZ machine pool for a multi-AZ cluster
+- `disk_size` (Number) Root disk size, in GiB.
 - `labels` (Map of String) Labels for the machine pool. Format should be a comma-separated list of 'key = value'. This list will overwrite any modifications made to node labels on an ongoing basis.
 - `max_replicas` (Number) The maximum number of replicas for autoscaling functionality.
 - `max_spot_price` (Number) Max Spot price.

--- a/internal/ocm/resource/cluster.go
+++ b/internal/ocm/resource/cluster.go
@@ -36,11 +36,19 @@ func (c *Cluster) Build() (object *cmv1.Cluster, err error) {
 
 func (c *Cluster) CreateNodes(autoScalingEnabled bool, replicas *int64, minReplicas *int64,
 	maxReplicas *int64, computeMachineType *string, labels map[string]string,
-	availabilityZones []string, multiAZ bool) error {
+	availabilityZones []string, multiAZ bool, workerDiskSize *int64) error {
 	nodes := cmv1.NewClusterNodes()
 	if computeMachineType != nil {
 		nodes.ComputeMachineType(
 			cmv1.NewMachineType().ID(*computeMachineType),
+		)
+	}
+
+	if workerDiskSize != nil {
+		nodes.ComputeRootVolume(
+			cmv1.NewRootVolume().AWS(
+				cmv1.NewAWSVolume().Size(int(*workerDiskSize)),
+			),
 		)
 	}
 

--- a/internal/ocm/resource/cluster_test.go
+++ b/internal/ocm/resource/cluster_test.go
@@ -15,22 +15,22 @@ var _ = Describe("Cluster", func() {
 	})
 	Context("CreateNodes validation", func() {
 		It("Autoscaling disabled minReplicas set - failure", func() {
-			err := cluster.CreateNodes(false, nil, pointer(int64(2)), nil, nil, nil, nil, false)
+			err := cluster.CreateNodes(false, nil, pointer(int64(2)), nil, nil, nil, nil, false, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Autoscaling must be enabled in order to set min and max replicas"))
 		})
 		It("Autoscaling disabled maxReplicas set - failure", func() {
-			err := cluster.CreateNodes(false, nil, nil, pointer(int64(2)), nil, nil, nil, false)
+			err := cluster.CreateNodes(false, nil, nil, pointer(int64(2)), nil, nil, nil, false, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Autoscaling must be enabled in order to set min and max replicas"))
 		})
 		It("Autoscaling disabled replicas smaller than 2 - failure", func() {
-			err := cluster.CreateNodes(false, pointer(int64(1)), nil, nil, nil, nil, nil, false)
+			err := cluster.CreateNodes(false, pointer(int64(1)), nil, nil, nil, nil, nil, false, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Cluster requires at least 2 compute nodes"))
 		})
 		It("Autoscaling disabled default replicas - success", func() {
-			err := cluster.CreateNodes(false, nil, nil, nil, nil, nil, nil, false)
+			err := cluster.CreateNodes(false, nil, nil, nil, nil, nil, nil, false, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -44,7 +44,7 @@ var _ = Describe("Cluster", func() {
 			Expect(autoscaleCompute).To(BeNil())
 		})
 		It("Autoscaling disabled 3 replicas - success", func() {
-			err := cluster.CreateNodes(false, pointer(int64(3)), nil, nil, nil, nil, nil, false)
+			err := cluster.CreateNodes(false, pointer(int64(3)), nil, nil, nil, nil, nil, false, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -58,12 +58,12 @@ var _ = Describe("Cluster", func() {
 			Expect(autoscaleCompute).To(BeNil())
 		})
 		It("Autoscaling enabled replicas set - failure", func() {
-			err := cluster.CreateNodes(true, pointer(int64(2)), nil, nil, nil, nil, nil, false)
+			err := cluster.CreateNodes(true, pointer(int64(2)), nil, nil, nil, nil, nil, false, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("When autoscaling is enabled, replicas should not be configured"))
 		})
 		It("Autoscaling enabled default minReplicas & maxReplicas - success", func() {
-			err := cluster.CreateNodes(true, nil, nil, nil, nil, nil, nil, false)
+			err := cluster.CreateNodes(true, nil, nil, nil, nil, nil, nil, false, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -79,12 +79,12 @@ var _ = Describe("Cluster", func() {
 			Expect(autoscaleCompute.MaxReplicas()).To(Equal(2))
 		})
 		It("Autoscaling enabled default maxReplicas smaller than minReplicas - failure", func() {
-			err := cluster.CreateNodes(true, nil, pointer(int64(4)), pointer(int64(3)), nil, nil, nil, false)
+			err := cluster.CreateNodes(true, nil, pointer(int64(4)), pointer(int64(3)), nil, nil, nil, false, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("max-replicas must be greater or equal to min-replicas"))
 		})
 		It("Autoscaling enabled set minReplicas & maxReplicas - success", func() {
-			err := cluster.CreateNodes(true, nil, pointer(int64(2)), pointer(int64(4)), nil, nil, nil, false)
+			err := cluster.CreateNodes(true, nil, pointer(int64(2)), pointer(int64(4)), nil, nil, nil, false, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("Cluster", func() {
 			Expect(autoscaleCompute.MaxReplicas()).To(Equal(4))
 		})
 		It("Autoscaling disabled set ComputeMachineType - success", func() {
-			err := cluster.CreateNodes(false, nil, nil, nil, pointer("asdf"), nil, nil, false)
+			err := cluster.CreateNodes(false, nil, nil, nil, pointer("asdf"), nil, nil, false, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = Describe("Cluster", func() {
 			Expect(autoscaleCompute).To(BeNil())
 		})
 		It("Autoscaling disabled set compute labels - success", func() {
-			err := cluster.CreateNodes(false, nil, nil, nil, nil, map[string]string{"key1": "val1"}, nil, false)
+			err := cluster.CreateNodes(false, nil, nil, nil, nil, map[string]string{"key1": "val1"}, nil, false, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -132,7 +132,7 @@ var _ = Describe("Cluster", func() {
 			Expect(autoscaleCompute).To(BeNil())
 		})
 		It("Autoscaling disabled multiAZ false set one availability zone - success", func() {
-			err := cluster.CreateNodes(false, nil, nil, nil, nil, nil, []string{"us-east-1a"}, false)
+			err := cluster.CreateNodes(false, nil, nil, nil, nil, nil, []string{"us-east-1a"}, false, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -147,17 +147,17 @@ var _ = Describe("Cluster", func() {
 			Expect(autoscaleCompute).To(BeNil())
 		})
 		It("Autoscaling disabled multiAZ false set three availability zones - failure", func() {
-			err := cluster.CreateNodes(false, nil, nil, nil, nil, nil, []string{"us-east-1a", "us-east-1b", "us-east-1c"}, false)
+			err := cluster.CreateNodes(false, nil, nil, nil, nil, nil, []string{"us-east-1a", "us-east-1b", "us-east-1c"}, false, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("The number of availability zones for a single AZ cluster should be 1, instead received: 3"))
 		})
 		It("Autoscaling disabled multiAZ true set three availability zones and two replicas - failure", func() {
-			err := cluster.CreateNodes(false, pointer(int64(2)), nil, nil, nil, nil, []string{"us-east-1a", "us-east-1b", "us-east-1c"}, true)
+			err := cluster.CreateNodes(false, pointer(int64(2)), nil, nil, nil, nil, []string{"us-east-1a", "us-east-1b", "us-east-1c"}, true, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Multi AZ cluster requires at least 3 compute nodes"))
 		})
 		It("Autoscaling disabled multiAZ true set three availability zones and three replicas - success", func() {
-			err := cluster.CreateNodes(false, pointer(int64(3)), nil, nil, nil, nil, []string{"us-east-1a", "us-east-1b", "us-east-1c"}, true)
+			err := cluster.CreateNodes(false, pointer(int64(3)), nil, nil, nil, nil, []string{"us-east-1a", "us-east-1b", "us-east-1c"}, true, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -172,9 +172,23 @@ var _ = Describe("Cluster", func() {
 			Expect(autoscaleCompute).To(BeNil())
 		})
 		It("Autoscaling disabled multiAZ true set one zone - failure", func() {
-			err := cluster.CreateNodes(false, nil, nil, nil, nil, nil, []string{"us-east-1a", "us-east-1b", "us-east-1c"}, true)
+			err := cluster.CreateNodes(false, nil, nil, nil, nil, nil, []string{"us-east-1a", "us-east-1b", "us-east-1c"}, true, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Multi AZ cluster requires at least 3 compute nodes"))
+		})
+		It("Custom disk size", func() {
+			diskSize := int64(543)
+			err := cluster.CreateNodes(false, pointer(int64(3)), nil, nil, nil, nil, nil, false, &diskSize)
+			Expect(err).NotTo(HaveOccurred())
+			ocmCluster, err := cluster.Build()
+			Expect(err).NotTo(HaveOccurred())
+			ocmClusterNode := ocmCluster.Nodes()
+			Expect(ocmClusterNode).NotTo(BeNil())
+			rootVolume := ocmClusterNode.ComputeRootVolume()
+			Expect(rootVolume).NotTo(BeNil())
+			awsVolume := rootVolume.AWS()
+			Expect(awsVolume).NotTo(BeNil())
+			Expect(awsVolume.Size()).To(Equal(int(diskSize)))
 		})
 	})
 	Context("CreateAWSBuilder validation", func() {

--- a/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
@@ -252,6 +252,10 @@ func (r *ClusterRosaClassicResource) Schema(ctx context.Context, req resource.Sc
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"worker_disk_size": schema.Int64Attribute{
+				Description: "Compute node root disk size, in GiB. (only valid during cluster creation)",
+				Optional:    true,
+			},
 			"default_mp_labels": schema.MapAttribute{
 				Description: "This value is the default/initial machine pool labels. Format should be a comma-separated list of '{\"key1\"=\"value1\", \"key2\"=\"value2\"}'. " +
 					"This list overwrites any modifications made to node labels on an ongoing basis. ",
@@ -586,9 +590,10 @@ func createClassicClusterObject(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	workerDiskSize := common.OptionalInt64(state.WorkerDiskSize)
 
 	if err = ocmClusterResource.CreateNodes(autoScalingEnabled, replicas, minReplicas, maxReplicas,
-		computeMachineType, labels, availabilityZones, multiAZ); err != nil {
+		computeMachineType, labels, availabilityZones, multiAZ, workerDiskSize); err != nil {
 		return nil, err
 	}
 

--- a/provider/clusterrosaclassic/cluster_rosa_classic_state.go
+++ b/provider/clusterrosaclassic/cluster_rosa_classic_state.go
@@ -36,6 +36,7 @@ type ClusterRosaClassicState struct {
 	ChannelGroup              types.String       `tfsdk:"channel_group"`
 	CloudRegion               types.String       `tfsdk:"cloud_region"`
 	ComputeMachineType        types.String       `tfsdk:"compute_machine_type"`
+	WorkerDiskSize            types.Int64        `tfsdk:"worker_disk_size"`
 	DefaultMPLabels           types.Map          `tfsdk:"default_mp_labels"`
 	Replicas                  types.Int64        `tfsdk:"replicas"`
 	ConsoleURL                types.String       `tfsdk:"console_url"`

--- a/provider/machinepool/machine_pool_state.go
+++ b/provider/machinepool/machine_pool_state.go
@@ -36,6 +36,7 @@ type MachinePoolState struct {
 	MultiAvailabilityZone types.Bool    `tfsdk:"multi_availability_zone"`
 	AvailabilityZone      types.String  `tfsdk:"availability_zone"`
 	SubnetID              types.String  `tfsdk:"subnet_id"`
+	DiskSize              types.Int64   `tfsdk:"disk_size"`
 }
 
 type Taints struct {

--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -829,6 +829,84 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 			Expect(resource).To(MatchJQ(".attributes.id", "1234")) // reconciled cluster has id of 1234
 		})
 
+		It("Creates basic cluster with custom worker disk size", func() {
+			// Prepare the server:
+			server.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					VerifyJQ(`.name`, "my-cluster"),
+					VerifyJQ(`.cloud_provider.id`, "aws"),
+					VerifyJQ(`.region.id`, "us-west-1"),
+					VerifyJQ(`.product.id`, "rosa"),
+					VerifyJQ(`.properties.rosa_tf_version`, build.Version),
+					VerifyJQ(`.properties.rosa_tf_commit`, build.Commit),
+					VerifyJQ(`.nodes.compute_root_volume.aws.size`, 400.0),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+						{
+						  "op": "add",
+						  "path": "/aws",
+						  "value": {
+							  "ec2_metadata_http_tokens": "optional",
+							  "sts" : {
+								  "oidc_endpoint_url": "https://127.0.0.2",
+								  "thumbprint": "111111",
+								  "role_arn": "",
+								  "support_role_arn": "",
+								  "instance_iam_roles" : {
+									"master_role_arn" : "",
+									"worker_role_arn" : ""
+								  },
+								  "operator_role_prefix" : "test"
+							  }
+						  }
+						},
+						{
+						  "op": "add",
+						  "path": "/nodes",
+						  "value": {
+							"compute": 3,
+							"availability_zones": ["az"],
+							"compute_machine_type": {
+								"id": "r5.xlarge"
+							},
+							"compute_root_volume": {
+								"aws": {
+									"size": 400
+								}
+							}
+						  }
+						}]`),
+				),
+			)
+
+			// Run the apply command:
+			terraform.Source(`
+			  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+				name           = "my-cluster"
+				cloud_region   = "us-west-1"
+				aws_account_id = "123"
+				sts = {
+					operator_role_prefix = "test"
+					role_arn = "",
+					support_role_arn = "",
+					instance_iam_roles = {
+						master_role_arn = "",
+						worker_role_arn = "",
+					}
+				}
+				worker_disk_size = 400
+			  }
+			`)
+			Expect(terraform.Apply()).To(BeZero())
+			resource := terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.current_version", "openshift-4.8.0"))
+			Expect(resource).To(MatchJQ(".attributes.worker_disk_size", 400.0))
+		})
+
 		It("Creates basic cluster with properties", func() {
 			prop_key := "my_prop_key"
 			prop_val := "my_prop_val"

--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -454,6 +454,11 @@ var _ = Describe("Machine pool creation", func() {
 				RespondWithJSON(http.StatusOK, `{
 				  "id": "my-pool",
 				  "instance_type": "r5.xlarge",
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "replicas": 12,
 				  "availability_zones": [
 					"us-east-1a",
@@ -507,6 +512,11 @@ var _ = Describe("Machine pool creation", func() {
 				    "label_key1": "label_value1",
 				    "label_key2": "label_value2"
 				  },
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "instance_type": "r5.xlarge"
 				}`),
 			),
@@ -522,6 +532,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "labels": {
 				    "label_key1": "label_value1",
 				    "label_key2": "label_value2"
+				  },
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
 				  },
 				  "instance_type": "r5.xlarge"
 				}`),
@@ -545,6 +560,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
 				  "kind": "MachinePool",
 				  "instance_type": "r5.xlarge",
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "replicas": 12,
 				  "labels": {
 				    "label_key3": "label_value3"
@@ -586,6 +606,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "kind": "MachinePool",
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
                   "replicas": 12,
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "labels": {
 				    "label_key1": "label_value1",
 				    "label_key2": "label_value2"
@@ -602,6 +627,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "kind": "MachinePool",
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
                   "replicas": 12,
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "labels": {
 				    "label_key1": "label_value1",
 				    "label_key2": "label_value2"
@@ -626,6 +656,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
 				  "kind": "MachinePool",
 				  "instance_type": "r5.xlarge",
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "replicas": 12,
                   "labels": {}
 				}`),
@@ -676,6 +711,11 @@ var _ = Describe("Machine pool creation", func() {
 				RespondWithJSON(http.StatusOK, `{
 				  "id": "my-pool",
 				  "instance_type": "r5.xlarge",
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "replicas": 12,
 				  "availability_zones": [
 					"us-east-1a",
@@ -730,6 +770,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "kind": "MachinePool",
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
                   "replicas": 12,
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "availability_zones": [
 					"us-east-1a",
 					"us-east-1b",
@@ -754,6 +799,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "kind": "MachinePool",
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
                   "replicas": 12,
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "availability_zones": [
 					"us-east-1a",
 					"us-east-1b",
@@ -797,6 +847,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
 				  "kind": "MachinePool",
 				  "instance_type": "r5.xlarge",
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "replicas": 12,
 				  "availability_zones": [
 					"us-east-1a",
@@ -880,6 +935,11 @@ var _ = Describe("Machine pool creation", func() {
 					"us-east-1b",
 					"us-east-1c"
 				  ],
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "replicas": 12,
 				  "taints": [
 					  {
@@ -929,6 +989,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "kind": "MachinePool",
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
                   "replicas": 12,
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "availability_zones": [
 					"us-east-1a",
 					"us-east-1b",
@@ -953,6 +1018,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "kind": "MachinePool",
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
                   "replicas": 12,
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "availability_zones": [
 					"us-east-1a",
 					"us-east-1b",
@@ -984,6 +1054,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "id": "my-pool",
 				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
 				  "kind": "MachinePool",
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "instance_type": "r5.xlarge",
 				  "replicas": 12,
 				  "availability_zones": [
@@ -1036,6 +1111,11 @@ var _ = Describe("Machine pool creation", func() {
 				RespondWithJSON(http.StatusOK, `{
 				  "id": "my-pool",
 				  "instance_type": "r5.xlarge",
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "availability_zones": [
 					"us-east-1a",
 					"us-east-1b",
@@ -1086,6 +1166,11 @@ var _ = Describe("Machine pool creation", func() {
 				  	"max_replicas": 3,
 				  	"min_replicas": 0
 				  },
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "availability_zones": [
 					"us-east-1a",
 					"us-east-1b",
@@ -1106,6 +1191,11 @@ var _ = Describe("Machine pool creation", func() {
 				  	"kind": "MachinePoolAutoscaling",
 				  	"max_replicas": 3,
 				  	"min_replicas": 0
+				  },
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
 				  },
 				  "availability_zones": [
 					"us-east-1a",
@@ -1132,6 +1222,11 @@ var _ = Describe("Machine pool creation", func() {
 				  "kind": "MachinePool",
 				  "instance_type": "r5.xlarge",
 				  "replicas": 12,
+				  "root_volume": {
+					"aws": {
+					  "size": 200
+					}
+				  },
 				  "availability_zones": [
 					"us-east-1a",
 					"us-east-1b",
@@ -1513,6 +1608,65 @@ var _ = Describe("Machine pool creation", func() {
 		Expect(resource).To(MatchJQ(`.attributes.labels | length`, 2))
 		Expect(resource).To(MatchJQ(`.attributes.taints | length`, 1))
 		Expect(resource).To(MatchJQ(".attributes.use_spot_instances", true))
+	})
+
+	It("Can create machine pool with custom disk size", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(
+					http.MethodPost,
+					"/api/clusters_mgmt/v1/clusters/123/machine_pools",
+				),
+				VerifyJSON(`{
+				  "kind": "MachinePool",
+				  "id": "my-pool",
+				  "instance_type": "r5.xlarge",
+				  "root_volume": {
+					"aws": {
+					  "size": 400
+					}
+				  },
+				  "replicas": 12
+				}`),
+				RespondWithJSON(http.StatusOK, `{
+				  "id": "my-pool",
+				  "instance_type": "r5.xlarge",
+				  "replicas": 12,
+				  "availability_zones": [
+					"us-east-1a",
+					"us-east-1b",
+					"us-east-1c"
+				  ],
+				  "root_volume": {
+					"aws": {
+					  "size": 400
+					}
+				  }
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		terraform.Source(`
+		  resource "rhcs_machine_pool" "my_pool" {
+		    cluster      = "123"
+		    name         = "my-pool"
+		    machine_type = "r5.xlarge"
+		    replicas     = 12
+			disk_size    = 400
+		  }
+		`)
+		Expect(terraform.Apply()).To(BeZero())
+
+		// Check the state:
+		resource := terraform.Resource("rhcs_machine_pool", "my_pool")
+		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
+		Expect(resource).To(MatchJQ(".attributes.id", "my-pool"))
+		Expect(resource).To(MatchJQ(".attributes.name", "my-pool"))
+		Expect(resource).To(MatchJQ(".attributes.machine_type", "r5.xlarge"))
+		Expect(resource).To(MatchJQ(".attributes.replicas", 12.0))
+		Expect(resource).To(MatchJQ(".attributes.disk_size", 400.0))
 	})
 })
 


### PR DESCRIPTION
- [OCM-2641](https://issues.redhat.com//browse/OCM-2641): Adds `worker_disk_size` to cluster resource. This is used only at cluster creation to determine the size of the default MP's disk size
- [OCM-17](https://issues.redhat.com//browse/OCM-17): Adds `disk_size` to the machinepool resource. -- Only used at pool creation time

Supersceedes #100