### PR TITLE
Fix the validators to support unknown values for proxy and private_ho…

### DIFF
--- a/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
@@ -586,7 +586,7 @@ func createClassicClusterObject(ctx context.Context,
 		builder.DisableUserWorkloadMonitoring(state.DisableWorkloadMonitoring.ValueBool())
 	}
 
-	if !common.IsStringAttributeEmpty(state.BaseDNSDomain) {
+	if !common.IsStringAttributeUnknownOrEmpty(state.BaseDNSDomain) {
 		dnsBuilder := cmv1.NewDNS()
 		dnsBuilder.BaseDomain(state.BaseDNSDomain.ValueString())
 		builder.DNS(dnsBuilder)
@@ -628,8 +628,8 @@ func createClassicClusterObject(ctx context.Context,
 
 	var privateHostedZoneID, privateHostedZoneRoleARN *string = nil, nil
 	if state.PrivateHostedZone != nil &&
-		!common.IsStringAttributeEmpty(state.PrivateHostedZone.ID) &&
-		!common.IsStringAttributeEmpty(state.PrivateHostedZone.RoleARN) {
+		!common.IsStringAttributeUnknownOrEmpty(state.PrivateHostedZone.ID) &&
+		!common.IsStringAttributeUnknownOrEmpty(state.PrivateHostedZone.RoleARN) {
 		privateHostedZoneRoleARN = state.PrivateHostedZone.RoleARN.ValueStringPointer()
 		privateHostedZoneID = state.PrivateHostedZone.ID.ValueStringPointer()
 	}
@@ -763,20 +763,20 @@ func buildProxy(state *ClusterRosaClassicState, builder *cmv1.ClusterBuilder) (*
 		httpNoProxy := ""
 		additionalTrustBundle := ""
 
-		if !common.IsStringAttributeEmpty(state.Proxy.HttpProxy) {
+		if !common.IsStringAttributeUnknownOrEmpty(state.Proxy.HttpProxy) {
 			httpProxy = state.Proxy.HttpProxy.ValueString()
 		}
 		proxy.HTTPProxy(httpProxy)
-		if !common.IsStringAttributeEmpty(state.Proxy.HttpsProxy) {
+		if !common.IsStringAttributeUnknownOrEmpty(state.Proxy.HttpsProxy) {
 			httpsProxy = state.Proxy.HttpsProxy.ValueString()
 		}
 		proxy.HTTPSProxy(httpsProxy)
-		if !common.IsStringAttributeEmpty(state.Proxy.NoProxy) {
+		if !common.IsStringAttributeUnknownOrEmpty(state.Proxy.NoProxy) {
 			httpNoProxy = state.Proxy.NoProxy.ValueString()
 		}
 		proxy.NoProxy(httpNoProxy)
 
-		if !common.IsStringAttributeEmpty(state.Proxy.AdditionalTrustBundle) {
+		if !common.IsStringAttributeUnknownOrEmpty(state.Proxy.AdditionalTrustBundle) {
 			additionalTrustBundle = state.Proxy.AdditionalTrustBundle.ValueString()
 		}
 		builder.AdditionalTrustBundle(additionalTrustBundle)
@@ -816,7 +816,7 @@ func (r *ClusterRosaClassicResource) getAndValidateVersionInChannelGroup(ctx con
 }
 
 func validateHttpTokensVersion(ctx context.Context, state *ClusterRosaClassicState, version string) error {
-	if common.IsStringAttributeEmpty(state.Ec2MetadataHttpTokens) ||
+	if common.IsStringAttributeUnknownOrEmpty(state.Ec2MetadataHttpTokens) ||
 		cmv1.Ec2MetadataHttpTokens(state.Ec2MetadataHttpTokens.ValueString()) == cmv1.Ec2MetadataHttpTokensOptional {
 		return nil
 	}
@@ -1183,7 +1183,7 @@ func (r *ClusterRosaClassicResource) Update(ctx context.Context, request resourc
 // Upgrades the cluster if the desired (plan) version is greater than the
 // current version
 func (r *ClusterRosaClassicResource) upgradeClusterIfNeeded(ctx context.Context, state, plan *ClusterRosaClassicState) error {
-	if common.IsStringAttributeEmpty(plan.Version) || common.IsStringAttributeEmpty(state.CurrentVersion) {
+	if common.IsStringAttributeUnknownOrEmpty(plan.Version) || common.IsStringAttributeUnknownOrEmpty(state.CurrentVersion) {
 		// No version information, nothing to do
 		tflog.Debug(ctx, "Insufficient cluster version information to determine if upgrade should be performed.")
 		return nil
@@ -1198,7 +1198,7 @@ func (r *ClusterRosaClassicResource) upgradeClusterIfNeeded(ctx context.Context,
 
 	// See if the user has changed the requested version for this run
 	requestedVersionChanged := true
-	if !common.IsStringAttributeEmpty(plan.Version) && !common.IsStringAttributeEmpty(state.Version) {
+	if !common.IsStringAttributeUnknownOrEmpty(plan.Version) && !common.IsStringAttributeUnknownOrEmpty(state.Version) {
 		if plan.Version.ValueString() == state.Version.ValueString() {
 			requestedVersionChanged = false
 		}
@@ -1556,7 +1556,7 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 			state.Sts.InstanceIAMRoles.WorkerRoleARN = types.StringValue(instanceIAMRoles.WorkerRoleARN())
 		}
 		// TODO: fix a bug in uhc-cluster-services
-		if common.IsStringAttributeEmpty(state.Sts.OperatorRolePrefix) {
+		if common.IsStringAttributeUnknownOrEmpty(state.Sts.OperatorRolePrefix) {
 			operatorRolePrefix, ok := sts.GetOperatorRolePrefix()
 			if ok {
 				state.Sts.OperatorRolePrefix = types.StringValue(operatorRolePrefix)
@@ -1635,7 +1635,7 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 	}
 
 	trustBundle, ok := object.GetAdditionalTrustBundle()
-	if ok && common.IsStringAttributeEmpty(state.Proxy.AdditionalTrustBundle) {
+	if ok && common.IsStringAttributeUnknownOrEmpty(state.Proxy.AdditionalTrustBundle) {
 		if state.Proxy == nil {
 			state.Proxy = &proxy.Proxy{}
 		}

--- a/provider/clusterrosaclassic/validators.go
+++ b/provider/clusterrosaclassic/validators.go
@@ -44,7 +44,7 @@ var privateHZValidator = attrvalidators.NewObjectValidator("proxy map should not
 		errSum := "Invalid private_hosted_zone attribute assignment"
 
 		// validate ID and ARN are not empty
-		if common.IsStringAttributeEmpty(privateHZ.ID) || common.IsStringAttributeEmpty(privateHZ.RoleARN) {
+		if common.IsStringAttributeKnownAndEmpty(privateHZ.ID) || common.IsStringAttributeKnownAndEmpty(privateHZ.RoleARN) {
 			resp.Diagnostics.AddError(errSum, "Invalid configuration. 'private_hosted_zone.id' and 'private_hosted_zone.role_arn' are required")
 			return
 		}

--- a/provider/common/helpers.go
+++ b/provider/common/helpers.go
@@ -102,16 +102,20 @@ func IsValidDomain(candidate string) bool {
 	return domainRegexp.MatchString(candidate)
 }
 
-func IsStringAttributeEmpty(param types.String) bool {
-	return param.IsUnknown() || param.IsNull() || param.ValueString() == ""
-}
-
 func EmptiableStringToStringType(s string) types.String {
 	if s == "" {
 		return types.StringNull()
 	}
 
 	return types.StringValue(s)
+}
+
+func IsStringAttributeUnknownOrEmpty(param types.String) bool {
+	return param.IsUnknown() || param.IsNull() || param.ValueString() == ""
+}
+
+func IsStringAttributeKnownAndEmpty(param types.String) bool {
+	return !param.IsUnknown() && (param.IsNull() || param.ValueString() == "")
 }
 
 func IsGreaterThanOrEqual(version1, version2 string) (bool, error) {

--- a/provider/identityprovider/ldap.go
+++ b/provider/identityprovider/ldap.go
@@ -98,19 +98,19 @@ var ldapAttrSchema = map[string]schema.Attribute{
 
 func CreateLDAPIDPBuilder(ctx context.Context, state *LDAPIdentityProvider) (*cmv1.LDAPIdentityProviderBuilder, error) {
 	builder := cmv1.NewLDAPIdentityProvider()
-	if !common.IsStringAttributeEmpty(state.BindDN) {
+	if !common.IsStringAttributeUnknownOrEmpty(state.BindDN) {
 		builder.BindDN(state.BindDN.ValueString())
 	}
-	if !common.IsStringAttributeEmpty(state.BindPassword) {
+	if !common.IsStringAttributeUnknownOrEmpty(state.BindPassword) {
 		builder.BindPassword(state.BindPassword.ValueString())
 	}
-	if !common.IsStringAttributeEmpty(state.CA) {
+	if !common.IsStringAttributeUnknownOrEmpty(state.CA) {
 		builder.CA(state.CA.ValueString())
 	}
 	if !state.Insecure.IsNull() && !state.Insecure.IsUnknown() {
 		builder.Insecure(state.Insecure.ValueBool())
 	}
-	if !common.IsStringAttributeEmpty(state.URL) {
+	if !common.IsStringAttributeUnknownOrEmpty(state.URL) {
 		builder.URL(state.URL.ValueString())
 	}
 

--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -315,10 +315,10 @@ func (r *MachinePoolResource) Create(ctx context.Context, req resource.CreateReq
 		)
 		return
 	}
-	if !common.IsStringAttributeEmpty(state.AvailabilityZone) {
+	if !common.IsStringAttributeUnknownOrEmpty(state.AvailabilityZone) {
 		builder.AvailabilityZones(state.AvailabilityZone.ValueString())
 	}
-	if !common.IsStringAttributeEmpty(state.SubnetID) {
+	if !common.IsStringAttributeUnknownOrEmpty(state.SubnetID) {
 		builder.Subnets(state.SubnetID.ValueString())
 	}
 	if common.HasValue(state.AdditionalSecurityGroupIds) {
@@ -713,12 +713,12 @@ func (r *MachinePoolResource) validateAZConfig(state *MachinePoolState) (bool, e
 
 	if isMultiAZCluster {
 		// Can't set both availability_zone and subnet_id
-		if !common.IsStringAttributeEmpty(state.AvailabilityZone) && !common.IsStringAttributeEmpty(state.SubnetID) {
+		if !common.IsStringAttributeUnknownOrEmpty(state.AvailabilityZone) && !common.IsStringAttributeUnknownOrEmpty(state.SubnetID) {
 			return false, fmt.Errorf("availability_zone and subnet_id are mutually exclusive")
 		}
 
 		// multi_availability_zone setting must be consistent with availability_zone and subnet_id
-		azOrSubnet := !common.IsStringAttributeEmpty(state.AvailabilityZone) || !common.IsStringAttributeEmpty(state.SubnetID)
+		azOrSubnet := !common.IsStringAttributeUnknownOrEmpty(state.AvailabilityZone) || !common.IsStringAttributeUnknownOrEmpty(state.SubnetID)
 		if common.HasValue(state.MultiAvailabilityZone) {
 			if azOrSubnet && state.MultiAvailabilityZone.ValueBool() {
 				return false, fmt.Errorf("multi_availability_zone must be False when availability_zone or subnet_id is set")
@@ -727,7 +727,7 @@ func (r *MachinePoolResource) validateAZConfig(state *MachinePoolState) (bool, e
 			state.MultiAvailabilityZone = types.BoolValue(!azOrSubnet)
 		}
 	} else { // not a multi-AZ cluster
-		if !common.IsStringAttributeEmpty(state.AvailabilityZone) {
+		if !common.IsStringAttributeUnknownOrEmpty(state.AvailabilityZone) {
 			return false, fmt.Errorf("availability_zone can only be set for multi-AZ clusters")
 		}
 		if common.HasValue(state.MultiAvailabilityZone) && state.MultiAvailabilityZone.ValueBool() {
@@ -737,7 +737,7 @@ func (r *MachinePoolResource) validateAZConfig(state *MachinePoolState) (bool, e
 	}
 
 	// If AZ is set, we make sure it's valid for the cluster. If not set and neither is subnet, we default it to the 1st AZ in the cluster
-	if !common.IsStringAttributeEmpty(state.AvailabilityZone) {
+	if !common.IsStringAttributeUnknownOrEmpty(state.AvailabilityZone) {
 		inClusterAZ := false
 		for _, az := range clusterAZs {
 			if az == state.AvailabilityZone.ValueString() {
@@ -749,7 +749,7 @@ func (r *MachinePoolResource) validateAZConfig(state *MachinePoolState) (bool, e
 			return false, fmt.Errorf("availability_zone %s is not valid for cluster %s", state.AvailabilityZone.ValueString(), state.Cluster.ValueString())
 		}
 	} else {
-		if len(clusterAZs) > 0 && !state.MultiAvailabilityZone.ValueBool() && isMultiAZCluster && common.IsStringAttributeEmpty(state.SubnetID) {
+		if len(clusterAZs) > 0 && !state.MultiAvailabilityZone.ValueBool() && isMultiAZCluster && common.IsStringAttributeUnknownOrEmpty(state.SubnetID) {
 			state.AvailabilityZone = types.StringValue(clusterAZs[0])
 		} else {
 			state.AvailabilityZone = types.StringNull()

--- a/provider/proxy/proxy_validator.go
+++ b/provider/proxy/proxy_validator.go
@@ -35,17 +35,8 @@ func (v proxyValidator) ValidateObject(ctx context.Context, request validator.Ob
 		return
 	}
 	errSum := "Invalid proxy's attribute assignment"
-	httpsProxy := ""
-	httpProxy := ""
 
-	if !common.IsStringAttributeEmpty(proxy.HttpProxy) {
-		httpProxy = proxy.HttpProxy.ValueString()
-	}
-	if !common.IsStringAttributeEmpty(proxy.HttpsProxy) {
-		httpsProxy = proxy.HttpsProxy.ValueString()
-	}
-
-	if httpProxy == "" && httpsProxy == "" {
+	if common.IsStringAttributeKnownAndEmpty(proxy.HttpProxy) && common.IsStringAttributeKnownAndEmpty(proxy.HttpsProxy) {
 		response.Diagnostics.AddError(errSum, "Expected at least one of the following: http-proxy, https-proxy")
 		return
 	}

--- a/provider/rosa_operator_roles/rosa_operator_roles_data_source.go
+++ b/provider/rosa_operator_roles/rosa_operator_roles_data_source.go
@@ -148,7 +148,7 @@ func (s *RosaOperatorRolesDataSource) Read(ctx context.Context, req datasource.R
 	})
 
 	accountRolePrefix := DefaultAccountRolePrefix
-	if !common.IsStringAttributeEmpty(state.AccountRolePrefix) {
+	if !common.IsStringAttributeUnknownOrEmpty(state.AccountRolePrefix) {
 		accountRolePrefix = state.AccountRolePrefix.ValueString()
 	}
 


### PR DESCRIPTION
…sted_zone

Check if the ID and RoleARN are not empty string only if the value is known This enable to use unkonw values like pointing to a different resource output