### PR TITLE
Add terraform cluster destroy step

### DIFF
--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -226,6 +226,21 @@ func CreateRHCSClusterByProfile(profile *Profile, creationArgs *EXE.ClusterCreat
 	return clusterID, err
 }
 
+func DestroyRHCSClusterByCreationArgs(creationArgs *EXE.ClusterCreationArgs, manifests_dir string) {
+
+	// destroy selected cluster
+	clusterService := EXE.NewClusterService(manifests_dir)
+	clusterService.Destroy(creationArgs)
+
+	// destroy account roles
+	accService := EXE.NewAccountRoleService()
+	accRoleParam := &EXE.AccountRolesArgs{
+		Token:             GetEnvWithDefault(CON.TokenENVName, ""),
+		AccountRolePrefix: creationArgs.AccountRolePrefix,
+	}
+	accService.Destroy(accRoleParam)
+}
+
 func PrepareRHCSClusterByProfileENV() (*Profile, *EXE.ClusterCreationArgs, string) {
 
 	profile := LoadProfileYamlFile()

--- a/tests/e2e/cluster_creation.go
+++ b/tests/e2e/cluster_creation.go
@@ -75,26 +75,18 @@ var _ = Describe("TF Test", func() {
 
 		})
 
-		It("TestCreateClusterByProfile", func() {
+		It("TestClusterE2EFlowByProfile", func() {
 
 			// Generate/build cluster by profile selected
 			profile, creationArgs, manifests_dir := CI.PrepareRHCSClusterByProfileENV()
-			accService := EXE.NewAccountRoleService()
-			accRoleParam := &EXE.AccountRolesArgs{
-				Token:             CI.GetEnvWithDefault(CON.TokenENVName, ""),
-				AccountRolePrefix: creationArgs.AccountRolePrefix,
-			}
-			// destroy account roles
-			defer accService.Destroy(accRoleParam)
 
 			// Create rhcs cluster
 			clusterID, err := CI.CreateRHCSClusterByProfile(profile, creationArgs, manifests_dir)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(clusterID).ToNot(BeEmpty())
 
-			// destroy selected cluster
-			clusterService := EXE.NewClusterService(manifests_dir)
-			defer clusterService.Destroy(creationArgs)
+			// Destroy cluster's resources
+			CI.DestroyRHCSClusterByCreationArgs(creationArgs, manifests_dir)
 		})
 	})
 })


### PR DESCRIPTION
Just added a function for destroying the account roles resources and the cluster itself after it deployed by profile.