### PR TITLE
Enhance the oc login command to kill no kubeconfig warning in prow

### DIFF
--- a/tests/e2e/cluster_destroy_test.go
+++ b/tests/e2e/cluster_destroy_test.go
@@ -1,19 +1,27 @@
 package e2e
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	CI "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
+	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
 )
 
 var _ = Describe("TF Test", func() {
 	Describe("Create cluster test", func() {
 		It("DestroyClusterByProfile", CI.Destroy,
 			func() {
+				// Destroy kubeconfig folder
+				if _, err := os.Stat(CON.RHCS.KubeConfigDir); err == nil {
+					os.RemoveAll(CON.RHCS.KubeConfigDir)
+				}
 
 				// Generate/build cluster by profile selected
 				profile := CI.LoadProfileYamlFileByENV()
 				err := CI.DestroyRHCSClusterByProfile(token, profile)
+
 				Expect(err).ToNot(HaveOccurred())
 			})
 	})

--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
+	"fmt"
 	"net/http"
+	"path"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -72,12 +74,15 @@ var _ = Describe("TF Test", func() {
 					server := getResp.Body().API().URL()
 
 					ocAtter := &openshift.OcAttributes{
-						Server:          server,
-						Username:        userName,
-						Password:        password,
-						ClusterID:       clusterID,
-						AdditioanlFlags: []string{"--insecure-skip-tls-verify"},
-						Timeout:         7,
+						Server:    server,
+						Username:  userName,
+						Password:  password,
+						ClusterID: clusterID,
+						AdditioanlFlags: []string{
+							"--insecure-skip-tls-verify",
+							fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
+						},
+						Timeout: 7,
 					}
 					_, err = openshift.OcLogin(*ocAtter)
 					Expect(err).ToNot(HaveOccurred())
@@ -120,12 +125,15 @@ var _ = Describe("TF Test", func() {
 					server := getResp.Body().API().URL()
 
 					ocAtter := &openshift.OcAttributes{
-						Server:          server,
-						Username:        userName,
-						Password:        password,
-						ClusterID:       clusterID,
-						AdditioanlFlags: []string{"--insecure-skip-tls-verify"},
-						Timeout:         7,
+						Server:    server,
+						Username:  userName,
+						Password:  password,
+						ClusterID: clusterID,
+						AdditioanlFlags: []string{
+							"--insecure-skip-tls-verify",
+							fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
+						},
+						Timeout: 7,
 					}
 					_, err = openshift.OcLogin(*ocAtter)
 					Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -49,45 +49,47 @@ var _ = Describe("TF Test", func() {
 			})
 
 			Context("Author:smiron-High-OCP-63151 @OCP-63151 @smiron", func() {
-				It("OCP-63151 - Provision HTPASSWD IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP, func() {
-					By("Create htpasswd idp for an existing cluster")
+				It("OCP-63151 - Provision HTPASSWD IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP,
+					ci.Exclude,
+					func() {
+						By("Create htpasswd idp for an existing cluster")
 
-					idpParam := &exe.IDPArgs{
-						Token:         token,
-						ClusterID:     clusterID,
-						Name:          "htpasswd-idp-test",
-						HtpasswdUsers: htpasswdMap,
-					}
-					err := idpService.htpasswd.Create(idpParam, "-auto-approve", "-no-color")
-					Expect(err).ToNot(HaveOccurred())
-					idpID, _ := idpService.htpasswd.Output()
+						idpParam := &exe.IDPArgs{
+							Token:         token,
+							ClusterID:     clusterID,
+							Name:          "htpasswd-idp-test",
+							HtpasswdUsers: htpasswdMap,
+						}
+						err := idpService.htpasswd.Create(idpParam, "-auto-approve", "-no-color")
+						Expect(err).ToNot(HaveOccurred())
+						idpID, _ := idpService.htpasswd.Output()
 
-					By("List existing HtpasswdUsers and compare to the created one")
-					htpasswdUsersList, _ := cms.ListHtpasswdUsers(ci.RHCSConnection, clusterID, idpID.ID)
-					Expect(htpasswdUsersList.Status()).To(Equal(http.StatusOK))
-					respUserName, _ := htpasswdUsersList.Items().Slice()[0].GetUsername()
-					Expect(respUserName).To(Equal(userName))
+						By("List existing HtpasswdUsers and compare to the created one")
+						htpasswdUsersList, _ := cms.ListHtpasswdUsers(ci.RHCSConnection, clusterID, idpID.ID)
+						Expect(htpasswdUsersList.Status()).To(Equal(http.StatusOK))
+						respUserName, _ := htpasswdUsersList.Items().Slice()[0].GetUsername()
+						Expect(respUserName).To(Equal(userName))
 
-					By("Login with created htpasswd idp")
-					getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-					Expect(err).ToNot(HaveOccurred())
-					server := getResp.Body().API().URL()
+						By("Login with created htpasswd idp")
+						getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+						Expect(err).ToNot(HaveOccurred())
+						server := getResp.Body().API().URL()
 
-					ocAtter := &openshift.OcAttributes{
-						Server:    server,
-						Username:  userName,
-						Password:  password,
-						ClusterID: clusterID,
-						AdditioanlFlags: []string{
-							"--insecure-skip-tls-verify",
-							fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
-						},
-						Timeout: 7,
-					}
-					_, err = openshift.OcLogin(*ocAtter)
-					Expect(err).ToNot(HaveOccurred())
+						ocAtter := &openshift.OcAttributes{
+							Server:    server,
+							Username:  userName,
+							Password:  password,
+							ClusterID: clusterID,
+							AdditioanlFlags: []string{
+								"--insecure-skip-tls-verify",
+								fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
+							},
+							Timeout: 7,
+						}
+						_, err = openshift.OcLogin(*ocAtter)
+						Expect(err).ToNot(HaveOccurred())
 
-				})
+					})
 			})
 		})
 		Describe("LDAP IDP test cases", func() {
@@ -105,39 +107,41 @@ var _ = Describe("TF Test", func() {
 			})
 
 			Context("Author:smiron-High-OCP-63332 @OCP-63332 @smiron", func() {
-				It("OCP-63332 - Provision LDAP IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP, func() {
-					By("Create LDAP idp for an existing cluster")
+				It("OCP-63332 - Provision LDAP IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP,
+					ci.Exclude,
+					func() {
+						By("Create LDAP idp for an existing cluster")
 
-					idpParam := &exe.IDPArgs{
-						Token:     token,
-						ClusterID: clusterID,
-						Name:      "ldap-idp-test",
-						CA:        "",
-						URL:       con.LdapURL,
-						Insecure:  true,
-					}
-					err := idpService.ldap.Create(idpParam, "-auto-approve", "-no-color")
-					Expect(err).ToNot(HaveOccurred())
+						idpParam := &exe.IDPArgs{
+							Token:     token,
+							ClusterID: clusterID,
+							Name:      "ldap-idp-test",
+							CA:        "",
+							URL:       con.LdapURL,
+							Insecure:  true,
+						}
+						err := idpService.ldap.Create(idpParam, "-auto-approve", "-no-color")
+						Expect(err).ToNot(HaveOccurred())
 
-					By("Login with created ldap idp")
-					getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-					Expect(err).ToNot(HaveOccurred())
-					server := getResp.Body().API().URL()
+						By("Login with created ldap idp")
+						getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+						Expect(err).ToNot(HaveOccurred())
+						server := getResp.Body().API().URL()
 
-					ocAtter := &openshift.OcAttributes{
-						Server:    server,
-						Username:  userName,
-						Password:  password,
-						ClusterID: clusterID,
-						AdditioanlFlags: []string{
-							"--insecure-skip-tls-verify",
-							fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
-						},
-						Timeout: 7,
-					}
-					_, err = openshift.OcLogin(*ocAtter)
-					Expect(err).ToNot(HaveOccurred())
-				})
+						ocAtter := &openshift.OcAttributes{
+							Server:    server,
+							Username:  userName,
+							Password:  password,
+							ClusterID: clusterID,
+							AdditioanlFlags: []string{
+								"--insecure-skip-tls-verify",
+								fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
+							},
+							Timeout: 7,
+						}
+						_, err = openshift.OcLogin(*ocAtter)
+						Expect(err).ToNot(HaveOccurred())
+					})
 			})
 		})
 	})

