### PR TITLE
OCM-3124: fix for additional_trust_bundle resulting in an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.4 (Sep 4, 2023)
+-ENHANCEMENTS:
+* Fix for "Provider produced inconsistent result after apply" error when setting proxy.additional_trust_bundle
+
 ## 1.2.3 (Aug 24, 2023)
 -ENHANCEMENTS:
 * Fixed a bug in cluster_rosa_resource -Terraform provider panic after adding additional CA bundle to ROSA cluster

--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -1660,7 +1660,7 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 	}
 
 	trustBundle, ok := object.GetAdditionalTrustBundle()
-	if ok {
+	if ok && common.IsStringAttributeEmpty(state.Proxy.AdditionalTrustBundle) {
 		if state.Proxy == nil {
 			state.Proxy = &Proxy{}
 		}

--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -1645,7 +1645,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 					  "op": "add",
 					  "path": "/",
 					  "value": {
-						  "additional_trust_bundle" : "123"
+						  "additional_trust_bundle" : "REDUCTED"
 					  }
 					},
 					{
@@ -1695,7 +1695,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 					  "op": "add",
 					  "path": "/",
 					  "value": {
-						  "additional_trust_bundle" : "123"
+						  "additional_trust_bundle" : "REDUCTED"
 					  }
 					},
 					{


### PR DESCRIPTION
Since OCM returns `REDUCTED` as values of sensitive content, the provider was populating `REDUCTED` as the new state for `additional_trust_bundle`. 

This PR ensures that if there is a value in the state, do not override value from backend.

Should fix #229 