### PR TITLE
OCM-3005: Fix allow private cluster without private link

### DIFF
--- a/internal/ocm/resource/cluster.go
+++ b/internal/ocm/resource/cluster.go
@@ -145,8 +145,8 @@ func (c *Cluster) CreateAWSBuilder(awsTags map[string]string, ec2MetadataHttpTok
 }
 
 func (c *Cluster) SetAPIPrivacy(isPrivate bool, isPrivateLink bool, isSTS bool) error {
-	if isSTS && isPrivate && !isPrivateLink {
-		return errors.New("Private STS clusters are only supported through AWS PrivateLink")
+	if isSTS && !isPrivate && isPrivateLink {
+		return errors.New("PrivateLink is only supported on private clusters")
 	}
 	api := cmv1.NewClusterAPI()
 	if isPrivate {

--- a/internal/ocm/resource/cluster_test.go
+++ b/internal/ocm/resource/cluster_test.go
@@ -260,10 +260,18 @@ var _ = Describe("Cluster", func() {
 		})
 	})
 	Context("SetAPIPrivacy validation", func() {
-		It("Private STS cluster without private link - failure", func() {
+		It("Private STS cluster without private link - success", func() {
 			err := cluster.SetAPIPrivacy(true, false, true)
+			Expect(err).NotTo(HaveOccurred())
+			ocmCluster, err := cluster.Build()
+			Expect(err).NotTo(HaveOccurred())
+			api := ocmCluster.API()
+			Expect(api.Listening()).To(Equal(cmv1.ListeningMethodInternal))
+		})
+		It("Public STS cluster with private link - failure", func() {
+			err := cluster.SetAPIPrivacy(false, true, true)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Private STS clusters are only supported through AWS PrivateLink"))
+			Expect(err.Error()).To(Equal("PrivateLink is only supported on private clusters"))
 		})
 		It("Private cluster - success", func() {
 			err := cluster.SetAPIPrivacy(true, true, true)
@@ -274,7 +282,7 @@ var _ = Describe("Cluster", func() {
 			Expect(api.Listening()).To(Equal(cmv1.ListeningMethodInternal))
 		})
 		It("Non private cluster - success", func() {
-			err := cluster.SetAPIPrivacy(false, true, true)
+			err := cluster.SetAPIPrivacy(false, false, true)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())

--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -1947,7 +1947,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 		Expect(terraform.Apply()).NotTo(BeZero())
 
 	})
-	It("Creates cluster with aws subnet ids & private link", func() {
+	It("Creates private cluster with aws subnet ids without private link", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(
@@ -1961,14 +1961,15 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 				VerifyJQ(`.region.id`, "us-west-1"),
 				VerifyJQ(`.product.id`, "rosa"),
 				VerifyJQ(`.aws.subnet_ids.[0]`, "id1"),
-				VerifyJQ(`.aws.private_link`, true),
+				VerifyJQ(`.aws.private_link`, false),
 				VerifyJQ(`.nodes.availability_zones.[0]`, "az1"),
+				VerifyJQ(`.api.listening`, "internal"),
 				RespondWithPatchedJSON(http.StatusOK, template, `[
 					{
 					  "op": "add",
 					  "path": "/aws",
 					  "value": {
-						  "private_link": true,
+						  "private_link": false,
 						  "subnet_ids": ["id1", "id2", "id3"],
 						  "ec2_metadata_http_tokens": "optional",
 						  "sts" : {
@@ -1982,6 +1983,13 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 							  },
 							  "operator_role_prefix" : "test"
 						  }
+					  }
+					},
+					{
+					  "op": "add",
+					  "path": "/api",
+					  "value": {
+					  	"listening": "internal"
 					  }
 					},
 					{
@@ -2009,7 +2017,8 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 		    cloud_region   = "us-west-1"
 			aws_account_id = "123"
 			availability_zones = ["az1"]
-			aws_private_link = true
+			aws_private_link = false
+			private = true
 			aws_subnet_ids = [
 				"id1", "id2", "id3"
 			]
@@ -2026,7 +2035,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 		`)
 		Expect(terraform.Apply()).To(BeZero())
 	})
-	It("Creates cluster with aws subnet ids & private & private link", func() {
+	It("Creates private cluster with aws subnet ids & private link", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(


### PR DESCRIPTION
Change the terraform provider logic to align with the logic in the backend

The following cases are allowed:
1. private cluster with private link
2. public cluster without private link
3. private cluster without private link

Public cluster with private link is not allowed