### PR TITLE
ignore tags for kubernetes.io/*

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 page_title: "Red Hat Cloud Services Terraform Provider"
 subcategory: ""
 description: |-
-  
+
 ---
 <a href="https://redhat.com">
     <img src=".github/Logo_Red_Hat.png" alt="Red Hat logo" title="Red Hat" align="right" max-width="60px" />
@@ -20,7 +20,7 @@ The Red Hat Cloud Services Terraform provider allows Terraform to manage Red Hat
 
 For more information about ROSA, see the Red Hat documentation [here](https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-understanding).
 
-## Prerequisites 
+## Prerequisites
 * [GoLang version 1.20 or newer](https://go.dev/doc/install)
 * [Terraform version 1.4.6 or newer](https://developer.hashicorp.com/terraform/downloads)
 * An offline [OCM token](https://console.redhat.com/openshift/token/rosa)
@@ -39,13 +39,21 @@ The following items are limitations with the current release of the OCM Terrafor
 
 * The latest version is not backward compatible with version 1.0.1.
 * When creating a cluster, the cluster uses AWS credentials configured on your local machine. These credentials provide access to the AWS API for validating your account.
-* When creating a machine pool, you need to specify your replica count. You must define either the `replicas= "<count>"` variable or provide values for the following variables to build the machine pool:  
-   * `min_replicas = "<count>"` 
-   * `max_replicas="<count>"` 
+* When creating a machine pool, you need to specify your replica count. You must define either the `replicas= "<count>"` variable or provide values for the following variables to build the machine pool:
+   * `min_replicas = "<count>"`
+   * `max_replicas="<count>"`
    * `autoscaling_enabled=true`
 * The htpasswd identity provider does not support creating the identity provider with multiple users or adding additional users to the existing identity provider.
 * The S3 bucket that is created as part of the OIDC configuration must be created in the same region as your OIDC provider.
 * The Terraform provider does not support auto-generated `operator_role_prefix`. You must provide your `operator_role_prefix` when creating the account roles.
+* The ROSA cluster may add `kubernetes.io/*` tags to VPC resources which need to be preserved.  Thus we recommend adding them to the `ignore_tags` section of the `aws` provider configuration such as:
+    ```hcl
+    provider "aws" {
+      ignore_tags {
+        key_prefixes = ["kubernetes.io/"]
+      }
+    }
+    ```
 
 ## Examples
 
@@ -73,8 +81,8 @@ If you want to build a local Red Hat Cloud Services provider to develop improvem
     <HOME>/.terraform.d/plugins/terraform.local/local/rhcs/<VERSION>/<TARGET_ARCH>
     ```
 
-    For example, the following location would contain the `terraform-rhcs-provider` binary file: 
-    ```    
+    For example, the following location would contain the `terraform-rhcs-provider` binary file:
+    ```
     ~/.terraform.d/plugins/terraform.local/local/rhcs/0.0.1/linux_amd64
 2. You now need to update your `main.tf` to the location of the local provider by pointing the required_providers rhcs to the local terraform directory.
 
@@ -103,4 +111,4 @@ Binary image only runs on AMD64 architectures up to now.
 
 ### Developing the Provider
 Detailed documentation for developing and contributing to RHCS provider can be found in our [contribution guide](CONTRIBUTE.md).
- 
+

--- a/examples/create_rosa_sts_cluster/classic_sts/cluster/main.tf
+++ b/examples/create_rosa_sts_cluster/classic_sts/cluster/main.tf
@@ -32,6 +32,13 @@ provider "rhcs" {
   url   = var.url
 }
 
+provider "aws" {
+  region = var.cloud_region
+  ignore_tags {
+    key_prefixes = ["kubernetes.io/"]
+  }
+}
+
 locals {
   sts_roles = {
     role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",

--- a/examples/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/examples/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -31,6 +31,13 @@ provider "rhcs" {
   url   = var.url
 }
 
+provider "aws" {
+  region = var.cloud_region
+  ignore_tags {
+    key_prefixes = ["kubernetes.io/"]
+  }
+}
+
 # Create managed OIDC config
 module "oidc_config" {
   token                = var.token

--- a/examples/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/examples/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -31,6 +31,13 @@ provider "rhcs" {
   url   = var.url
 }
 
+provider "aws" {
+  region = var.cloud_region
+  ignore_tags {
+    key_prefixes = ["kubernetes.io/"]
+  }
+}
+
 locals {
   installer_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Installer-Role"
 }


### PR DESCRIPTION
Kubernetes / OCP will add tags to VPC / Subnets to help with load balancer discovery for services.  This ensures those tags are preserved on subsequent terraform runs.