### PR TITLE
OCM-3102: Fixing a bug in while updating the Proxy attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.3 (Aug 24, 2023)
+-ENHANCEMENTS:
+* Fixed a bug in cluster_rosa_resource -Terraform provider panic after adding additional CA bundle to ROSA cluster
+
 ## 1.2.2 (Aug 3, 2023)
 -ENHANCEMENTS:
 * Update the documentation files to point the correct links.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/terraform-redhat/terraform-provider-rhcs
 go 1.18
 
 require (
+	github.com/aws/aws-sdk-go v1.39.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v0.5.0
@@ -25,7 +26,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go v1.39.3 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect

--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -1705,6 +1705,9 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 
 	proxy, ok := object.GetProxy()
 	if ok {
+		if state.Proxy == nil {
+			state.Proxy = &Proxy{}
+		}
 		httpProxy, ok := proxy.GetHTTPProxy()
 		if ok {
 			state.Proxy.HttpProxy = types.String{
@@ -1729,6 +1732,9 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 
 	trustBundle, ok := object.GetAdditionalTrustBundle()
 	if ok {
+		if state.Proxy == nil {
+			state.Proxy = &Proxy{}
+		}
 		state.Proxy.AdditionalTrustBundle = types.String{
 			Value: trustBundle,
 		}

--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -1499,23 +1499,24 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 
 	})
 
-	It("Creates cluster with http proxy and update it", func() {
-		// Prepare the server:
-		server.AppendHandlers(
-			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
-				RespondWithJSON(http.StatusOK, versionListPage1),
-			),
-			CombineHandlers(
-				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
-				VerifyJQ(`.name`, "my-cluster"),
-				VerifyJQ(`.cloud_provider.id`, "aws"),
-				VerifyJQ(`.region.id`, "us-west-1"),
-				VerifyJQ(`.product.id`, "rosa"),
-				VerifyJQ(`.proxy.http_proxy`, "http://proxy.com"),
-				VerifyJQ(`.proxy.https_proxy`, "https://proxy.com"),
-				VerifyJQ(`.additional_trust_bundle`, "123"),
-				RespondWithPatchedJSON(http.StatusOK, template, `[
+	Context("Test Proxy", func() {
+		It("Creates cluster with http proxy and update it", func() {
+			// Prepare the server:
+			server.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					VerifyJQ(`.name`, "my-cluster"),
+					VerifyJQ(`.cloud_provider.id`, "aws"),
+					VerifyJQ(`.region.id`, "us-west-1"),
+					VerifyJQ(`.product.id`, "rosa"),
+					VerifyJQ(`.proxy.http_proxy`, "http://proxy.com"),
+					VerifyJQ(`.proxy.https_proxy`, "https://proxy.com"),
+					VerifyJQ(`.additional_trust_bundle`, "123"),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
 					{
 					  "op": "add",
 					  "path": "/aws",
@@ -1558,11 +1559,11 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 						}
 					  }
 					}]`),
-			),
-		)
+				),
+			)
 
-		// Run the apply command:
-		terraform.Source(`
+			// Run the apply command:
+			terraform.Source(`
 		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
 		    name           = "my-cluster"
 		    cloud_region   = "us-west-1"
@@ -1584,14 +1585,14 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 		  }
 		`)
 
-		Expect(terraform.Apply()).To(BeZero())
+			Expect(terraform.Apply()).To(BeZero())
 
-		// apply for update the proxy's attributes
-		// Prepare the server:
-		server.AppendHandlers(
-			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
-				RespondWithPatchedJSON(http.StatusOK, template, `[
+			// apply for update the proxy's attributes
+			// Prepare the server:
+			server.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
 					{
 					  "op": "add",
 					  "path": "/aws",
@@ -1634,13 +1635,13 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 						}
 					  }
 					}]`),
-			),
-			CombineHandlers(
-				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
-				VerifyJQ(`.proxy.https_proxy`, "https://proxy2.com"),
-				VerifyJQ(`.proxy.no_proxy`, "test"),
-				VerifyJQ(`.additional_trust_bundle`, "123"),
-				RespondWithPatchedJSON(http.StatusOK, template, `[
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
+					VerifyJQ(`.proxy.https_proxy`, "https://proxy2.com"),
+					VerifyJQ(`.proxy.no_proxy`, "test"),
+					VerifyJQ(`.additional_trust_bundle`, "123"),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
 					{
 					  "op": "add",
 					  "path": "/aws",
@@ -1683,11 +1684,11 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 						}
 					  }
 					}]`),
-			),
-		)
+				),
+			)
 
-		// update the attribute "proxy"
-		terraform.Source(`
+			// update the attribute "proxy"
+			terraform.Source(`
 		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
 		    name           = "my-cluster"
 		    cloud_region   = "us-west-1"
@@ -1708,13 +1709,176 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 			}
 		  }
 		`)
