### PR TITLE
OCM-4983: Update machinepool error message re replicas/autoscaling

### DIFF
--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -629,7 +629,7 @@ func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolSt
 		diags.AddError(
 			"Cannot update machine pool",
 			fmt.Sprintf(
-				"Cannot update machine pool for cluster '%s: either autoscaling or compute nodes should be enabled", state.Cluster.ValueString(),
+				"Cannot update machine pool for cluster '%s: either replicas should be set or autoscaling enabled", state.Cluster.ValueString(),
 			),
 		)
 		return diags


### PR DESCRIPTION
Updates the error message when neither or both replicas and autoscaling are set.