### PR TITLE
single-az machinepool tc

### DIFF
--- a/tests/tf-manifests/aws/vpc-tags/main.tf
+++ b/tests/tf-manifests/aws/vpc-tags/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.20.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  ignore_tags {
+    key_prefixes = ["kubernetes.io/cluster/"]
+  }
+}
+
+resource "aws_ec2_tag" "tagging" {
+  for_each = toset(var.ids)
+  resource_id = each.value
+  key         = var.key
+  value       = var.value
+}

--- a/tests/tf-manifests/aws/vpc-tags/variables.tf
+++ b/tests/tf-manifests/aws/vpc-tags/variables.tf
@@ -1,0 +1,19 @@
+variable "aws_region" {
+  type = string
+  default = null
+}
+
+variable "ids" {
+  type = list(string)
+  default = null
+}
+
+variable "key" {
+  type = string
+  default = null
+}
+
+variable "value" {
+  type = string
+  default = null
+}

--- a/tests/utils/constants/constants.go
+++ b/tests/utils/constants/constants.go
@@ -74,6 +74,7 @@ var (
 	AccountRolesDir                      = path.Join(configrationDir, AWSProviderDIR, "account-roles")
 	OIDCProviderOperatorRolesManifestDir = path.Join(configrationDir, AWSProviderDIR, "oidc-provider-operator-roles")
 	AWSVPCDir                            = path.Join(configrationDir, AWSProviderDIR, "vpc")
+	AWSVPCTagDir                         = path.Join(configrationDir, AWSProviderDIR, "vpc-tags")
 )
 
 // Dirs of rhcs provider

--- a/tests/utils/exec/tf-exec.go
+++ b/tests/utils/exec/tf-exec.go
@@ -35,7 +35,7 @@ func runTerraformInit(ctx context.Context, dir string) error {
 
 func runTerraformApplyWithArgs(ctx context.Context, dir string, terraformArgs []string) (output string, err error) {
 	applyArgs := append([]string{"apply", "-auto-approve", "-no-color"}, terraformArgs...)
-	Logger.Infof("Running terraform apply against the dir: %s ", dir)
+	Logger.Infof("Running terraform apply against the dir: %s", dir)
 	Logger.Debugf("Running terraform apply against the dir: %s with args %v", dir, terraformArgs)
 	terraformApply := exec.Command("terraform", applyArgs...)
 	terraformApply.Dir = dir

--- a/tests/utils/exec/vpc-tags.go
+++ b/tests/utils/exec/vpc-tags.go
@@ -1,0 +1,66 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+)
+
+type VPCTagArgs struct {
+	AWSRegion string   `json:"aws_region,omitempty"`
+	IDs       []string `json:"ids,omitempty"`
+	TagKey    string   `json:"key,omitempty"`
+	TagValue  string   `json:"value,omitempty"`
+}
+
+type VPCTagService struct {
+	CreationArgs *VPCTagArgs
+	ManifestDir  string
+	Context      context.Context
+}
+
+func (vpctag *VPCTagService) Init(manifestDirs ...string) error {
+	vpctag.ManifestDir = CON.AWSVPCTagDir
+	if len(manifestDirs) != 0 {
+		vpctag.ManifestDir = manifestDirs[0]
+	}
+	ctx := context.TODO()
+	vpctag.Context = ctx
+	err := runTerraformInit(ctx, vpctag.ManifestDir)
+	if err != nil {
+		return err
+	}
+	return nil
+
+}
+
+func (vpctag *VPCTagService) Create(createArgs *VPCTagArgs, extraArgs ...string) error {
+	vpctag.CreationArgs = createArgs
+	args := combineStructArgs(createArgs, extraArgs...)
+	_, err := runTerraformApplyWithArgs(vpctag.Context, vpctag.ManifestDir, args)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (vpctag *VPCTagService) Destroy(createArgs ...*VPCTagArgs) error {
+	if vpctag.CreationArgs == nil && len(createArgs) == 0 {
+		return fmt.Errorf("got unset destroy args, set it in object or pass as a parameter")
+	}
+	destroyArgs := vpctag.CreationArgs
+	if len(createArgs) != 0 {
+		destroyArgs = createArgs[0]
+	}
+	args := combineStructArgs(destroyArgs)
+	err := runTerraformDestroyWithArgs(vpctag.Context, vpctag.ManifestDir, args)
+
+	return err
+}
+
+func NewVPCTagService(manifestDir ...string) *VPCTagService {
+	vpctag := &VPCTagService{}
+	vpctag.Init(manifestDir...)
+	return vpctag
+}


### PR DESCRIPTION
Singleaz test ocp-65063


the test passed after the fix
Ran 1 of 24 Specs in 27.974 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 23 Skipped
PASS

Ginkgo ran 1 suite in 28.970285431s
Test Suite Passed
[amalykhi@amalykhi-thinkpadp1gen5 terraform-provider-rhcs]$ ginkgo run --focus OCP-65071 --timeout 2h --output-dir /tmp/secret --junit-report result.xml -r --focus-file tests/e2e/. tests/e2e/..
