### PR TITLE
Store the correct state during worker pool import

### DIFF
--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -440,19 +440,7 @@ func (r *MachinePoolResource) magicImport(ctx context.Context, state *MachinePoo
 		return
 	}
 
-	// the 1AZ-related settings don't apply to the default machine pool
-	if state.MultiAvailabilityZone.IsUnknown() {
-		state.MultiAvailabilityZone = types.BoolNull()
-	}
-	if state.AvailabilityZone.IsUnknown() {
-		state.AvailabilityZone = types.StringNull()
-	}
-	if state.SubnetID.IsUnknown() {
-		state.SubnetID = types.StringNull()
-	}
-
-	// Save the state:
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, existingState)...)
 }
 
 func (r *MachinePoolResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {


### PR DESCRIPTION
The "magic import" of the day-1 worker pool was not storing the result of the resource update operation, and so values were not being properly populated, specifically disk size.