-		Expect(terraform.Apply()).To(BeZero())
-		resource := terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
-		Expect(resource).To(MatchJQ(`.attributes.proxy.https_proxy`, "https://proxy2.com"))
-		Expect(resource).To(MatchJQ(`.attributes.proxy.no_proxy`, "test"))
-		Expect(resource).To(MatchJQ(`.attributes.proxy.additional_trust_bundle`, "123"))
-	})
+			Expect(terraform.Apply()).To(BeZero())
+			resource := terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(`.attributes.proxy.https_proxy`, "https://proxy2.com"))
+			Expect(resource).To(MatchJQ(`.attributes.proxy.no_proxy`, "test"))
+			Expect(resource).To(MatchJQ(`.attributes.proxy.additional_trust_bundle`, "123"))
+		})
+		It("Creates cluster without http proxy and update trust bundle", func() {
+			// Prepare the server:
+			server.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					VerifyJQ(`.name`, "my-cluster"),
+					VerifyJQ(`.cloud_provider.id`, "aws"),
+					VerifyJQ(`.region.id`, "us-west-1"),
+					VerifyJQ(`.product.id`, "rosa"),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.2",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"master_role_arn" : "",
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/nodes",
+					  "value": {
+						"compute": 3,
+						"compute_machine_type": {
+							"id": "r5.xlarge"
+						}
+					  }
+					}]`),
+				),
+			)
 
+			// Run the apply command:
+			terraform.Source(`
+		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+		    name           = "my-cluster"
+		    cloud_region   = "us-west-1"
+			aws_account_id = "123"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+		  }
+		`)
+
+			Expect(terraform.Apply()).To(BeZero())
+
+			// apply for update the proxy's attributes
+			// Prepare the server:
+			server.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.2",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"master_role_arn" : "",
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/nodes",
+					  "value": {
+						"compute": 3,
+						"compute_machine_type": {
+							"id": "r5.xlarge"
+						}
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
+					VerifyJQ(`.additional_trust_bundle`, "123"),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.2",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"master_role_arn" : "",
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/",
+					  "value": {
+						  "additional_trust_bundle" : "123"
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/nodes",
+					  "value": {
+						"compute": 3,
+						"compute_machine_type": {
+							"id": "r5.xlarge"
+						}
+					  }
+					}]`),
+				),
+			)
+
+			// update the attribute "proxy"
+			terraform.Source(`
+		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+		    name           = "my-cluster"
+		    cloud_region   = "us-west-1"
+			aws_account_id = "123"
+			proxy = {
+				additional_trust_bundle = "123",
+			}
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+		  }
+		`)
+			Expect(terraform.Apply()).To(BeZero())
+			resource := terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(`.attributes.proxy.additional_trust_bundle`, "123"))
+		})
+	})
 	It("Creates cluster with default_mp_labels and update them", func() {
 		// Prepare the server:
 		server.AppendHandlers(


### PR DESCRIPTION
While updating the Proxy needs to initialize the state.Proxy object if this is the first time to be set.