### PR TITLE
OCM-4931: Remove a validation in machinepool so it can be created with the subnet from different AZ than the cluster was created - for singleAZ cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1 (Nov 20, 2023)
+ENHANCEMENTS:
+* Fix the error message of `private_hosted_zone` validator in `cluster_rosa_classic` resource  
+* Fix a bug in `identity_provider` resource from type openid - `cannot reflect tftypes.List[tftypes.String] into a map, must be a map` 
+
 ## 1.4.0 (Oct 19, 2023)
 FEATURES:
 * Add wait attribute in `cluster_rosa_classic` resource for waiting cluster readiness in the creation flow

--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -710,7 +710,6 @@ func (r *MachinePoolResource) validateAZConfig(state *MachinePoolState) (bool, e
 	cluster := resp.Body()
 	isMultiAZCluster := cluster.MultiAZ()
 	clusterAZs := cluster.Nodes().AvailabilityZones()
-	clusterSubnets := cluster.AWS().SubnetIDs()
 
 	if isMultiAZCluster {
 		// Can't set both availability_zone and subnet_id
@@ -737,22 +736,6 @@ func (r *MachinePoolResource) validateAZConfig(state *MachinePoolState) (bool, e
 		state.MultiAvailabilityZone = types.BoolValue(false)
 	}
 
-	// Ensure that the machine pool's AZ and subnet are valid for the cluster
-	// If subnet is set, we make sure it's valid for the cluster, but we don't default it if not set
-	if !common.IsStringAttributeEmpty(state.SubnetID) {
-		inClusterSubnet := false
-		for _, subnet := range clusterSubnets {
-			if subnet == state.SubnetID.ValueString() {
-				inClusterSubnet = true
-				break
-			}
-		}
-		if !inClusterSubnet {
-			return false, fmt.Errorf("subnet_id %s is not valid for cluster %s", state.SubnetID.ValueString(), state.Cluster.ValueString())
-		}
-	} else {
-		state.SubnetID = types.StringNull()
-	}
 	// If AZ is set, we make sure it's valid for the cluster. If not set and neither is subnet, we default it to the 1st AZ in the cluster
 	if !common.IsStringAttributeEmpty(state.AvailabilityZone) {
 		inClusterAZ := false

--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -2246,19 +2246,6 @@ var _ = Describe("Machine pool w/ 1AZ byo VPC cluster", func() {
 		Expect(resource).To(MatchJQ(".attributes.aws_additional_security_group_ids.[0]", "id1"))
 	})
 
-	It("Fails to create pool if subnet_id not in byo vpc subnets", func() {
-		// Run the apply command:
-		terraform.Source(`
-		  resource "rhcs_machine_pool" "my_pool" {
-		    cluster      = "123"
-		    name         = "my-pool"
-		    machine_type = "r5.xlarge"
-		    replicas     = 4
-			subnet_id = "not-in-vpc-of-cluster"
-		  }
-		`)
-		Expect(terraform.Apply()).NotTo(BeZero())
-	})
 })
 
 var _ = Describe("Machine pool import", func() {


### PR DESCRIPTION
@amalykhi 