### PR TITLE
small fix for mp test

### DIFF
--- a/tests/e2e/machine_pool_test.go
+++ b/tests/e2e/machine_pool_test.go
@@ -409,12 +409,13 @@ var _ = Describe("TF Test", func() {
 
 				By("Create additional machinepool with multi_availability_zone=false specified")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:       token,
-					Cluster:     clusterID,
-					Replicas:    replicas,
-					MachineType: machineType,
-					Name:        name,
-					MultiAZ:     false,
+					Token:            token,
+					Cluster:          clusterID,
+					Replicas:         replicas,
+					MachineType:      machineType,
+					Name:             name,
+					MultiAZ:          false,
+					AvailabilityZone: azs[1],
 				}
 
 				err = mpService.Create(MachinePoolArgs)


### PR DESCRIPTION
OCP-65063 Create single-az machinepool for multi-az cluster"
The test passed on local

Ran 1 of 21 Specs in 18.502 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 20 Skipped
PASS

Ginkgo ran 1 suite in 21.295953125s
Test Suite Passed
amalykhi@amalykhi-mac terraform-provider-rhcs % ginkgo run --focus OCP-65063 ./tests/e2e