### PR TITLE
OCM-4701 Automate OCP-65928 Cluster admin user during deployment 

### DIFF
--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -3,6 +3,7 @@ package ci
 import (
 	"fmt"
 	"os"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -224,7 +225,17 @@ func GenerateClusterCreationArgsByProfile(token string, profile *Profile) (clust
 	}
 
 	if profile.AdminEnabled {
-		// ToDo
+		userName := CON.ClusterAdminUser
+		password := HELPER.GenerateRandomStringWithSymbols(14)
+		adminPasswdMap := map[string]string{"username": userName, "password": password}
+		clusterArgs.AdminCredentials = adminPasswdMap
+		pass := []byte(password)
+		err = os.WriteFile(path.Join(CON.GetRHCSOutputDir(), CON.ClusterAdminUser), pass, 0644)
+		if err != nil {
+			return
+		}
+		Logger.Infof("Admin password is written to the output directory")
+
 	}
 
 	if profile.AuditLogForward {

--- a/tests/ci/profiles/tf_cluster_profile.yml
+++ b/tests/ci/profiles/tf_cluster_profile.yml
@@ -26,6 +26,7 @@ profiles:
     zones: ""
     imdsv2: "optional"
     oidc_config: "managed"
+    admin_enabled: false
 # rosa-sts-ad :: creating unmanaged oidc config cluster 
 - as: rosa-sts-ad
   cluster:
@@ -53,6 +54,7 @@ profiles:
     zones: ""
     imdsv2: "required"
     oidc_config: "un-managed"
+    admin_enabled: true
 # rosa-sts-up :: creating a managed cluster for upgrade purpose
 - as: rosa-sts-up
   cluster:
@@ -80,3 +82,4 @@ profiles:
     zones: ""
     imdsv2: ""
     oidc_config: "managed"
+    admin_enabled: true

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -83,6 +83,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   service_cidr                = var.service_cidr
   pod_cidr                    = var.pod_cidr
   tags                        = var.tags
+  admin_credentials           = var.admin_credentials
   destroy_timeout             = 120
   lifecycle {
     ignore_changes = [availability_zones]

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -176,5 +176,10 @@ variable "aws_region" {
 variable "oidc_config_id" {
   type        = string
   default     = null
+}
 
+variable "admin_credentials" {
+  description = "Admin user and password"
+  type        = map(string)
+  default     = null
 }

--- a/tests/utils/constants/constants.go
+++ b/tests/utils/constants/constants.go
@@ -28,7 +28,7 @@ var (
 )
 
 var (
-	DefaultMajorVersion = "4.13"
+	DefaultMajorVersion = "4.14"
 	CharsBytes          = "abcdefghijklmnopqrstuvwxyz123456789"
 	WorkSpace           = "WORKSPACE"
 	RHCSPrefix          = "rhcs"
@@ -38,10 +38,11 @@ var (
 	Organizations       = []string{"openshift"}
 	HostedDomain        = "redhat.com"
 	NilMap              map[string]string
+	Tags                = map[string]string{"tag1": "test_tag1", "tag2": "test_tag2"}
+	ClusterAdminUser    = "cluster_admin_name"
 	DefaultMPLabels     = map[string]string{
 		"test1": "testdata1",
 	}
-	Tags = map[string]string{"tag1": "test_tag1", "tag2": "test_tag2"}
 )
 
 const (

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -34,6 +34,7 @@ type ClusterCreationArgs struct {
 	MultiAZ              bool              `json:"multi_az,omitempty"`
 	MachineCIDR          string            `json:"machine_cidr,omitempty"`
 	OIDCConfigID         string            `json:"oidc_config_id,omitempty"`
+	AdminCredentials     map[string]string `json:"admin_credentials,omitempty"`
 }
 
 // Just a placeholder, not research what to output yet.

--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -2,6 +2,8 @@ package helper
 
 import (
 	"bytes"
+	r "crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -390,6 +392,15 @@ func RandStringWithUpper(n int) string {
 	return strings.Join(b, "")
 }
 
+func GenerateRandomStringWithSymbols(length int) string {
+	b := make([]byte, length)
+	_, err := r.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
 func subfix() string {
 	subfix := make([]byte, 3)
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -404,4 +415,13 @@ func GenerateClusterName(profileName string) string {
 
 	clusterPrefix := CON.RHCSPrefix + CON.HyphenConnector + profileName[5:]
 	return clusterPrefix + CON.HyphenConnector + subfix()
+}
+
+func GetClusterAdminPassword() string {
+	path := fmt.Sprintf(path.Join(CON.GetRHCSOutputDir(), CON.ClusterAdminUser))
+	b, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Print(err)
+	}
+	return string(b)
 }


### PR DESCRIPTION
OCP-65928 - [tf] [OCM-2674](https://issues.redhat.com//browse/OCM-2674) - Cluster admin during deployment - confirm user created ONLY during cluster creation operation


time="2023-11-26T12:45:49+02:00" level=info msg="[>>] Running CMD: oc login https://api.rhcs-sts-ad-ldi.6vaq.s1.devshift.org:6443 --username CLUSTER_ADMIN --password <password>"
time="2023-11-26T12:46:00+02:00" level=info msg="Got output Login successful.\n\nYou have access to 102 projects, the list has been suppressed. You can list all projects with 'oc projects'\n\nUsing project \"default\".\nWelcome! See 'oc help' to get started."
•SSSSSSSSSSSSSS

Ran 1 of 23 Specs in 12.780 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 22 Skipped
PASS

Ginkgo ran 1 suite in 13.546559198s
Test Suite Passed

