### PR TITLE
OCM-4779: Fixing error in openid IDP

### DIFF
--- a/provider/identityprovider/openid.go
+++ b/provider/identityprovider/openid.go
@@ -2,7 +2,6 @@ package identityprovider
 
 import (
 	"context"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -15,7 +14,7 @@ type OpenIDIdentityProvider struct {
 	ClientID                 types.String                  `tfsdk:"client_id"`
 	ClientSecret             types.String                  `tfsdk:"client_secret"`
 	ExtraScopes              types.List                    `tfsdk:"extra_scopes"`
-	ExtraAuthorizeParameters map[string]string             `tfsdk:"extra_authorize_parameters"`
+	ExtraAuthorizeParameters types.Map                     `tfsdk:"extra_authorize_parameters"`
 	Issuer                   types.String                  `tfsdk:"issuer"`
 }
 
@@ -50,7 +49,7 @@ var openidSchema = map[string]schema.Attribute{
 		ElementType: types.StringType,
 		Optional:    true,
 	},
-	"extra_authorize_parameters": schema.ListAttribute{
+	"extra_authorize_parameters": schema.MapAttribute{
 		ElementType: types.StringType,
 		Optional:    true,
 	},
@@ -128,8 +127,13 @@ func CreateOpenIDIDPBuilder(ctx context.Context, state *OpenIDIdentityProvider) 
 	if !state.ClientSecret.IsNull() {
 		builder.ClientSecret(state.ClientSecret.ValueString())
 	}
-	if state.ExtraAuthorizeParameters != nil {
-		builder.ExtraAuthorizeParameters(state.ExtraAuthorizeParameters)
+	if common.HasValue(state.ExtraAuthorizeParameters) {
+		elements, err := common.OptionalMap(ctx, state.ExtraAuthorizeParameters)
+		if err != nil {
+			return nil, err
+		}
+
+		builder.ExtraAuthorizeParameters(elements)
 	}
 	if !state.ExtraScopes.IsUnknown() && !state.ExtraScopes.IsNull() {
 		extraScopes, err := common.StringListToArray(ctx, state.ExtraScopes)

--- a/subsystem/identity_provider_resource_test.go
+++ b/subsystem/identity_provider_resource_test.go
@@ -1049,6 +1049,9 @@ var _ = Describe("Identity provider creation", func() {
     					},
     					"client_id": "test_client",
     					"client_secret": "test_secret",
+    					"extra_authorize_parameters": {
+    					  "test_key": "test_value"
+    					},
     					"extra_scopes": [
     					  "email",
     					  "profile"
@@ -1081,6 +1084,9 @@ var _ = Describe("Identity provider creation", func() {
     							]
     						},
     						"client_id": "test_client",
+    						"extra_authorize_parameters": {
+    							"test_key": "test_value"
+    						},
     						"extra_scopes": [
     							"email",
     							"profile"
@@ -1097,11 +1103,14 @@ var _ = Describe("Identity provider creation", func() {
     		    cluster    				= "123"
     		    name       				= "my-ip"
     		    openid = {
-    				ca            			= "test_ca"
-    				issuer					= "https://test.okta.com"
-    				client_id 				= "test_client"
-    				client_secret			= "test_secret"
-    				extra_scopes 			= ["email","profile"]
+    				ca            						= "test_ca"
+    				issuer								= "https://test.okta.com"
+    				client_id 							= "test_client"
+    				client_secret						= "test_secret"
+    				extra_scopes 						= ["email","profile"]
+    				extra_authorize_parameters 			= {
+    					test_key              = "test_value"
+    		      	}
     				claims = {
     					email              = ["email"]
     					groups			   = ["admins"]
@@ -1112,6 +1121,8 @@ var _ = Describe("Identity provider creation", func() {
     		  }
     		`)
 			Expect(terraform.Apply()).To(BeZero())
+			resource := terraform.Resource("rhcs_identity_provider", "my_ip")
+			Expect(resource).To(MatchJQ(`.attributes.openid.extra_authorize_parameters.test_key`, "test_value"))
 		})
 
 		It("Should fail with invalid mapping_method", func() {


### PR DESCRIPTION
cannot reflect tftypes.List[tftypes.String] into a map, must be a map