### PR TITLE
OCM-3909: Fix availability zones to ListNull in case nothing returned

### DIFF
--- a/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
@@ -1498,14 +1498,14 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 		state.MinReplicas = types.Int64Null()
 	}
 
-	azs, ok := object.Nodes().GetAvailabilityZones()
-	if ok {
+	if azs, ok := object.Nodes().GetAvailabilityZones(); ok {
 		listValue, err := common.StringArrayToList(azs)
 		if err != nil {
 			return err
-		} else {
-			state.AvailabilityZones = listValue
 		}
+		state.AvailabilityZones = listValue
+	} else {
+		state.AvailabilityZones = types.ListNull(types.StringType)
 	}
 
 	state.CCSEnabled = types.BoolValue(object.CCS().Enabled())

--- a/subsystem/cluster_resource_rosa_test.go
+++ b/subsystem/cluster_resource_rosa_test.go
@@ -380,6 +380,76 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 			Expect(resource).To(MatchJQ(".attributes.current_version", "openshift-4.8.0"))
 		})
 
+		It("Creates basic cluster returned empty az list", func() {
+			// Prepare the server:
+			server.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					VerifyJQ(`.name`, "my-cluster"),
+					VerifyJQ(`.cloud_provider.id`, "aws"),
+					VerifyJQ(`.region.id`, "us-west-1"),
+					VerifyJQ(`.product.id`, "rosa"),
+					VerifyJQ(`.properties.rosa_tf_version`, build.Version),
+					VerifyJQ(`.properties.rosa_tf_commit`, build.Commit),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "ec2_metadata_http_tokens": "optional",
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.2",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"master_role_arn" : "",
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "replace",
+					  "path": "/nodes",
+					  "value": {
+						  "compute": 3,
+	            "compute_machine_type": {
+	              "id": "r5.xlarge"
+	            }
+					  }
+					}
+					]`),
+				),
+			)
+
+			// Run the apply command:
+			terraform.Source(`
+		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+		    name           = "my-cluster"
+		    cloud_region   = "us-west-1"
+			aws_account_id = "123"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+		  }
+		`)
+			Expect(terraform.Apply()).To(BeZero())
+			resource := terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.current_version", "openshift-4.8.0"))
+		})
+
 		It("Creates basic cluster with admin user", func() {
 			// Prepare the server:
 			server.AppendHandlers(
@@ -1046,7 +1116,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 		`)
 			Expect(terraform.Apply()).ToNot(BeZero())
 		})
-		
+
 		It("Should fail cluster creation when cluster name length is more than 15", func() {
 			// Run the apply command:
 			terraform.Source(`
@@ -1336,6 +1406,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 					  "path": "/nodes",
 					  "value": {
 						"compute": 3,
+            "availability_zones": ["az"],
 						"compute_machine_type": {
 							"id": "r5.xlarge"
 						}
@@ -2223,6 +2294,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 					  "path": "/nodes",
 					  "value": {
 						"compute": 3,
+            "availability_zones": ["az1"],
 						"compute_machine_type": {
 							"id": "r5.xlarge"
 						}


### PR DESCRIPTION
In case the user doesn't provide the availability zone, cluster create returnes before it ready and with empty azs list.
This change is done in order to avoid from the following error:
![Screenshot from 2023-09-26 11-01-31](https://github.com/terraform-redhat/terraform-provider-rhcs/assets/38751082/74dfcbdd-2917-4ae4-9842-8ed03836b3cb)
