### PR TITLE
Add post day 1 verification tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,12 +4,14 @@ This package is the automation package for Function Verification Testing on the 
 ## Structure of tests
 ```sh
 tests
-|____e2e                                          ---- e2e folder contains all of the e2e cases
-|    |____init_test.go
-|    |____machine_pool_test.go
-|    |____...
-|    |____cluster_creation_validation_test.go
-|    |____cluster_creation.go                     ---- cluster_creation.go will handle cluster creation by profile
+|____e2e      
+    |____cluster_creation_test.go                 ---- handles cluster creation by profile
+    |____cluster_destroy_test.go
+    |____e2e_suite_test.go                        ---- test suite for all the e2e tests
+    |____idps_test.go
+    |____...
+    |____machine_pool_test.go
+    |____verfication_post_day1_test.go            ---- post day1 verification tests
 |____utils
 |    |____exec                                    ---- exec will package the tf commands like init state apply destroy
 |    |    |____tf.go

--- a/tests/ci/profiles/tf_cluster_profile.yml
+++ b/tests/ci/profiles/tf_cluster_profile.yml
@@ -2,7 +2,6 @@ profiles:
 - as: rosa-sts-pl
   cluster:
     multi_az: false
-    machine_type: ""
     product_id: "rosa"
     hypershift: false
     cloud_provider: "aws"
@@ -12,12 +11,13 @@ profiles:
     byovpc: false
     private_link: true
     private: true
-    etcd: false
+    etcd_encryption: false
     fips: false
     autoscale: false
     byok: false
     version: "latest"
     major_version: "4.13"
+    compute_machine_type: "m5.xlarge"
     proxy: false
     labeling: false
     tagging: false
@@ -28,7 +28,6 @@ profiles:
 - as: rosa-sts-ad
   cluster:
     multi_az: true
-    machine_type: ""
     product_id: "rosa"
     hypershift: false
     cloud_provider: "aws"
@@ -38,12 +37,13 @@ profiles:
     byovpc: true
     private_link: false
     private: false
-    etcd: true
+    etcd_encryption: true
     fips: true
     autoscale: true
     byok: true
     version: "latest"
     major_version: "4.13"
+    compute_machine_type: "m5.2xlarge"
     proxy: true
     labeling: true
     tagging: true
@@ -54,7 +54,6 @@ profiles:
 - as: rosa-sts-up
   cluster:
     multi_az: false
-    machine_type: "m5.xlarge"
     product_id: "rosa"
     hypershift: false
     cloud_provider: "aws"
@@ -64,12 +63,13 @@ profiles:
     byovpc: true
     private_link: false
     private: false
-    etcd: true
+    etcd_encryption: true
     fips: false
     autoscale: false
     byok: true
     version: "z-1"
     major_version: "4.13"
+    compute_machine_type: "m5.xlarge"
     proxy: false
     labeling: false
     tagging: false

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -17,8 +17,7 @@ var clusterID string
 
 func TestRHCSProvider(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RHCS Provider Test")
-
+	RunSpecs(t, "e2e tests suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -5,8 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
-	conn "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
+	ci "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/cms"
 	con "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
 	exe "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/exec"
@@ -32,6 +31,7 @@ var _ = Describe("TF Test", func() {
 
 		Describe("Htpasswd IDP test cases", func() {
 			var htpasswdMap = []interface{}{map[string]string{}}
+			var userName, password string
 
 			BeforeEach(func() {
 
@@ -61,13 +61,13 @@ var _ = Describe("TF Test", func() {
 					idpID, _ := idpService.htpasswd.Output()
 
 					By("List existing HtpasswdUsers and compare to the created one")
-					htpasswdUsersList, _ := cms.ListHtpasswdUsers(conn.RHCSConnection, clusterID, idpID.ID)
+					htpasswdUsersList, _ := cms.ListHtpasswdUsers(ci.RHCSConnection, clusterID, idpID.ID)
 					Expect(htpasswdUsersList.Status()).To(Equal(http.StatusOK))
 					respUserName, _ := htpasswdUsersList.Items().Slice()[0].GetUsername()
 					Expect(respUserName).To(Equal(userName))
 
 					By("Login with created htpasswd idp")
-					getResp, err := cms.RetrieveClusterDetail(conn.RHCSConnection, clusterID)
+					getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
 					Expect(err).ToNot(HaveOccurred())
 					server := getResp.Body().API().URL()
 
@@ -115,7 +115,7 @@ var _ = Describe("TF Test", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Login with created ldap idp")
-					getResp, err := cms.RetrieveClusterDetail(conn.RHCSConnection, clusterID)
+					getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
 					Expect(err).ToNot(HaveOccurred())
 					server := getResp.Body().API().URL()
 

--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -1,0 +1,84 @@
+package e2e
+
+import (
+	// nolint
+
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	CI "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
+	CMS "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/cms"
+	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	H "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+)
+
+var _ = Describe("TF Test", func() {
+	Describe("Verfication/Post day 1 tests", func() {
+		var err error
+		var profile *CI.Profile
+
+		BeforeEach(func() {
+			profile = CI.LoadProfileYamlFileByENV()
+			Expect(err).ToNot(HaveOccurred())
+		})
+		AfterEach(func() {
+		})
+
+		Context("Author:smiron-High-OCP-63140 @OCP-63140 @smiron", func() {
+			It("Verify fips is enabled/disabled post cluster creation", CI.Day1Post, CI.High, func() {
+				getResp, err := CMS.RetrieveClusterDetail(CI.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResp.Body().FIPS()).To(Equal(profile.FIPS))
+			})
+		})
+		Context("Author:smiron-High-OCP-63133 @OCP-63133 @smiron", func() {
+			It("Verify private_link is enabled/disabled post cluster creation", CI.Day1Post, CI.High, func() {
+				getResp, err := CMS.RetrieveClusterDetail(CI.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResp.Body().AWS().PrivateLink()).To(Equal(profile.PrivateLink))
+			})
+		})
+		Context("Author:smiron-High-OCP-63143 @OCP-63143 @smiron", func() {
+			It("Verify etcd-encryption is enabled/disabled post cluster creation", CI.Day1Post, CI.High, func() {
+				getResp, err := CMS.RetrieveClusterDetail(CI.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResp.Body().EtcdEncryption()).To(Equal(profile.Etcd))
+			})
+		})
+		Context("Author:smiron-Medium-OCP-64023 @OCP-64023 @smiron", func() {
+			It("Verify compute_machine_type value is set post cluster creation", CI.Day1Post, CI.Medium, func() {
+				getResp, err := CMS.RetrieveClusterDetail(CI.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResp.Body().Nodes().ComputeMachineType().ID()).To(Equal(profile.ComputeMachineType))
+			})
+		})
+		Context("Author:smiron-Medium-OCP-63141 @OCP-63141 @smiron", func() {
+			It("Verify availability zones and multi-az is set post cluster creation", CI.Day1Post, CI.Medium, func() {
+				getResp, err := CMS.RetrieveClusterDetail(CI.RHCSConnection, clusterID)
+				zonesArray := strings.Split(profile.Zones, ",")
+				clusterAvailZones := getResp.Body().Nodes().AvailabilityZones()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResp.Body().MultiAZ()).To(Equal(profile.MultiAZ))
+				if clusterAvailZones != nil {
+					Expect(clusterAvailZones).
+						To(Equal(H.JoinStringWithArray(profile.Region, zonesArray)))
+				} else {
+					Expect(clusterAvailZones).To(Equal(nil))
+				}
+			})
+		})
+		Context("Author:smiron-High-OCP-68423 @OCP-68423 @smiron", func() {
+			It("Verify compute_labels are set post cluster creation", CI.Day1Post, CI.High, func() {
+				getResp, err := CMS.RetrieveClusterDetail(CI.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				if profile.Labeling {
+					Expect(getResp.Body().Nodes().ComputeLabels()).To(Equal(CON.DefaultMPLabels))
+				} else {
+					Expect(getResp.Body().Nodes().ComputeLabels()).To(Equal(""))
+				}
+			})
+		})
+	})
+})

--- a/tests/utils/constants/config.go
+++ b/tests/utils/constants/config.go
@@ -26,14 +26,15 @@ type RHCSconfig struct {
 	RHCSEnv           string `env:"RHCS_ENV" default:"staging" yaml:"env"`
 	ClusterProfile    string `env:"CLUSTER_PROFILE" yaml:"clusterProfile,omitempty"`
 	ClusterProfileDir string `env:"CLUSTER_PROFILE_DIR" yaml:"clusterProfileDir,omitempty"`
-
-	YAMLProfilesDir string
+	RhcsOutputDir     string
+	YAMLProfilesDir   string
+	RootDir           string
 }
 
 func init() {
 	currentDir, _ := os.Getwd()
 	project := "terraform-provider-rhcs"
-	rootDir := GetEnvWithDefault(WorkSpace, strings.SplitAfter(currentDir, project)[0])
+	RHCS.RootDir = GetEnvWithDefault(WorkSpace, strings.SplitAfter(currentDir, project)[0])
 
 	// defaulted to staging
 	RHCS.RHCSEnv = GetEnvWithDefault(RHCSENV, RHCS.RHCSEnv)
@@ -45,7 +46,8 @@ func init() {
 		RHCS.ClusterProfileDir = os.Getenv("CLUSTER_PROFILE_DIR")
 	}
 
-	RHCS.YAMLProfilesDir = path.Join(rootDir, "tests", "ci", "profiles")
+	RHCS.RhcsOutputDir = GetRhcsOutputDir()
+	RHCS.YAMLProfilesDir = path.Join(RHCS.RootDir, "tests", "ci", "profiles")
 }
 
 // gatewayURL is used to get the global env of default gateway for testing
@@ -91,4 +93,16 @@ func GetEnvWithDefault(key string, defaultValue string) string {
 		}
 	}
 	return defaultValue
+}
+
+func GetRhcsOutputDir() string {
+	var rhcsNewOutPath string
+
+	if GetEnvWithDefault("RHCS_OUTPUT", "") != "" {
+		rhcsNewOutPath = os.Getenv("RHCS_OUTPUT")
+		return rhcsNewOutPath
+	}
+	rhcsNewOutPath = path.Join(RHCS.RootDir, "tests", "rhcs_output")
+	os.MkdirAll(rhcsNewOutPath, 0777)
+	return rhcsNewOutPath
 }

--- a/tests/utils/constants/constants.go
+++ b/tests/utils/constants/constants.go
@@ -34,6 +34,9 @@ var (
 	RHCSPrefix          = "rhcs"
 	TFYAMLProfile       = "tf_cluster_profile.yml"
 	LdapURL             = "ldap://ldap.forumsys.com/dc=example,dc=com?uid"
+	DefaultMPLabels     = map[string]string{
+		"test1": "testdata1",
+	}
 )
 
 const (

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -22,6 +22,11 @@ type ClusterCreationArgs struct {
 	AWSHttpTokensState   string            `json:"aws_http_tokens_state,omitempty"`
 	PrivateLink          string            `json:"private_link,omitempty"`
 	Private              string            `json:"private,omitempty"`
+	Fips                 bool              `json:"fips,omitempty"`
+	Tagging              map[string]string `json:"tags,omitempty"`
+	AuditLogForward      bool              `json:"audit_log_forward,omitempty"`
+	Autoscale            bool              `json:"autoscaling_enabled,omitempty"`
+	Etcd                 bool              `json:"etcd_encryption,omitempty"`
 	AWSSubnetIDs         []string          `json:"aws_subnet_ids,omitempty"`
 	ComputeMachineType   string            `json:"compute_machine_type,omitempty"`
 	DefaultMPLabels      map[string]string `json:"default_mp_labels,omitempty"`

--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,8 +27,8 @@ func Parse(data []byte) map[string]interface{} {
 	return object
 }
 
-func GetJsonFromPath(path string, filename string) map[string]interface{} {
-	combinedFilePath := path + "/" + filename
+func GetJsonFromPath(filePath string, filename string) map[string]interface{} {
+	combinedFilePath := path.Join(filePath, filename)
 	file, err := os.ReadFile(combinedFilePath)
 	Expect(err).ToNot(HaveOccurred())
 	return Parse(file)


### PR DESCRIPTION
**PR changes:**

- 6 new verification tests added for testing post cluster creation 
- `FIPS`, `Etcd`, `Autoscale`, `ComputeMachineType` attributes were added 
- Getter/Setter for `clusterID` and `token` inside the test suite
- Test case coverage:` OCP-63140, OCP-63133, OCP-63143, OCP-64023, OCP-63141, OCP-68423`