### PR TITLE
insecure-skip-tls-verify and timeout fix

### DIFF
--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -153,10 +153,9 @@ var _ = Describe("TF Test", func() {
 					Password:  password,
 					ClusterID: clusterID,
 					AdditioanlFlags: []string{
-						"--insecure-skip-tls-verify",
 						fmt.Sprintf("--kubeconfig %s", path.Join(con.RHCS.KubeConfigDir, fmt.Sprintf("%s.%s", clusterID, username))),
 					},
-					Timeout: 5,
+					Timeout: 10,
 				}
 				_, err = openshift.OcLogin(*ocAtter)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
As I see in logs
WARNING: Using insecure TLS client config. Setting this option is not supported!
-removing

As experienced with last CI runs - it takes in average 5 minutes to get cluster ready and access oc login command - increased the timeout