### PR TITLE
OCM-4927: Prevent trying to replace the default machinepool

### DIFF
--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -32,7 +32,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -76,7 +75,7 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 				Description: "Identifier of the cluster.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					requiresReplaceMachinepool(),
 				},
 			},
 			"id": schema.StringAttribute{
@@ -90,7 +89,7 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 				Description: "Name of the machine pool. Must consist of lower-case alphanumeric characters or '-', start and end with an alphanumeric character.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					requiresReplaceMachinepool(),
 				},
 			},
 			"machine_type": schema.StringAttribute{
@@ -99,7 +98,7 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 					"source to find the possible values.",
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					requiresReplaceMachinepool(),
 				},
 			},
 			"replicas": schema.Int64Attribute{
@@ -110,14 +109,14 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 				Description: "Use Amazon EC2 Spot Instances.",
 				Optional:    true,
 				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
+					requiresReplaceMachinepool(),
 				},
 			},
 			"max_spot_price": schema.Float64Attribute{
 				Description: "Max Spot price.",
 				Optional:    true,
 				PlanModifiers: []planmodifier.Float64{
-					float64planmodifier.RequiresReplace(),
+					requiresReplaceMachinepool(),
 				},
 				Validators: []validator.Float64{
 					float64validator.AtLeast(1e-6), // Greater than zero
@@ -171,8 +170,8 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
 					boolplanmodifier.UseStateForUnknown(),
+					requiresReplaceMachinepool(),
 				},
 			},
 			"availability_zone": schema.StringAttribute{
@@ -180,8 +179,8 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+					requiresReplaceMachinepool(),
 				},
 			},
 			"subnet_id": schema.StringAttribute{
@@ -189,8 +188,8 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+					requiresReplaceMachinepool(),
 				},
 			},
 			"disk_size": schema.Int64Attribute{
@@ -198,8 +197,8 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
 					int64planmodifier.UseStateForUnknown(),
+					requiresReplaceMachinepool(),
 				},
 			},
 			"aws_additional_security_group_ids": schema.ListAttribute{

--- a/provider/machinepool/requires_replace_machinepool_modifier.go
+++ b/provider/machinepool/requires_replace_machinepool_modifier.go
@@ -1,0 +1,132 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinepool
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type machinepoolRequiresReplacer interface {
+	planmodifier.Bool
+	planmodifier.Float64
+	planmodifier.Int64
+	planmodifier.String
+}
+
+// requiresReplaceMachinepool returns a plan modifier that is identical to
+// requiresReplace, except in the case of the default machine pool, where it
+// returns an error instead of requiring replacement.
+func requiresReplaceMachinepool() machinepoolRequiresReplacer {
+	return requiresReplaceMachinepoolImpl{}
+}
+
+type requiresReplaceMachinepoolImpl struct{}
+
+func (r requiresReplaceMachinepoolImpl) Description(_ context.Context) string {
+	return "Return an error instead of trying to recreate the default machine pool"
+}
+func (r requiresReplaceMachinepoolImpl) MarkdownDescription(ctx context.Context) string {
+	return r.Description(ctx)
+}
+
+func (r requiresReplaceMachinepoolImpl) planModify(ctx context.Context, attrPath path.Path,
+	config tfsdk.Config, configValue attr.Value,
+	plan tfsdk.Plan, planValue attr.Value,
+	state tfsdk.State, stateValue attr.Value) (bool, diag.Diagnostics) {
+	tflog.Debug(ctx, "requiresReplaceMachinepool modifier", map[string]interface{}{
+		"Attribute":   attrPath.String(),
+		"Config":      configValue.String(),
+		"Plan":        planValue.String(),
+		"PlanIsNull":  plan.Raw.IsNull(),
+		"State":       stateValue.String(),
+		"StateIsNull": state.Raw.IsNull(),
+	})
+
+	// The resource is being created, so we allow it.
+	if state.Raw.IsNull() {
+		tflog.Debug(ctx, "requiresReplaceMachinepool modifier", map[string]interface{}{
+			"Attribute": attrPath.String(),
+			"Operation": "ResourceCreate",
+			"Value":     configValue.String(),
+		})
+		return false, nil
+	}
+
+	// The resource is being destroyed, so we allow it.
+	if plan.Raw.IsNull() {
+		tflog.Debug(ctx, "requiresReplaceMachinepool modifier", map[string]interface{}{
+			"Attribute": attrPath.String(),
+			"Operation": "ResourceDestroy",
+		})
+		return false, nil
+	}
+
+	// The attribute is unchanged, so we allow it.
+	if planValue.Equal(stateValue) {
+		return false, nil
+	}
+
+	// At this point, we know that the attribute is changing, so we need to make sure it's not the default machine pool
+	replace := true
+	diags := diag.Diagnostics{}
+
+	poolName := &types.String{}
+	diags.Append(config.GetAttribute(ctx, path.Root("name"), poolName)...)
+	if poolName.ValueString() == defaultMachinePoolName {
+		diags.AddAttributeError(
+			attrPath,
+			"Attribute cannot be changed for the default machine pool",
+			fmt.Sprintf("The attribute '%s' cannot be changed for the default machine pool because it"+
+				" would require recreating the machine pool, which is not supported.", attrPath.String()),
+		)
+	}
+
+	return replace, diags
+}
+
+func (r requiresReplaceMachinepoolImpl) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	replace, diags := r.planModify(ctx, req.Path, req.Config, req.ConfigValue, req.Plan, req.PlanValue, req.State, req.StateValue)
+	resp.RequiresReplace = replace
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r requiresReplaceMachinepoolImpl) PlanModifyFloat64(ctx context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
+	replace, diags := r.planModify(ctx, req.Path, req.Config, req.ConfigValue, req.Plan, req.PlanValue, req.State, req.StateValue)
+	resp.RequiresReplace = replace
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r requiresReplaceMachinepoolImpl) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	replace, diags := r.planModify(ctx, req.Path, req.Config, req.ConfigValue, req.Plan, req.PlanValue, req.State, req.StateValue)
+	resp.RequiresReplace = replace
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r requiresReplaceMachinepoolImpl) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	replace, diags := r.planModify(ctx, req.Path, req.Config, req.ConfigValue, req.Plan, req.PlanValue, req.State, req.StateValue)
+	resp.RequiresReplace = replace
+	resp.Diagnostics.Append(diags...)
+}

--- a/subsystem/main_test.go
+++ b/subsystem/main_test.go
@@ -247,6 +247,11 @@ func (r *TerraformRunner) Import(args ...string) int {
 	return r.Run(append([]string{"import"}, args...)...)
 }
 
+// Plan runs the `plan` command.
+func (r *TerraformRunner) Plan() int {
+	return r.Run("plan")
+}
+
 // State returns the reads the Terraform state and returns the result of parsing
 // it as a JSON document.
 func (r *TerraformRunner) State() interface{} {


### PR DESCRIPTION
We have a number of attributes w/in the machinepool resource that cannot be changed once the pool has been created. These attributes are marked w/ "requiresReplace" so that if they are changed, TF will destroy and recreate the MP with the desired settings.
Unfortunately, it is not possible to recreate the default "worker" machinepool, so this process fails if a user edits one of these attributes for the default pool.

This change implements a new "plan modifier" that is similar to the existing "requiresReplace" modifier, except that it checks the name of the machinepool that is being affected:
- If it is the "worker" pool, it returns an error (at plan-time) before any changes are made to the user's cluster.
- For any other pool, it acts identically to the normal "requiresReplace" modifier