--- a/tests/utils/constants/config.go
+++ b/tests/utils/constants/config.go
@@ -29,6 +29,7 @@ type RHCSconfig struct {
 	RhcsOutputDir     string
 	YAMLProfilesDir   string
 	RootDir           string
+	KubeConfigDir     string
 }
 
 func init() {
@@ -46,7 +47,8 @@ func init() {
 		RHCS.ClusterProfileDir = os.Getenv("CLUSTER_PROFILE_DIR")
 	}
 
-	RHCS.RhcsOutputDir = GetRhcsOutputDir()
+	RHCS.RhcsOutputDir = GetRHCSOutputDir()
+	RHCS.KubeConfigDir = GetKubeConfigDir()
 	RHCS.YAMLProfilesDir = path.Join(RHCS.RootDir, "tests", "ci", "profiles")
 }
 
@@ -95,7 +97,7 @@ func GetEnvWithDefault(key string, defaultValue string) string {
 	return defaultValue
 }
 
-func GetRhcsOutputDir() string {
+func GetRHCSOutputDir() string {
 	var rhcsNewOutPath string
 
 	if GetEnvWithDefault("RHCS_OUTPUT", "") != "" {
@@ -105,4 +107,13 @@ func GetRhcsOutputDir() string {
 	rhcsNewOutPath = path.Join(RHCS.RootDir, "tests", "rhcs_output")
 	os.MkdirAll(rhcsNewOutPath, 0777)
 	return rhcsNewOutPath
+}
+
+func GetKubeConfigDir() string {
+	outputDIR := GetRHCSOutputDir()
+	configDir := path.Join(outputDIR, "kubeconfig")
+	if _, err := os.Stat(configDir); err != nil {
+		os.MkdirAll(configDir, 0777)
+	}
+	return configDir
 }


### PR DESCRIPTION
When there is an ENV variable `KUBECONFIG`set and then try to login with `oc` command at the same time file path of `KUBECONFIG` not existing, it will cause warning of config not found. 
This PR enhanced the oc login command to make it redirect the kubeconfig path to an indicated file rather than using global `KUBECONFIG` env.
There will be a dir `$RHCS_OUTPUT/kubeconfig` created when run the tests, and it will be destroyed in destroy step(This is for clean local env. In prow, folders will be skipped when update $SHARE_DIR secret dir.)