### PR TITLE
add idp negative tests - validate mandatory fields

### DIFF
--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	CI "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
 	ci "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/cms"
 	con "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
@@ -30,257 +29,504 @@ var _ = Describe("TF Test", func() {
 			openid exe.IDPService
 		}
 
-		var profile *CI.Profile
-		profile = CI.LoadProfileYamlFileByENV()
+		var profile *ci.Profile
+		profile = ci.LoadProfileYamlFileByENV()
 		var idpService IDPServices
-		var userName, password string
+		var htpasswdMap = []interface{}{map[string]string{}}
 
-		Describe("Htpasswd IDP test cases", func() {
-			var htpasswdMap = []interface{}{map[string]string{}}
-			var userName, password string
+		var userName, password,
+			googleIDPClientSecret, googleIDPClientId,
+			gitlabIDPClientSecret, gitlabIDPClientId,
+			githubIDPClientSecret, githubIDPClientId string
+
+		Describe("IDP Positive scenario test cases", func() {
+			Context("Htpasswd IDP test cases", func() {
+
+				BeforeEach(func() {
+					userName = "jacko"
+					password = h.RandStringWithUpper(15)
+					htpasswdMap = []interface{}{map[string]string{"username": userName, "password": password}}
+					idpService.htpasswd = *exe.NewIDPService(con.HtpasswdDir) // init new htpasswd service
+				})
+
+				AfterEach(func() {
+					err := idpService.htpasswd.Destroy()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("Author:smiron-High-OCP-63151 @OCP-63151 @smiron", func() {
+					It("OCP-63151 - Provision HTPASSWD IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP,
+						ci.Exclude,
+						func() {
+							By("Create htpasswd idp for an existing cluster")
+
+							idpParam := &exe.IDPArgs{
+								Token:         token,
+								ClusterID:     clusterID,
+								Name:          "OCP-63151-htpasswd-idp-test",
+								HtpasswdUsers: htpasswdMap,
+							}
+							err := idpService.htpasswd.Create(idpParam)
+							Expect(err).ToNot(HaveOccurred())
+							idpID, _ := idpService.htpasswd.Output()
+
+							By("List existing HtpasswdUsers and compare to the created one")
+							htpasswdUsersList, _ := cms.ListHtpasswdUsers(ci.RHCSConnection, clusterID, idpID.ID)
+							Expect(htpasswdUsersList.Status()).To(Equal(http.StatusOK))
+							respUserName, _ := htpasswdUsersList.Items().Slice()[0].GetUsername()
+							Expect(respUserName).To(Equal(userName))
+
+							By("Login with created htpasswd idp")
+							// this condition is for cases where the cluster profile
+							// has private_link enabled, then regular login won't work
+							if !profile.PrivateLink {
+								getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+								Expect(err).ToNot(HaveOccurred())
+								server := getResp.Body().API().URL()
+
+								ocAtter := &openshift.OcAttributes{
+									Server:    server,
+									Username:  userName,
+									Password:  password,
+									ClusterID: clusterID,
+									AdditioanlFlags: []string{
+										"--insecure-skip-tls-verify",
+										fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
+									},
+									Timeout: 7,
+								}
+								_, err = openshift.OcLogin(*ocAtter)
+								Expect(err).ToNot(HaveOccurred())
+							} else {
+								l.Logger.Infof("private_link is enabled, skipping login command check.")
+							}
+
+						})
+				})
+			})
+			Context("LDAP IDP test cases", func() {
+				BeforeEach(func() {
+
+					userName = "newton"
+					password = "password"
+					idpService.ldap = *exe.NewIDPService(con.LdapDir) // init new ldap service
+				})
+
+				AfterEach(func() {
+					err := idpService.ldap.Destroy()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("Author:smiron-High-OCP-63332 @OCP-63332 @smiron", func() {
+					It("OCP-63332 - Provision LDAP IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP,
+						ci.Exclude,
+						func() {
+							By("Create LDAP idp for an existing cluster")
+
+							idpParam := &exe.IDPArgs{
+								Token:      token,
+								ClusterID:  clusterID,
+								Name:       "OCP-63332-ldap-idp-test",
+								CA:         "",
+								URL:        con.LdapURL,
+								Attributes: make(map[string]interface{}),
+								Insecure:   true,
+							}
+							err := idpService.ldap.Create(idpParam)
+							Expect(err).ToNot(HaveOccurred())
+
+							By("Login with created ldap idp")
+							// this condition is for cases where the cluster profile
+							// has private_link enabled, then regular login won't work
+							if !profile.PrivateLink {
+								getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+								Expect(err).ToNot(HaveOccurred())
+								server := getResp.Body().API().URL()
+
+								ocAtter := &openshift.OcAttributes{
+									Server:    server,
+									Username:  userName,
+									Password:  password,
+									ClusterID: clusterID,
+									AdditioanlFlags: []string{
+										"--insecure-skip-tls-verify",
+										fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
+									},
+									Timeout: 7,
+								}
+								_, err = openshift.OcLogin(*ocAtter)
+								Expect(err).ToNot(HaveOccurred())
+							} else {
+								l.Logger.Infof("private_link is enabled, skipping login command check.")
+							}
+						})
+				})
+			})
+			Context("GitLab IDP test cases", func() {
+				BeforeEach(func() {
+					gitlabIDPClientId = h.RandStringWithUpper(20)
+					gitlabIDPClientSecret = h.RandStringWithUpper(30)
+					idpService.gitlab = *exe.NewIDPService(con.GitlabDir) // init new gitlab service
+				})
+
+				AfterEach(func() {
+					err := idpService.gitlab.Destroy()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("Author:smiron-High-OCP-64028 @OCP-64028 @smiron", func() {
+					It("OCP-64028 - Provision GitLab IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP, func() {
+						By("Create GitLab idp for an existing cluster")
+
+						idpParam := &exe.IDPArgs{
+							Token:        token,
+							ClusterID:    clusterID,
+							Name:         "OCP-64028-gitlab-idp-test",
+							ClientID:     gitlabIDPClientId,
+							ClientSecret: gitlabIDPClientSecret,
+							URL:          con.GitLabURL,
+						}
+						err := idpService.gitlab.Create(idpParam)
+						Expect(err).ToNot(HaveOccurred())
+
+						By("Check gitlab idp created for the cluster")
+						idpID, err := idpService.gitlab.Output()
+						Expect(err).ToNot(HaveOccurred())
+
+						resp, err := cms.RetrieveClusterIDPDetail(ci.RHCSConnection, clusterID, idpID.ID)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(resp.Status()).To(Equal(http.StatusOK))
+					})
+				})
+			})
+			Context("GitHub IDP test cases", func() {
+				BeforeEach(func() {
+
+					githubIDPClientSecret = h.RandStringWithUpper(20)
+					githubIDPClientId = h.RandStringWithUpper(30)
+					idpService.github = *exe.NewIDPService(con.GithubDir) // init new github service
+				})
+
+				AfterEach(func() {
+					err := idpService.github.Destroy()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("Author:smiron-High-OCP-64027 @OCP-64027 @smiron", func() {
+					It("OCP-64027 - Provision GitHub IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP, func() {
+						By("Create GitHub idp for an existing cluster")
+
+						idpParam := &exe.IDPArgs{
+							Token:         token,
+							ClusterID:     clusterID,
+							Name:          "OCP-64027-github-idp-test",
+							ClientID:      githubIDPClientId,
+							ClientSecret:  githubIDPClientSecret,
+							Organizations: con.Organizations,
+						}
+						err := idpService.github.Create(idpParam)
+						Expect(err).ToNot(HaveOccurred())
+
+						By("Check github idp created for the cluster")
+						idpID, err := idpService.github.Output()
+						Expect(err).ToNot(HaveOccurred())
+
+						resp, err := cms.RetrieveClusterIDPDetail(ci.RHCSConnection, clusterID, idpID.ID)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(resp.Status()).To(Equal(http.StatusOK))
+					})
+				})
+			})
+			Context("Google IDP test cases", func() {
+				BeforeEach(func() {
+
+					googleIDPClientSecret = h.RandStringWithUpper(20)
+					googleIDPClientId = h.RandStringWithUpper(30)
+					idpService.google = *exe.NewIDPService(con.GoogleDir) // init new google service
+				})
+
+				AfterEach(func() {
+					err := idpService.google.Destroy()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				Context("Author:smiron-High-OCP-64029 @OCP-64029 @smiron", func() {
+					It("OCP-64029 - Provision Google IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP, func() {
+						By("Create Google idp for an existing cluster")
+
+						idpParam := &exe.IDPArgs{
+							Token:        token,
+							ClusterID:    clusterID,
+							Name:         "OCP-64029-google-idp-test",
+							ClientID:     googleIDPClientId,
+							ClientSecret: googleIDPClientSecret,
+							HostedDomain: con.HostedDomain,
+						}
+						err := idpService.google.Create(idpParam)
+						Expect(err).ToNot(HaveOccurred())
+
+						By("Check google idp created for the cluster")
+						idpID, err := idpService.google.Output()
+						Expect(err).ToNot(HaveOccurred())
+
+						resp, err := cms.RetrieveClusterIDPDetail(ci.RHCSConnection, clusterID, idpID.ID)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(resp.Status()).To(Equal(http.StatusOK))
+					})
+				})
+			})
+		})
+		Describe("IDP Negative scenario test cases", func() {
 
 			BeforeEach(func() {
 
 				userName = "jacko"
 				password = h.RandStringWithUpper(15)
-				htpasswdMap = []interface{}{map[string]string{"username": userName, "password": password}}
-				idpService.htpasswd = *exe.NewIDPService(con.HtpasswdDir) // init new htpasswd service
-			})
-
-			AfterEach(func() {
-				err := idpService.htpasswd.Destroy()
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			Context("Author:smiron-High-OCP-63151 @OCP-63151 @smiron", func() {
-				It("OCP-63151 - Provision HTPASSWD IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP,
-					ci.Exclude,
-					func() {
-						By("Create htpasswd idp for an existing cluster")
-
-						idpParam := &exe.IDPArgs{
-							Token:         token,
-							ClusterID:     clusterID,
-							Name:          "OCP-63151-htpasswd-idp-test",
-							HtpasswdUsers: htpasswdMap,
-						}
-						err := idpService.htpasswd.Create(idpParam)
-						Expect(err).ToNot(HaveOccurred())
-						idpID, _ := idpService.htpasswd.Output()
-
-						By("List existing HtpasswdUsers and compare to the created one")
-						htpasswdUsersList, _ := cms.ListHtpasswdUsers(ci.RHCSConnection, clusterID, idpID.ID)
-						Expect(htpasswdUsersList.Status()).To(Equal(http.StatusOK))
-						respUserName, _ := htpasswdUsersList.Items().Slice()[0].GetUsername()
-						Expect(respUserName).To(Equal(userName))
-
-						By("Login with created htpasswd idp")
-
-						// this condition is for cases where the cluster profile
-						// has private_link enabled, then regular login won't work
-						if !profile.PrivateLink {
-
-							getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-							Expect(err).ToNot(HaveOccurred())
-							server := getResp.Body().API().URL()
-
-							ocAtter := &openshift.OcAttributes{
-								Server:    server,
-								Username:  userName,
-								Password:  password,
-								ClusterID: clusterID,
-								AdditioanlFlags: []string{
-									"--insecure-skip-tls-verify",
-									fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
-								},
-								Timeout: 7,
-							}
-							_, err = openshift.OcLogin(*ocAtter)
-							Expect(err).ToNot(HaveOccurred())
-						} else {
-							l.Logger.Infof("private_link is enabled, skipping login command check.")
-						}
-					})
-			})
-		})
-		Describe("LDAP IDP test cases", func() {
-
-			BeforeEach(func() {
-
-				userName = "newton"
-				password = "password"
-				idpService.ldap = *exe.NewIDPService(con.LdapDir) // init new ldap service
-			})
-
-			AfterEach(func() {
-				err := idpService.ldap.Destroy()
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			Context("Author:smiron-High-OCP-63332 @OCP-63332 @smiron", func() {
-				It("OCP-63332 - Provision LDAP IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP,
-					ci.Exclude,
-					func() {
-						By("Create LDAP idp for an existing cluster")
-
-						idpParam := &exe.IDPArgs{
-							Token:     token,
-							ClusterID: clusterID,
-							Name:      "OCP-63332-ldap-idp-test",
-							CA:        "",
-							URL:       con.LdapURL,
-							Insecure:  true,
-						}
-						err := idpService.ldap.Create(idpParam)
-						Expect(err).ToNot(HaveOccurred())
-
-						By("Login with created ldap idp")
-
-						// this condition is for cases where the cluster profile
-						// has private_link enabled, then regular login won't work
-						if !profile.PrivateLink {
-							getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-							Expect(err).ToNot(HaveOccurred())
-							server := getResp.Body().API().URL()
-
-							ocAtter := &openshift.OcAttributes{
-								Server:    server,
-								Username:  userName,
-								Password:  password,
-								ClusterID: clusterID,
-								AdditioanlFlags: []string{
-									"--insecure-skip-tls-verify",
-									fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, userName))),
-								},
-								Timeout: 7,
-							}
-							_, err = openshift.OcLogin(*ocAtter)
-							Expect(err).ToNot(HaveOccurred())
-						} else {
-							l.Logger.Infof("private_link is enabled, skipping login command check.")
-						}
-					})
-			})
-		})
-		Describe("GitLab IDP test cases", func() {
-
-			var gitlabIDPClientSecret, gitlabIDPClientId string
-
-			BeforeEach(func() {
 				gitlabIDPClientId = h.RandStringWithUpper(20)
 				gitlabIDPClientSecret = h.RandStringWithUpper(30)
-				idpService.gitlab = *exe.NewIDPService(con.GitlabDir) // init new gitlab service
-			})
-
-			AfterEach(func() {
-				err := idpService.gitlab.Destroy()
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			Context("Author:smiron-High-OCP-64028 @OCP-64028 @smiron", func() {
-				It("OCP-64028 - Provision GitLab IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP, func() {
-					By("Create GitLab idp for an existing cluster")
-
-					idpParam := &exe.IDPArgs{
-						Token:        token,
-						ClusterID:    clusterID,
-						Name:         "OCP-64028-gitlab-idp-test",
-						ClientID:     gitlabIDPClientId,
-						ClientSecret: gitlabIDPClientSecret,
-						URL:          con.GitLabURL,
-					}
-					err := idpService.gitlab.Create(idpParam)
-					Expect(err).ToNot(HaveOccurred())
-
-					By("Check gitlab idp created for the cluster")
-					idpID, err := idpService.gitlab.Output()
-					Expect(err).ToNot(HaveOccurred())
-
-					resp, err := cms.RetrieveClusterIDPDetail(ci.RHCSConnection, clusterID, idpID.ID)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(resp.Status()).To(Equal(http.StatusOK))
-				})
-			})
-		})
-		Describe("GitHub IDP test cases", func() {
-
-			var githubIDPClientSecret, githubIDPClientId string
-
-			BeforeEach(func() {
 				githubIDPClientSecret = h.RandStringWithUpper(20)
 				githubIDPClientId = h.RandStringWithUpper(30)
-				idpService.github = *exe.NewIDPService(con.GithubDir) // init new github service
+				googleIDPClientSecret = h.RandStringWithUpper(20)
+				googleIDPClientId = h.RandStringWithUpper(30)
+
+				idpService.htpasswd = *exe.NewIDPService(con.HtpasswdDir) // init new htpasswd service
+				idpService.ldap = *exe.NewIDPService(con.LdapDir)         // init new ldap service
+				idpService.github = *exe.NewIDPService(con.GithubDir)     // init new github service
+				idpService.gitlab = *exe.NewIDPService(con.GitlabDir)     // init new gitlab service
+				idpService.google = *exe.NewIDPService(con.GoogleDir)     // init new google service
 			})
 
-			AfterEach(func() {
-				err := idpService.github.Destroy()
-				Expect(err).ToNot(HaveOccurred())
-			})
+			Context("Author:smiron-High-OCP-68939 @OCP-68939 @smiron", func() {
+				It("OCP-68939 - Validate that the mandatory idp's attributes must be set", ci.Day2, ci.Medium, ci.FeatureIDP, func() {
 
-			Context("Author:smiron-High-OCP-64027 @OCP-64027 @smiron", func() {
-				It("OCP-64027 - Provision GitHub IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP, func() {
-					By("Create GitHub idp for an existing cluster")
-
+					By("Create htpasswd idp without/empty name field")
 					idpParam := &exe.IDPArgs{
 						Token:         token,
 						ClusterID:     clusterID,
-						Name:          "OCP-64027-github-idp-test",
+						Name:          "",
+						HtpasswdUsers: htpasswdMap,
+					}
+					err := idpService.htpasswd.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring(
+							"The root module input variable \"name\" is not set, and has no default value"))
+
+					By("Create htpasswd idp without/empty username field")
+					userName = ""
+					idpParam = &exe.IDPArgs{
+						Token:         token,
+						ClusterID:     clusterID,
+						Name:          "htpasswd-idp-test",
+						HtpasswdUsers: htpasswdMap,
+					}
+
+					err = idpService.htpasswd.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("attributes \"password\" and \"username\" are required"))
+
+					By("Create htpasswd idp without/empty password field")
+					password = ""
+					userName = "jacko"
+					idpParam = &exe.IDPArgs{
+						Token:         token,
+						ClusterID:     clusterID,
+						Name:          "htpasswd-idp-test",
+						HtpasswdUsers: htpasswdMap,
+					}
+					err = idpService.htpasswd.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("attributes \"password\" and \"username\" are required"))
+
+					By("Create ldap idp without/empty name field")
+					idpParam = &exe.IDPArgs{
+						Token:      token,
+						ClusterID:  clusterID,
+						Name:       "",
+						CA:         "",
+						URL:        con.LdapURL,
+						Attributes: make(map[string]interface{}),
+						Insecure:   true,
+					}
+					err = idpService.ldap.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring(
+							"The root module input variable \"name\" is not set, " +
+								"and has no default value"))
+
+					By("Create ldap idp without url field")
+					idpParam = &exe.IDPArgs{
+						Token:      token,
+						ClusterID:  clusterID,
+						Name:       "ldap-idp-test",
+						CA:         "",
+						URL:        "",
+						Attributes: make(map[string]interface{}),
+						Insecure:   true,
+					}
+					err = idpService.ldap.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring(
+						"Must set a configuration value for the ldap.url attribute"))
+
+					By("Create ldap idp without attributes field")
+					idpParam = &exe.IDPArgs{
+						Token:     token,
+						ClusterID: clusterID,
+						Name:      "ldap-idp-test",
+						CA:        "",
+						Insecure:  true,
+					}
+
+					err = idpService.ldap.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring("provider has marked it as required"))
+
+					By("Create github idp without/empty name field")
+					idpParam = &exe.IDPArgs{
+						Token:         token,
+						ClusterID:     clusterID,
+						Name:          "",
 						ClientID:      githubIDPClientId,
 						ClientSecret:  githubIDPClientSecret,
 						Organizations: con.Organizations,
 					}
-					err := idpService.github.Create(idpParam)
-					Expect(err).ToNot(HaveOccurred())
+					err = idpService.github.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring(
+							"The root module input variable \"name\" is not set, and has no default value"))
 
-					By("Check github idp created for the cluster")
-					idpID, err := idpService.github.Output()
-					Expect(err).ToNot(HaveOccurred())
+					By("Create github idp without/empty client_id field")
+					idpParam = &exe.IDPArgs{
+						Token:         token,
+						ClusterID:     clusterID,
+						Name:          "github-idp-test",
+						ClientID:      "",
+						ClientSecret:  githubIDPClientSecret,
+						Organizations: con.Organizations,
+					}
+					err = idpService.github.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring("No value for required variable"))
 
-					resp, err := cms.RetrieveClusterIDPDetail(ci.RHCSConnection, clusterID, idpID.ID)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(resp.Status()).To(Equal(http.StatusOK))
-				})
-			})
-		})
-		Describe("Google IDP test cases", func() {
+					By("Create github idp without/empty client_secret field")
+					idpParam = &exe.IDPArgs{
+						Token:         token,
+						ClusterID:     clusterID,
+						Name:          "github-idp-test",
+						ClientID:      githubIDPClientId,
+						ClientSecret:  "",
+						Organizations: con.Organizations,
+					}
+					err = idpService.github.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring("No value for required variable"))
 
-			var googleIDPClientSecret, googleIDPClientId string
-
-			BeforeEach(func() {
-				googleIDPClientSecret = h.RandStringWithUpper(20)
-				googleIDPClientId = h.RandStringWithUpper(30)
-				idpService.google = *exe.NewIDPService(con.GoogleDir) // init new google service
-			})
-
-			AfterEach(func() {
-				err := idpService.google.Destroy()
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			Context("Author:smiron-High-OCP-64029 @OCP-64029 @smiron", func() {
-				It("OCP-64029 - Provision Google IDP against cluster using TF", ci.Day2, ci.High, ci.FeatureIDP, func() {
-					By("Create Google idp for an existing cluster")
-
-					idpParam := &exe.IDPArgs{
+					By("Create gitlab idp without/empty name field")
+					idpParam = &exe.IDPArgs{
 						Token:        token,
 						ClusterID:    clusterID,
-						Name:         "OCP-64029-google-idp-test",
+						Name:         "",
+						ClientID:     gitlabIDPClientId,
+						ClientSecret: gitlabIDPClientSecret,
+						URL:          con.GitLabURL,
+					}
+					err = idpService.gitlab.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring(
+							"The root module input variable \"name\" is not set, and has no default value"))
+
+					By("Create gitlab idp without/empty client_id field")
+					idpParam = &exe.IDPArgs{
+						Token:        token,
+						ClusterID:    clusterID,
+						Name:         "gitlab-idp-test",
+						ClientID:     "",
+						ClientSecret: gitlabIDPClientSecret,
+						URL:          con.GitLabURL,
+					}
+					err = idpService.gitlab.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring("provider has marked it as required"))
+
+					By("Create gitlab idp without/empty client_secret field")
+					idpParam = &exe.IDPArgs{
+						Token:        token,
+						ClusterID:    clusterID,
+						Name:         "gitlab-idp-test",
+						ClientID:     gitlabIDPClientId,
+						ClientSecret: "",
+						URL:          con.GitLabURL,
+					}
+					err = idpService.gitlab.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring("provider has marked it as required"))
+
+					By("Create gitlab idp without url field")
+					idpParam = &exe.IDPArgs{
+						Token:        token,
+						ClusterID:    clusterID,
+						Name:         "gitlab-idp-test",
+						URL:          "",
+						ClientID:     gitlabIDPClientId,
+						ClientSecret: gitlabIDPClientSecret,
+					}
+					err = idpService.gitlab.Create(idpParam)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).Should(
+						ContainSubstring("Must set a configuration value for the gitlab.url"))
+
+					By("Create google idp without/empty name field")
+					idpParam = &exe.IDPArgs{
+						Token:        token,
+						ClusterID:    clusterID,
+						Name:         "",
 						ClientID:     googleIDPClientId,
 						ClientSecret: googleIDPClientSecret,
 						HostedDomain: con.HostedDomain,
 					}
-					err := idpService.google.Create(idpParam)
-					Expect(err).ToNot(HaveOccurred())
+					err = idpService.google.Create(idpParam)
+					Expect(err.Error()).Should(
+						ContainSubstring(
+							"The root module input variable \"name\" is not set, and has no default value"))
 
-					By("Check google idp created for the cluster")
-					idpID, err := idpService.google.Output()
-					Expect(err).ToNot(HaveOccurred())
+					By("Create google idp without/empty client_id field")
+					idpParam = &exe.IDPArgs{
+						Token:        token,
+						ClusterID:    clusterID,
+						Name:         "google-idp-test",
+						ClientID:     "",
+						ClientSecret: googleIDPClientSecret,
+						HostedDomain: con.HostedDomain,
+					}
+					err = idpService.google.Create(idpParam)
+					Expect(err.Error()).Should(
+						ContainSubstring("provider has marked it as required"))
 
-					resp, err := cms.RetrieveClusterIDPDetail(ci.RHCSConnection, clusterID, idpID.ID)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(resp.Status()).To(Equal(http.StatusOK))
+					By("Create google idp without/empty client_secret field")
+					idpParam = &exe.IDPArgs{
+						Token:        token,
+						ClusterID:    clusterID,
+						Name:         "google-idp-test",
+						ClientID:     googleIDPClientId,
+						ClientSecret: "",
+						HostedDomain: con.HostedDomain,
+					}
+					err = idpService.google.Create(idpParam)
+					Expect(err.Error()).Should(
+						ContainSubstring("provider has marked it as required"))
+
 				})
 			})
+
 		})
 	})
 })

--- a/tests/tf-manifests/rhcs/idps/github/main.tf
+++ b/tests/tf-manifests/rhcs/idps/github/main.tf
@@ -29,7 +29,7 @@ provider "rhcs" {
 resource "rhcs_identity_provider" "github_idp" {
   cluster        = var.cluster_id
   mapping_method = var.mapping_method
-  name           = "GitHub"
+  name           = var.name
   github = {
     client_id     = var.client_id
     client_secret = var.client_secret

--- a/tests/tf-manifests/rhcs/idps/github/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/github/variables.tf
@@ -34,5 +34,4 @@ variable "organizations" {
 }
 variable "name" {
     type= string
-    default = "Github"
 }

--- a/tests/tf-manifests/rhcs/idps/gitlab/main.tf
+++ b/tests/tf-manifests/rhcs/idps/gitlab/main.tf
@@ -32,7 +32,7 @@ locals {
 resource "rhcs_identity_provider" "gitlab_idp" {
   cluster        = var.cluster_id
   mapping_method = var.mapping_method
-  name           = "Gitlab"
+  name           = var.name
   gitlab = {
     client_id     = var.client_id
     client_secret = var.client_secret

--- a/tests/tf-manifests/rhcs/idps/ldap/main.tf
+++ b/tests/tf-manifests/rhcs/idps/ldap/main.tf
@@ -35,8 +35,9 @@ resource "rhcs_identity_provider" "ldap_idp" {
   ldap = {
     ca            = var.ca
     insecure      = true
-    url           = "ldap://ldap.forumsys.com/dc=example,dc=com?uid"
+    url           = var.url
+    
     # optional
-    attributes    = {}
+    attributes    = var.attributes
   }
 }

--- a/tests/tf-manifests/rhcs/idps/ldap/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/ldap/variables.tf
@@ -40,6 +40,7 @@ variable "attributes" {
     preferred_username = optional(list(string))
   })
   default = null
+  description = "attributes optional fields list"
 }
 
 variable "ca" {

--- a/tests/utils/exec/idps.go
+++ b/tests/utils/exec/idps.go
@@ -16,6 +16,7 @@ type IDPArgs struct {
 	OCMENV        string        `json:"ocm_environment,omitempty"`
 	URL           string        `json:"url,omitempty"`
 	CA            string        `json:"ca,omitempty"`
+	Attributes    interface{}   `json:"attributes,omitempty"`
 	ClientID      string        `json:"client_id,omitempty"`
 	ClientSecret  string        `json:"client_secret,omitempty"`
 	Organizations []string      `json:"organizations,omitempty"`
@@ -51,7 +52,6 @@ func (idp *IDPService) Init(manifestDirs ...string) error {
 }
 
 func (idp *IDPService) Create(createArgs *IDPArgs, extraArgs ...string) error {
-	createArgs.URL = CON.GateWayURL
 	idp.CreationArgs = createArgs
 	args := combineStructArgs(createArgs, extraArgs...)
 	_, err := runTerraformApplyWithArgs(idp.Context, idp.ManifestDir, args)


### PR DESCRIPTION
This PR will validate all the mandatory fields each idp resource has, as described in the[ terraform rhcs provider doc](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/identity_provider)

<img width="1041" alt="image" src="https://github.com/terraform-redhat/terraform-provider-rhcs/assets/54883783/c6524f64-a958-40f5-84ee-38112784452e">
