### PR TITLE
Fix machine pool validation

### DIFF
--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -25,6 +25,23 @@ import (
 	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
 )
 
+var _ = Describe("Machine pool (static) validation", func() {
+	It("is invalid to specify both availability_zone and subnet_id", func() {
+		terraform.Source(`
+		  resource "rhcs_machine_pool" "my_pool" {
+		    cluster      = "123"
+		    name         = "my-pool"
+		    machine_type = "r5.xlarge"
+		    replicas     = 12
+			multi_availability_zone = true
+			availability_zone = "us-east-1a"
+			subnet_id = "subnet-123"
+		  }
+		`)
+		Expect(terraform.Validate()).NotTo(BeZero())
+	})
+})
+
 var _ = Describe("Machine pool creation", func() {
 	BeforeEach(func() {
 		// The first thing that the provider will do for any operation on machine pools
@@ -1511,7 +1528,8 @@ var _ = Describe("Machine pool w/ mAZ cluster", func() {
 		// Check the state:
 		resource := terraform.Resource("rhcs_machine_pool", "my_pool")
 		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
-		Expect(resource).To(MatchJQ(".attributes.availability_zone", nil))
+		Expect(resource).To(MatchJQ(".attributes.availability_zone", ""))
+		Expect(resource).To(MatchJQ(".attributes.subnet_id", ""))
 	})
 
 	It("Can create mAZ pool, setting multi_availbility_zone", func() {
@@ -1556,7 +1574,7 @@ var _ = Describe("Machine pool w/ mAZ cluster", func() {
 		// Check the state:
 		resource := terraform.Resource("rhcs_machine_pool", "my_pool")
 		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
-		Expect(resource).To(MatchJQ(".attributes.availability_zone", nil))
+		Expect(resource).To(MatchJQ(".attributes.availability_zone", ""))
 	})
 
 	It("Fails to create mAZ pool if replicas not multiple of 3", func() {
@@ -1740,10 +1758,10 @@ var _ = Describe("Machine pool w/ 1AZ cluster", func() {
 		// Check the state:
 		resource := terraform.Resource("rhcs_machine_pool", "my_pool")
 		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
-		Expect(resource).To(MatchJQ(".attributes.availability_zone", nil))
+		Expect(resource).To(MatchJQ(".attributes.availability_zone", "us-east-1a"))
 	})
 
-	It("Can create 1az pool w/ multi_availability_zone", func() {
+	It("Can create 1az pool by setting multi_availability_zone", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(
@@ -1783,7 +1801,7 @@ var _ = Describe("Machine pool w/ 1AZ cluster", func() {
 		// Check the state:
 		resource := terraform.Resource("rhcs_machine_pool", "my_pool")
 		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
-		Expect(resource).To(MatchJQ(".attributes.availability_zone", nil))
+		Expect(resource).To(MatchJQ(".attributes.availability_zone", "us-east-1a"))
 	})
 
 	It("Fails to create pool if az and subnet supplied", func() {

--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -40,6 +40,44 @@ var _ = Describe("Machine pool (static) validation", func() {
 		`)
 		Expect(terraform.Validate()).NotTo(BeZero())
 	})
+
+	It("is necessary to specify both min and max replicas", func() {
+		terraform.Source(`
+		  resource "rhcs_machine_pool" "my_pool" {
+		    cluster      = "123"
+		    name         = "my-pool"
+		    machine_type = "r5.xlarge"
+			auto_scaling = true
+			min_replicas = 1
+		  }
+		`)
+		Expect(terraform.Validate()).NotTo(BeZero())
+
+		terraform.Source(`
+		  resource "rhcs_machine_pool" "my_pool" {
+		    cluster      = "123"
+		    name         = "my-pool"
+		    machine_type = "r5.xlarge"
+			auto_scaling = true
+			max_replicas = 5
+		  }
+		`)
+		Expect(terraform.Validate()).NotTo(BeZero())
+	})
+
+	It("is invalid to specify min_replicas or max_replicas and replicas", func() {
+		terraform.Source(`
+		  resource "rhcs_machine_pool" "my_pool" {
+		    cluster      = "123"
+		    name         = "my-pool"
+		    machine_type = "r5.xlarge"
+			auto_scaling = true
+			min_replicas = 1
+			replicas     = 5
+		  }
+		`)
+		Expect(terraform.Validate()).NotTo(BeZero())
+	})
 })
 
 var _ = Describe("Machine pool creation", func() {


### PR DESCRIPTION
- This fixes the problem of TF deciding the machine pool needs to be replaced unnecessarily.
  - There is a change here where az and subnet will now have empty ("") values instead of null. This is necessary in order for UseStateForUnknown to allow us to avoid replacing due to (known after apply).
- It adds some static validation of parameters, but isn't really able to remove much of the run-time validation because it depends on the state of the cluster.
- Added some static validation for a couple other parameters