### PR TITLE
new automated 69073 69009 69727 and some updates

### DIFF
--- a/tests/ci/labels.go
+++ b/tests/ci/labels.go
@@ -15,6 +15,9 @@ var Day1Prepare = Label("day1-prepare")
 var Day1Post = Label("day1-post")
 var Day2 = Label("day2")
 
+// day3 : the test cases will destroy default resource
+var Day3 = Label("day3")
+
 // destroy
 var Destroy = Label("destroy")
 

--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -431,7 +431,7 @@ func DestroyRHCSClusterByProfile(token string, profile *Profile) error {
 		clusterArgs.AdditionalInfraSecurityGroups = output.AdditionalInfraSecurityGroups
 		clusterArgs.AdditionalControlPlaneSecurityGroups = output.AdditionalControlPlaneSecurityGroups
 	}
-	err = clusterService.Destroy(clusterArgs)
+	_, err = clusterService.Destroy(clusterArgs)
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/cluster_destroy_test.go
+++ b/tests/e2e/cluster_destroy_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = Describe("TF Test", func() {
-	Describe("Create cluster test", func() {
+	Describe("Delete cluster test", func() {
 		It("DestroyClusterByProfile", CI.Destroy,
 			func() {
 				// Destroy kubeconfig folder

--- a/tests/e2e/machine_pool_test.go
+++ b/tests/e2e/machine_pool_test.go
@@ -4,6 +4,7 @@ import (
 
 	// nolint
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -11,6 +12,7 @@ import (
 	cms "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/cms"
 	con "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
 	exe "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/exec"
+	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
 var _ = Describe("TF Test", func() {
@@ -21,20 +23,20 @@ var _ = Describe("TF Test", func() {
 			mpService = exe.NewMachinePoolService(con.MachinePoolDir)
 		})
 		AfterEach(func() {
-			err := mpService.Destroy()
+			_, err := mpService.Destroy()
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("MachinePoolExampleNegative", func() {
-
+			replicas := 3
 			MachinePoolArgs := &exe.MachinePoolArgs{
 				Token:       token,
 				Cluster:     clusterID,
-				Replicas:    3,
+				Replicas:    &replicas,
 				MachineType: "invalid",
 				Name:        "testmp",
 			}
 
-			err := mpService.Create(MachinePoolArgs)
+			_, err := mpService.Create(MachinePoolArgs)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("is not supported for cloud provider 'aws'"))
 		})
@@ -47,12 +49,12 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs := &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: machineType,
 					Name:        name,
 				}
 
-				err := mpService.Create(MachinePoolArgs)
+				_, err := mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 				_, err = mpService.Output()
 				Expect(err).ToNot(HaveOccurred())
@@ -79,13 +81,13 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs := &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: machineType,
 					Name:        name,
 					Labels:      creationLabels,
 				}
 
-				err := mpService.Create(MachinePoolArgs)
+				_, err := mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the created machinepool")
@@ -95,7 +97,7 @@ var _ = Describe("TF Test", func() {
 
 				By("Edit the labels of the machinepool")
 				MachinePoolArgs.Labels = updatingLabels
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 				mpResponseBody, err = cms.RetrieveClusterMachinePool(ci.RHCSConnection, clusterID, name)
 				Expect(err).ToNot(HaveOccurred())
@@ -103,7 +105,7 @@ var _ = Describe("TF Test", func() {
 
 				By("Delete the labels of the machinepool")
 				MachinePoolArgs.Labels = emptyLabels
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the updated machinepool")
@@ -124,14 +126,14 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs := &exe.MachinePoolArgs{
 					Token:              token,
 					Cluster:            clusterID,
-					MinReplicas:        minReplicas,
-					MaxReplicas:        maxReplicas,
+					MinReplicas:        &minReplicas,
+					MaxReplicas:        &maxReplicas,
 					MachineType:        machineType,
 					Name:               name,
 					AutoscalingEnabled: true,
 				}
 
-				err := mpService.Create(MachinePoolArgs)
+				_, err := mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the created machinepool")
@@ -141,9 +143,11 @@ var _ = Describe("TF Test", func() {
 				Expect(mpResponseBody.Autoscaling().MaxReplicas()).To(Equal(maxReplicas))
 
 				By("Change the number of replicas of the machinepool")
-				MachinePoolArgs.MinReplicas = minReplicas * 2
-				MachinePoolArgs.MaxReplicas = maxReplicas * 2
-				err = mpService.Create(MachinePoolArgs)
+				NewMinReplicas := minReplicas * 2
+				NewMaxReplicas := maxReplicas * 2
+				MachinePoolArgs.MinReplicas = &NewMinReplicas
+				MachinePoolArgs.MaxReplicas = &NewMaxReplicas
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the updated machinepool")
@@ -156,12 +160,12 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: machineType,
 					Name:        name,
 				}
 
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the updated machinepool")
@@ -185,13 +189,13 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs := &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: machineType,
 					Name:        name,
 					Taints:      taints,
 				}
 
-				err := mpService.Create(MachinePoolArgs)
+				_, err := mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the created machinepool")
@@ -211,7 +215,7 @@ var _ = Describe("TF Test", func() {
 				taints = append(taints, taint2)
 
 				By("Apply the changes to the machinepool")
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the updated machinepool")
@@ -226,7 +230,7 @@ var _ = Describe("TF Test", func() {
 
 				By("Delete the taints of the machinepool")
 				MachinePoolArgs.Taints = emptyTaints
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the updated machinepool")
@@ -249,11 +253,11 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs := &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    invalidMpReplicas,
+					Replicas:    &invalidMpReplicas,
 					Name:        invalidMachinepoolName,
 					MachineType: machineType,
 				}
-				err := mpService.Create(MachinePoolArgs)
+				_, err := mpService.Create(MachinePoolArgs)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("Expected a valid value for 'name'"))
 
@@ -261,11 +265,11 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    invalidMpReplicas,
+					Replicas:    &invalidMpReplicas,
 					Name:        machinepoolName,
 					MachineType: machineType,
 				}
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("Attribute 'replicas'\nmust be a non-negative integer"))
 
@@ -273,11 +277,11 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    mpReplicas,
+					Replicas:    &mpReplicas,
 					Name:        machinepoolName,
 					MachineType: InvalidInstanceType,
 				}
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("Machine type\n'%s' is not supported for cloud provider", InvalidInstanceType))
 
@@ -285,12 +289,12 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:              token,
 					Cluster:            clusterID,
-					Replicas:           mpReplicas,
+					Replicas:           &mpReplicas,
 					Name:               machinepoolName,
 					AutoscalingEnabled: true,
 					MachineType:        machineType,
 				}
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("when\nenabling autoscaling, should set value for maxReplicas"))
 
@@ -298,13 +302,13 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:              token,
 					Cluster:            clusterID,
-					MinReplicas:        maxReplicas,
-					MaxReplicas:        minReplicas,
+					MinReplicas:        &maxReplicas,
+					MaxReplicas:        &minReplicas,
 					Name:               machinepoolName,
 					AutoscalingEnabled: true,
 					MachineType:        machineType,
 				}
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("'min_replicas' must be less than or equal to 'max_replicas'"))
 
@@ -312,12 +316,12 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					MinReplicas: minReplicas,
-					MaxReplicas: maxReplicas,
+					MinReplicas: &minReplicas,
+					MaxReplicas: &maxReplicas,
 					Name:        machinepoolName,
 					MachineType: machineType,
 				}
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("when\ndisabling autoscaling, cannot set min_replicas and/or max_replicas"))
 
@@ -328,26 +332,26 @@ var _ = Describe("TF Test", func() {
 					MachinePoolArgs = &exe.MachinePoolArgs{
 						Token:              token,
 						Cluster:            clusterID,
-						MinReplicas:        minReplicas,
-						MaxReplicas:        invalidMaxReplicas4Mutilcluster,
+						MinReplicas:        &minReplicas,
+						MaxReplicas:        &invalidMaxReplicas4Mutilcluster,
 						Name:               machinepoolName,
 						MachineType:        machineType,
 						AutoscalingEnabled: true,
 					}
-					err = mpService.Create(MachinePoolArgs)
+					_, err = mpService.Create(MachinePoolArgs)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).Should(ContainSubstring("Multi AZ clusters require that the number of replicas be a\nmultiple of 3"))
 
 					MachinePoolArgs = &exe.MachinePoolArgs{
 						Token:              token,
 						Cluster:            clusterID,
-						MinReplicas:        invalidMinReplicas4Mutilcluster,
-						MaxReplicas:        maxReplicas,
+						MinReplicas:        &invalidMinReplicas4Mutilcluster,
+						MaxReplicas:        &maxReplicas,
 						Name:               machinepoolName,
 						MachineType:        machineType,
 						AutoscalingEnabled: true,
 					}
-					err = mpService.Create(MachinePoolArgs)
+					_, err = mpService.Create(MachinePoolArgs)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).Should(ContainSubstring("Multi AZ clusters require that the number of replicas be a\nmultiple of 3"))
 
@@ -370,13 +374,13 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs := &exe.MachinePoolArgs{
 					Token:            token,
 					Cluster:          clusterID,
-					Replicas:         replicas,
+					Replicas:         &replicas,
 					MachineType:      machineType,
 					Name:             name,
 					AvailabilityZone: azs[0],
 				}
 
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the created machinepool")
@@ -384,7 +388,7 @@ var _ = Describe("TF Test", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(mpResponseBody.AvailabilityZones()[0]).To(Equal(azs[0]))
 
-				err = mpService.Destroy()
+				_, err = mpService.Destroy()
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Create additional machinepool with subnet id specified")
@@ -392,13 +396,13 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: machineType,
 					Name:        name,
 					SubnetID:    awsSubnetIds[0],
 				}
 
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the created machinepool")
@@ -406,21 +410,21 @@ var _ = Describe("TF Test", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(mpResponseBody.Subnets()[0]).To(Equal(awsSubnetIds[0]))
 
-				err = mpService.Destroy()
+				_, err = mpService.Destroy()
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Create additional machinepool with multi_availability_zone=false specified")
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:            token,
 					Cluster:          clusterID,
-					Replicas:         replicas,
+					Replicas:         &replicas,
 					MachineType:      machineType,
 					Name:             name,
 					MultiAZ:          false,
 					AvailabilityZone: azs[1],
 				}
 
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 				By("Verify the parameters of the created machinepool")
 				mpResponseBody, err = cms.RetrieveClusterMachinePool(ci.RHCSConnection, clusterID, name)
@@ -457,7 +461,7 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs := &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: machineType,
 					Name:        name,
 					SubnetID:    newZonePrivateSubnet,
@@ -467,8 +471,9 @@ var _ = Describe("TF Test", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(mpResponseBody.Subnets()[0]).To(Equal(newZonePrivateSubnet))
 
-				MachinePoolArgs.Replicas = 4
-				err = mpService.Create(MachinePoolArgs)
+				replicas = 4
+				MachinePoolArgs.Replicas = &replicas
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the updated machinepool")
@@ -487,16 +492,16 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs := &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: machineType,
 					Name:        name,
 					DiskSize:    diskSize,
 				}
 
-				err := mpService.Create(MachinePoolArgs)
+				_, err := mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 				defer func() {
-					err = mpService.Destroy()
+					_, err = mpService.Destroy()
 					Expect(err).ToNot(HaveOccurred())
 				}()
 
@@ -510,13 +515,13 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: machineType,
 					Name:        name,
 					DiskSize:    320,
 				}
 
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the created machinepool")
@@ -529,12 +534,12 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: "m5.2xlarge",
 					Name:        name,
 				}
 
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the created machinepool")
@@ -584,16 +589,16 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs := &exe.MachinePoolArgs{
 					Token:                    token,
 					Cluster:                  clusterID,
-					Replicas:                 replicas,
+					Replicas:                 &replicas,
 					MachineType:              machineType,
 					Name:                     name,
 					AdditionalSecurityGroups: sgIDs,
 				}
 
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 				defer func() {
-					err = mpService.Destroy()
+					_, err = mpService.Destroy()
 					Expect(err).ToNot(HaveOccurred())
 				}()
 
@@ -609,7 +614,7 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:                    token,
 					Cluster:                  clusterID,
-					Replicas:                 replicas,
+					Replicas:                 &replicas,
 					MachineType:              machineType,
 					Name:                     name,
 					AdditionalSecurityGroups: output.SGIDs[0:1],
@@ -620,8 +625,8 @@ var _ = Describe("TF Test", func() {
 				Expect(applyOutput).Should(ContainSubstring("attribute \"aws_additional_security_group_ids\" must have a known value and may not be changed."))
 
 				By("Destroy the machinepool")
-				mpService.CreationArgs.AdditionalSecurityGroups = sgIDs
-				err = mpService.Destroy()
+				mpService.CreationArgs.AdditionalSecurityGroups = output.SGIDs
+				_, err = mpService.Destroy()
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Create another machinepool without additional sg ")
@@ -629,12 +634,12 @@ var _ = Describe("TF Test", func() {
 				MachinePoolArgs = &exe.MachinePoolArgs{
 					Token:       token,
 					Cluster:     clusterID,
-					Replicas:    replicas,
+					Replicas:    &replicas,
 					MachineType: "m5.2xlarge",
 					Name:        name,
 				}
 
-				err = mpService.Create(MachinePoolArgs)
+				_, err = mpService.Create(MachinePoolArgs)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verify the parameters of the created machinepool")
@@ -643,6 +648,288 @@ var _ = Describe("TF Test", func() {
 				Expect(mpResponseBody.AWS().AdditionalSecurityGroupIds()).To(BeNil())
 				Expect(mpResponseBody.InstanceType()).To(Equal("m5.2xlarge"))
 
+			})
+		})
+	})
+})
+
+var _ = Describe("TF Test, default machinepool day-2 testing", func() {
+	Describe("Default MachinePool test cases", func() {
+
+		var (
+			dmpService             *exe.MachinePoolService
+			defaultMachinePoolArgs exe.MachinePoolArgs
+			mpService              *exe.MachinePoolService
+			defaultMachinePoolNmae = "worker"
+		)
+
+		BeforeEach(func() {
+			dmpService = exe.NewMachinePoolService(con.DefaultMachinePoolDir)
+			mpService = exe.NewMachinePoolService(con.MachinePoolDir)
+
+			_, err := cms.RetrieveClusterMachinePool(ci.RHCSConnection, clusterID, defaultMachinePoolNmae)
+			if err != nil && strings.Contains(err.Error(), fmt.Sprintf("Machine pool with id '%s' not found", defaultMachinePoolNmae)) {
+				Skip("The default machinepool does not exist")
+			}
+
+			By("Make sure the default machinepool imported from cluster state")
+			imported, _ := h.MakeSureDefaultMachinePoolImported()
+			if !imported {
+				By("Create default machinepool by importing from cluster state")
+				resource, err := h.GetResource(con.ROSAClassic, "rhcs_cluster_rosa_classic", "rosa_sts_cluster")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resource).NotTo(BeNil())
+				defaultMachinePoolArgs, err = exe.BuildDefaultMachinePoolArgsFromClusterState(resource)
+				defaultMachinePoolArgs.Cluster = clusterID
+				defaultMachinePoolArgs.Token = token
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dmpService.Create(&defaultMachinePoolArgs)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+		AfterEach(func() {
+			// Check if current test is skipped, skip this AfterEach block too
+			if CurrentSpecReport().Failure.Message == "The default machinepool does not exist" {
+				return
+			}
+
+			By("Recover the default machinepool to the original state")
+			_, err := dmpService.Create(&defaultMachinePoolArgs)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Destroy additonal mp")
+			_, err = mpService.Destroy()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("Author:yuwan-Critical-OCP-69073 @OCP-69073 @yuwan", func() {
+			It("Author:yuwan-High-OCP-69073 Check the validations and some negative scenarios of creating/editing/deleting default machinepool via terraform", ci.Day2, ci.Critical, ci.FeatureMachinepool, func() {
+				defaultMachinePoolResource, err := h.GetResource(con.ROSAClassic, "rhcs_machine_pool", "dmp")
+				Expect(err).NotTo(HaveOccurred())
+				defaultMachinepoolArgFromMachinepool, err := exe.BuildDefaultMachinePoolArgsFromDefaultMachinePoolState(defaultMachinePoolResource)
+				Expect(err).NotTo(HaveOccurred())
+				defaultMachinepoolArgFromMachinepool.Cluster = clusterID
+				defaultMachinepoolArgFromMachinepool.Token = token
+				dmpArgFromMachinepoolForTesting := defaultMachinepoolArgFromMachinepool
+
+				By("Create machinepool with the default machinepool name 'worker' when it does exist")
+				output, err := dmpService.Create(&defaultMachinepoolArgFromMachinepool)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output).To(ContainSubstring("No changes. Your infrastructure matches the configuration."))
+
+				if h.DigBool(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "autoscaling_enabled") {
+					By("Edit the deafult machinepool max and min replicas to 0")
+					zeroReplicas := 0
+					dmpArgFromMachinepoolForTesting.MaxReplicas = &zeroReplicas
+					dmpArgFromMachinepoolForTesting.MinReplicas = &zeroReplicas
+					Expect(err).To(HaveOccurred())
+					Expect(output).To(ContainSubstring("Failed to update machine pool"))
+					Expect(output).To(ContainSubstring("must be a integer greater than 0"))
+				} else {
+					By("Edit the deafult machinepool replicas to 0")
+					zeroReplicas := 0
+					dmpArgFromMachinepoolForTesting = defaultMachinepoolArgFromMachinepool
+					dmpArgFromMachinepoolForTesting.Replicas = &zeroReplicas
+					_, err = dmpService.Create(&dmpArgFromMachinepoolForTesting)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Failed to update machine pool"))
+					Expect(err.Error()).To(ContainSubstring("least one machine pool able to run OCP workload is required"))
+				}
+
+				By("Check the machine type change will triger re-creation")
+				dmpArgFromMachinepoolForTesting = defaultMachinepoolArgFromMachinepool
+				dmpArgFromMachinepoolForTesting.MachineType = "r5.xlarge"
+				out, err := dmpService.Plan(&dmpArgFromMachinepoolForTesting)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(ContainSubstring("rhcs_machine_pool.mp must be replaced"))
+				Expect(out).To(ContainSubstring("destroy and then create replacement"))
+
+				By("Delete dmp without additional mp exists")
+				resp, err := cms.ListMachinePool(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				num, _ := resp.GetSize()
+				Expect(num).To(Equal(1))
+
+				output, err = dmpService.Destroy()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output).To(ContainSubstring("Warning: Cannot delete machine pool"))
+			})
+		})
+
+		Context("Author:yuwan-Critical-OCP-69009 @OCP-69009 @yuwan", func() {
+			It("Author:yuwan-High-OCP-69009 Check the default machinepool creation with the cluster and edit/delete it via terraform", ci.Day2, ci.Critical, ci.FeatureMachinepool, func() {
+				taint0 := map[string]string{"key": "k1", "value": "val", "schedule_type": con.NoExecute}
+				taint1 := map[string]string{"key": "k2", "value": "val2", "schedule_type": con.NoSchedule}
+				taints := []map[string]string{taint0, taint1}
+
+				defaultMPName := "worker"
+
+				defaultMachinePoolResource, err := h.GetResource(con.ROSAClassic, "rhcs_machine_pool", "dmp")
+				Expect(err).NotTo(HaveOccurred())
+				defaultMachinepoolArgFromMachinepool, err := exe.BuildDefaultMachinePoolArgsFromDefaultMachinePoolState(defaultMachinePoolResource)
+				Expect(err).NotTo(HaveOccurred())
+				defaultMachinepoolArgFromMachinepool.Cluster = clusterID
+				defaultMachinepoolArgFromMachinepool.Token = token
+				dmpArgFromMachinepoolForTesting := defaultMachinepoolArgFromMachinepool
+
+				By("Edit the taints without additional machinepool")
+
+				dmpArgFromMachinepoolForTesting.Taints = taints
+				_, err = dmpService.Create(&dmpArgFromMachinepoolForTesting)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Failed to update machine pool"))
+				Expect(err.Error()).To(ContainSubstring("least one machine pool able to run OCP workload is required. Pool should not"))
+				dmpArgFromMachinepoolForTesting = defaultMachinepoolArgFromMachinepool
+
+				if h.DigBool(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "autoscaling_enabled") {
+					By("Edit default machinepool with autoscale configuration")
+					minReplicas := 3
+					maxReplicas := 6
+					dmpArgFromMachinepoolForTesting.MinReplicas = &minReplicas
+					dmpArgFromMachinepoolForTesting.MaxReplicas = &maxReplicas
+					_, err := dmpService.Create(&dmpArgFromMachinepoolForTesting)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Verify the parameters of the created machinepool")
+					mpResponseBody, err := cms.RetrieveClusterMachinePool(ci.RHCSConnection, clusterID, defaultMPName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mpResponseBody.Autoscaling().MinReplicas()).To(Equal(minReplicas))
+					Expect(mpResponseBody.Autoscaling().MaxReplicas()).To(Equal(maxReplicas))
+				} else {
+					By("Edit default machinepool with replicas")
+					replicas := 6
+					dmpArgFromMachinepoolForTesting.Replicas = &replicas
+					_, err := dmpService.Create(&dmpArgFromMachinepoolForTesting)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Verify the parameters of the created machinepool")
+					mpResponseBody, err := cms.RetrieveClusterMachinePool(ci.RHCSConnection, clusterID, defaultMPName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mpResponseBody.Replicas()).To(Equal(replicas))
+				}
+
+				By("Edit default machinepool with labels")
+				dmpArgFromMachinepoolForTesting = defaultMachinepoolArgFromMachinepool
+				creationLabels := map[string]string{"fo1": "bar1", "fo2": "baz2"}
+				dmpArgFromMachinepoolForTesting.Labels = creationLabels
+				_, err = dmpService.Create(&dmpArgFromMachinepoolForTesting)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verify the parameters of the created machinepool")
+				mpResponseBody, err := cms.RetrieveClusterMachinePool(ci.RHCSConnection, clusterID, defaultMPName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mpResponseBody.Labels()).To(Equal(creationLabels))
+
+				By("Create an additional machinepool")
+				replicas := 3
+				machineType := "r5.xlarge"
+				name := "amp-69009"
+
+				MachinePoolArgs := &exe.MachinePoolArgs{
+					Token:       token,
+					Cluster:     clusterID,
+					Replicas:    &replicas,
+					MachineType: machineType,
+					Name:        name,
+					Taints:      taints,
+				}
+
+				_, err = mpService.Create(MachinePoolArgs)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Edit the default machinepool with taints")
+				dmpArgFromMachinepoolForTesting = defaultMachinepoolArgFromMachinepool
+				_, err = dmpService.Create(&defaultMachinepoolArgFromMachinepool)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verify the parameters of the created machinepool")
+				mpResponseBody, err = cms.RetrieveClusterMachinePool(ci.RHCSConnection, clusterID, name)
+				Expect(err).ToNot(HaveOccurred())
+				respTaints := mpResponseBody.Taints()
+				for index, taint := range respTaints {
+					Expect(taint.Effect()).To(Equal(taints[index]["schedule_type"]))
+					Expect(taint.Key()).To(Equal(taints[index]["key"]))
+					Expect(taint.Value()).To(Equal(taints[index]["value"]))
+				}
+			})
+		})
+
+	})
+})
+
+var _ = Describe("TF Test, day-3 default machinepool testing", func() {
+	Describe("Default MachinePool day-3 test cases", func() {
+
+		var (
+			dmpService             *exe.MachinePoolService
+			defaultMachinePoolArgs exe.MachinePoolArgs
+			mpService              *exe.MachinePoolService
+		)
+
+		BeforeEach(func() {
+			dmpService = exe.NewMachinePoolService(con.DefaultMachinePoolDir)
+			mpService = exe.NewMachinePoolService(con.MachinePoolDir)
+
+			By("Make sure the default machinepool imported from cluster state")
+			imported, _ := h.MakeSureDefaultMachinePoolImported()
+			if !imported {
+				By("Create default machinepool by importing from cluster state")
+				resource, err := h.GetResource(con.ROSAClassic, "rhcs_cluster_rosa_classic", "rosa_sts_cluster")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resource).NotTo(BeNil())
+				defaultMachinePoolArgs, err = exe.BuildDefaultMachinePoolArgsFromClusterState(resource)
+				defaultMachinePoolArgs.Cluster = clusterID
+				defaultMachinePoolArgs.Token = token
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dmpService.Create(&defaultMachinePoolArgs)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		Context("Author:yuwan-Critical-OCP-69727 @OCP-69727 @yuwan", func() {
+			It("Author:yuwan-High-OCP-69727 Check the default machinepool edit/delete operations with additional mp exists it via terraform	", ci.Day3, ci.Critical, ci.FeatureMachinepool, func() {
+				defaultMachinePoolResource, err := h.GetResource(con.ROSAClassic, "rhcs_machine_pool", "dmp")
+				Expect(err).NotTo(HaveOccurred())
+				defaultMachinepoolArgFromMachinepool, err := exe.BuildDefaultMachinePoolArgsFromDefaultMachinePoolState(defaultMachinePoolResource)
+				Expect(err).NotTo(HaveOccurred())
+				defaultMachinepoolArgFromMachinepool.Cluster = clusterID
+				defaultMachinepoolArgFromMachinepool.Token = token
+
+				By("Destroy default machinepool without additional machinepool existing")
+				resp, err := cms.ListMachinePool(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				num, _ := resp.GetSize()
+				Expect(num).To(Equal(1))
+
+				output, err := dmpService.Destroy()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output).To(ContainSubstring("Warning: Cannot delete machine pool"))
+				Expect(output).To(ContainSubstring("must have at least"))
+
+				By("Create an additional machinepool")
+				replicas := 3
+				machineType := "r5.xlarge"
+				name := "amp-69727"
+
+				MachinePoolArgs := &exe.MachinePoolArgs{
+					Token:       token,
+					Cluster:     clusterID,
+					Replicas:    &replicas,
+					MachineType: machineType,
+					Name:        name,
+				}
+
+				_, err = mpService.Create(MachinePoolArgs)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Import the default machinepool state")
+				_, err = dmpService.Create(&defaultMachinepoolArgFromMachinepool)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Destroy default machinepool")
+				output, err = dmpService.Destroy()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output).To(ContainSubstring("Destroy complete! Resources: 1 destroyed."))
 			})
 		})
 	})

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -98,3 +98,14 @@ resource "rhcs_cluster_wait" "rosa_cluster" {
   cluster = rhcs_cluster_rosa_classic.rosa_sts_cluster.id
   timeout = 120
 }
+
+resource "rhcs_machine_pool" "dmp" {
+  cluster                 = rhcs_cluster_rosa_classic.rosa_sts_cluster.id
+  machine_type            = var.compute_machine_type
+  name                    = "worker"
+  replicas                = var.replicas
+  min_replicas                = var.autoscaling.min_replicas
+  max_replicas                = var.autoscaling.max_replicas
+  labels                  = var.default_mp_labels
+  autoscaling_enabled     = var.autoscaling.autoscaling_enabled
+}

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -98,14 +98,3 @@ resource "rhcs_cluster_wait" "rosa_cluster" {
   cluster = rhcs_cluster_rosa_classic.rosa_sts_cluster.id
   timeout = 120
 }
-
-resource "rhcs_machine_pool" "dmp" {
-  cluster                 = rhcs_cluster_rosa_classic.rosa_sts_cluster.id
-  machine_type            = var.compute_machine_type
-  name                    = "worker"
-  replicas                = var.replicas
-  min_replicas                = var.autoscaling.min_replicas
-  max_replicas                = var.autoscaling.max_replicas
-  labels                  = var.default_mp_labels
-  autoscaling_enabled     = var.autoscaling.autoscaling_enabled
-}

--- a/tests/tf-manifests/rhcs/default-machine-pool/main.tf
+++ b/tests/tf-manifests/rhcs/default-machine-pool/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    rhcs = {
+      version = ">= 1.1.0"
+      source  = "terraform.local/local/rhcs"
+    }
+  }
+}
+
+provider "rhcs" {
+  token = var.token
+  url   = var.url
+}
+
+resource "rhcs_machine_pool" "mp" {
+ cluster                 = var.cluster
+  machine_type            = var.machine_type
+  name                    = var.name
+  replicas                = var.replicas
+  labels                  = var.labels
+  taints                  = var.taints
+  min_replicas            = var.min_replicas
+  max_replicas            = var.max_replicas
+  autoscaling_enabled     = var.autoscaling_enabled
+  availability_zone       = var.availability_zone
+  subnet_id               = var.subnet_id
+  multi_availability_zone = var.multi_availability_zone
+
+}

--- a/tests/tf-manifests/rhcs/default-machine-pool/output.tf
+++ b/tests/tf-manifests/rhcs/default-machine-pool/output.tf
@@ -1,0 +1,29 @@
+output "machine_pool_id" {
+  value = rhcs_machine_pool.mp.id
+}
+output "name" {
+  value = rhcs_machine_pool.mp.name
+}
+output "cluster_id" {
+  value = rhcs_machine_pool.mp.cluster
+}
+
+output "replicas" {
+  value = rhcs_machine_pool.mp.replicas
+}
+
+output "machine_type" {
+  value = rhcs_machine_pool.mp.machine_type
+}
+
+output "autoscaling_enabled" {
+  value = rhcs_machine_pool.mp.autoscaling_enabled
+}
+
+output "labels" {
+  value = rhcs_machine_pool.mp.labels
+}
+
+output "taints" {
+  value = rhcs_machine_pool.mp.taints
+}

--- a/tests/tf-manifests/rhcs/default-machine-pool/variable.tf
+++ b/tests/tf-manifests/rhcs/default-machine-pool/variable.tf
@@ -1,0 +1,67 @@
+variable "cluster" {
+  type = string
+}
+variable "machine_type" {
+  default = null
+  type    = string
+}
+variable "name" {
+  type = string
+}
+variable "autoscaling_enabled" {
+  default = false
+  type    = bool
+}
+variable "labels" {
+  default = null
+  type    = map(string)
+}
+variable "max_replicas" {
+  type    = number
+  default = null
+}
+variable "max_spot_price" {
+  type    = number
+  default = null
+}
+variable "min_replicas" {
+  type    = number
+  default = null
+}
+variable "replicas" {
+  type    = number
+  default = null
+}
+variable "taints" {
+  default = null
+  type = list(object({
+    key           = string
+    value         = string
+    schedule_type = string
+  }))
+}
+variable "use_spot_instances" {
+  type    = bool
+  default = false
+}
+
+variable "token" {
+  type = string
+}
+variable "url" {
+  type    = string
+  default = "https://api.stage.openshift.com"
+}
+
+variable "availability_zone" {
+  type    = string
+  default = null
+}
+variable "subnet_id" {
+  type    = string
+  default = null
+}
+variable "multi_availability_zone" {
+  type    = bool
+  default = null
+}

--- a/tests/utils/constants/constants.go
+++ b/tests/utils/constants/constants.go
@@ -81,12 +81,13 @@ var (
 
 // Dirs of rhcs provider
 var (
-	ClusterDir        = path.Join(configrationDir, RHCSProviderDIR, "clusters")
-	ImportResourceDir = path.Join(configrationDir, RHCSProviderDIR, "resource-import")
-	IDPsDir           = path.Join(configrationDir, RHCSProviderDIR, "idps")
-	MachinePoolDir    = path.Join(configrationDir, RHCSProviderDIR, "machine-pools")
-	DNSDir            = path.Join(configrationDir, RHCSProviderDIR, "dns")
-	RhcsInfoDir       = path.Join(configrationDir, RHCSProviderDIR, "rhcs-info")
+	ClusterDir            = path.Join(configrationDir, RHCSProviderDIR, "clusters")
+	ImportResourceDir     = path.Join(configrationDir, RHCSProviderDIR, "resource-import")
+	IDPsDir               = path.Join(configrationDir, RHCSProviderDIR, "idps")
+	MachinePoolDir        = path.Join(configrationDir, RHCSProviderDIR, "machine-pools")
+	DNSDir                = path.Join(configrationDir, RHCSProviderDIR, "dns")
+	RhcsInfoDir           = path.Join(configrationDir, RHCSProviderDIR, "rhcs-info")
+	DefaultMachinePoolDir = path.Join(configrationDir, RHCSProviderDIR, "default-machine-pool")
 )
 
 // Dirs of different types of clusters

--- a/tests/utils/exec/account-roles.go
+++ b/tests/utils/exec/account-roles.go
@@ -85,7 +85,7 @@ func (acc *AccountRoleService) Destroy(createArgs ...*AccountRolesArgs) error {
 	destroyArgs.URL = CON.GateWayURL
 	destroyArgs.OCMENV = CON.OCMENV
 	args := combineStructArgs(destroyArgs)
-	err := runTerraformDestroyWithArgs(acc.Context, acc.ManifestDir, args)
+	_, err := runTerraformDestroyWithArgs(acc.Context, acc.ManifestDir, args)
 	return err
 }
 

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -124,11 +124,11 @@ func (creator *ClusterService) Output() (*ClusterOutput, error) {
 	return clusterOutput, nil
 }
 
-func (creator *ClusterService) Destroy(createArgs *ClusterCreationArgs, extraArgs ...string) error {
+func (creator *ClusterService) Destroy(createArgs *ClusterCreationArgs, extraArgs ...string) (string, error) {
 	createArgs.URL = CON.GateWayURL
 	args := combineStructArgs(createArgs, extraArgs...)
-	err := runTerraformDestroyWithArgs(creator.Context, creator.ManifestDir, args)
-	return err
+	output, err := runTerraformDestroyWithArgs(creator.Context, creator.ManifestDir, args)
+	return output, err
 }
 
 func (creator *ClusterService) Plan(planargs *ClusterCreationArgs, extraArgs ...string) (string, error) {

--- a/tests/utils/exec/dns-domain.go
+++ b/tests/utils/exec/dns-domain.go
@@ -52,7 +52,7 @@ func (dns *DnsService) Destroy(createArgs ...*DnsDomainArgs) error {
 		destroyArgs = createArgs[0]
 	}
 	args := combineStructArgs(destroyArgs)
-	err := runTerraformDestroyWithArgs(dns.Context, dns.ManifestDir, args)
+	_, err := runTerraformDestroyWithArgs(dns.Context, dns.ManifestDir, args)
 
 	return err
 }

--- a/tests/utils/exec/idps.go
+++ b/tests/utils/exec/idps.go
@@ -93,7 +93,7 @@ func (idp *IDPService) Destroy(createArgs ...*IDPArgs) error {
 		destroyArgs.URL = CON.GateWayURL
 	}
 	args := combineStructArgs(destroyArgs)
-	err := runTerraformDestroyWithArgs(idp.Context, idp.ManifestDir, args)
+	_, err := runTerraformDestroyWithArgs(idp.Context, idp.ManifestDir, args)
 
 	return err
 }

--- a/tests/utils/exec/machine-pools.go
+++ b/tests/utils/exec/machine-pools.go
@@ -15,11 +15,11 @@ type MachinePoolArgs struct {
 	Token                    string              `json:"token,omitempty"`
 	URL                      string              `json:"url,omitempty"`
 	MachineType              string              `json:"machine_type,omitempty"`
-	Replicas                 int                 `json:"replicas,omitempty"`
+	Replicas                 *int                `json:"replicas,omitempty"`
 	AutoscalingEnabled       bool                `json:"autoscaling_enabled,omitempty"`
 	UseSpotInstances         bool                `json:"use_spot_instances,omitempty"`
-	MaxReplicas              int                 `json:"max_replicas,omitempty"`
-	MinReplicas              int                 `json:"min_replicas,omitempty"`
+	MaxReplicas              *int                `json:"max_replicas,omitempty"`
+	MinReplicas              *int                `json:"min_replicas,omitempty"`
 	MaxSpotPrice             float64             `json:"max_spot_price,omitempty"`
 	Labels                   map[string]string   `json:"labels,omitempty"`
 	Taints                   []map[string]string `json:"taints,omitempty"`
@@ -62,7 +62,18 @@ func (mp *MachinePoolService) Init(manifestDirs ...string) error {
 
 }
 
-func (mp *MachinePoolService) Create(createArgs *MachinePoolArgs, extraArgs ...string) error {
+func (mp *MachinePoolService) Create(createArgs *MachinePoolArgs, extraArgs ...string) (string, error) {
+	createArgs.URL = CON.GateWayURL
+	mp.CreationArgs = createArgs
+	args := combineStructArgs(createArgs, extraArgs...)
+	output, err := runTerraformApplyWithArgs(mp.Context, mp.ManifestDir, args)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+func (mp *MachinePoolService) MagicImport(createArgs *MachinePoolArgs, extraArgs ...string) error {
 	createArgs.URL = CON.GateWayURL
 	mp.CreationArgs = createArgs
 	args := combineStructArgs(createArgs, extraArgs...)
@@ -115,9 +126,9 @@ func (mp *MachinePoolService) Output() (MachinePoolOutput, error) {
 	return output, nil
 }
 
-func (mp *MachinePoolService) Destroy(createArgs ...*MachinePoolArgs) error {
+func (mp *MachinePoolService) Destroy(createArgs ...*MachinePoolArgs) (output string, err error) {
 	if mp.CreationArgs == nil && len(createArgs) == 0 {
-		return fmt.Errorf("got unset destroy args, set it in object or pass as a parameter")
+		return "", fmt.Errorf("got unset destroy args, set it in object or pass as a parameter")
 	}
 	destroyArgs := mp.CreationArgs
 	if len(createArgs) != 0 {
@@ -125,13 +136,78 @@ func (mp *MachinePoolService) Destroy(createArgs ...*MachinePoolArgs) error {
 	}
 	destroyArgs.URL = CON.GateWayURL
 	args := combineStructArgs(destroyArgs)
-	err := runTerraformDestroyWithArgs(mp.Context, mp.ManifestDir, args)
+	output, err = runTerraformDestroyWithArgs(mp.Context, mp.ManifestDir, args)
 
-	return err
+	return
 }
 
 func NewMachinePoolService(manifestDir ...string) *MachinePoolService {
 	mp := &MachinePoolService{}
 	mp.Init(manifestDir...)
 	return mp
+}
+
+func BuildDefaultMachinePoolArgsFromClusterState(clusterResource interface{}) (MachinePoolArgs, error) {
+	var machinePoolArgs MachinePoolArgs
+	if h.DigString(clusterResource, "type") != "rhcs_cluster_rosa_classic" {
+		return machinePoolArgs, fmt.Errorf("expected a cluster resource of type rhcs_cluster_rosa_classic, got %s", h.DigString(clusterResource, "type"))
+	}
+	if h.DigBool(h.DigArray(clusterResource, "instances")[0], "attributes", "autoscaling_enabled") {
+		machinePoolArgs.AutoscalingEnabled = true
+		maxReplicas := h.DigInt(h.DigArray(clusterResource, "instances")[0], "attributes", "max_replicas")
+		minReplicas := h.DigInt(h.DigArray(clusterResource, "instances")[0], "attributes", "min_replicas")
+		machinePoolArgs.MaxReplicas = &maxReplicas
+		machinePoolArgs.MinReplicas = &minReplicas
+	} else {
+		replicas := h.DigInt(h.DigArray(clusterResource, "instances")[0], "attributes", "replicas")
+		machinePoolArgs.Replicas = &replicas
+	}
+	machinePoolArgs.Name = "worker"
+	machinePoolArgs.MachineType = h.DigString(h.DigArray(clusterResource, "instances")[0], "attributes", "compute_machine_type")
+	labelsInterface := h.DigObject(h.DigArray(clusterResource, "instances")[0], "attributes", "default_mp_labels")
+	labels := make(map[string]string)
+	for key, value := range labelsInterface.(map[string]interface{}) {
+		labels[key] = fmt.Sprint(value)
+	}
+	machinePoolArgs.Labels = labels
+	return machinePoolArgs, nil
+}
+
+func BuildDefaultMachinePoolArgsFromDefaultMachinePoolState(defaultMachinePoolResource interface{}) (MachinePoolArgs, error) {
+	var machinePoolArgs MachinePoolArgs
+	if h.DigString(defaultMachinePoolResource, "type") != "rhcs_machine_pool" && h.DigString(defaultMachinePoolResource, "name") != "worker" {
+		return machinePoolArgs, fmt.Errorf("expected a default machinepool resource of type rhcs_machine_pool and named worker, got %s named %s", h.DigString(defaultMachinePoolResource, "type"), h.DigString(defaultMachinePoolResource, "name"))
+	}
+	if h.DigBool(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "autoscaling_enabled") {
+		machinePoolArgs.AutoscalingEnabled = true
+		maxReplicas := h.DigInt(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "max_replicas")
+		minReplicas := h.DigInt(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "min_replicas")
+		machinePoolArgs.MaxReplicas = &maxReplicas
+		machinePoolArgs.MinReplicas = &minReplicas
+	} else {
+		replicas := h.DigInt(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "replicas")
+		machinePoolArgs.Replicas = &replicas
+	}
+	machinePoolArgs.Name = "worker"
+	machinePoolArgs.MachineType = h.DigString(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "machine_type")
+	labelsInterface := h.DigObject(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "labels")
+	labels := make(map[string]string)
+	for key, value := range labelsInterface.(map[string]interface{}) {
+		labels[key] = fmt.Sprint(value)
+	}
+	machinePoolArgs.Labels = labels
+	if h.DigObject(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "taints") != nil {
+		taintsInterface := h.DigArray(h.DigArray(defaultMachinePoolResource, "instances")[0], "attributes", "taints")
+		taints := make([]map[string]string, len(taintsInterface))
+		for i, taintInterface := range taintsInterface {
+			taintMap := taintInterface.(map[string]interface{})
+			taint := make(map[string]string)
+			for key, value := range taintMap {
+				taint[key] = fmt.Sprint(value)
+			}
+			taints[i] = taint
+		}
+		machinePoolArgs.Taints = taints
+	}
+	return machinePoolArgs, nil
 }

--- a/tests/utils/exec/oidc-provider-operator-roles.go
+++ b/tests/utils/exec/oidc-provider-operator-roles.go
@@ -86,7 +86,7 @@ func (oidcOP *OIDCProviderOperatorRolesService) Destroy(createArgs ...*OIDCProvi
 	destroyArgs.URL = CON.GateWayURL
 	destroyArgs.OCMENV = CON.OCMENV
 	args := combineStructArgs(destroyArgs)
-	err := runTerraformDestroyWithArgs(oidcOP.Context, oidcOP.ManifestDir, args)
+	_, err := runTerraformDestroyWithArgs(oidcOP.Context, oidcOP.ManifestDir, args)
 	return err
 }
 

--- a/tests/utils/exec/rhcs-info.go
+++ b/tests/utils/exec/rhcs-info.go
@@ -54,7 +54,7 @@ func (rhcsInfo *RhcsInfoService) Destroy(createArgs ...*RhcsInfoArgs) error {
 		destroyArgs = createArgs[0]
 	}
 	args := combineStructArgs(destroyArgs)
-	err := runTerraformDestroyWithArgs(rhcsInfo.Context, rhcsInfo.ManifestDir, args)
+	_, err := runTerraformDestroyWithArgs(rhcsInfo.Context, rhcsInfo.ManifestDir, args)
 
 	return err
 }

--- a/tests/utils/exec/security-groups.go
+++ b/tests/utils/exec/security-groups.go
@@ -73,7 +73,7 @@ func (sgs *SecurityGroupService) Destroy(createArgs ...*SecurityGroupArgs) error
 		destroyArgs = createArgs[0]
 	}
 	args := combineStructArgs(destroyArgs)
-	err := runTerraformDestroyWithArgs(sgs.Context, sgs.ManifestDir, args)
+	_, err := runTerraformDestroyWithArgs(sgs.Context, sgs.ManifestDir, args)
 
 	return err
 }

--- a/tests/utils/exec/tf-exec.go
+++ b/tests/utils/exec/tf-exec.go
@@ -76,23 +76,23 @@ func runTerraformPlanWithArgs(ctx context.Context, dir string, terraformArgs []s
 	return
 }
 
-func runTerraformDestroyWithArgs(ctx context.Context, dir string, terraformArgs []string) (err error) {
+func runTerraformDestroyWithArgs(ctx context.Context, dir string, terraformArgs []string) (output string, err error) {
 	destroyArgs := append([]string{"destroy", "-auto-approve", "-no-color"}, terraformArgs...)
 	Logger.Infof("Running terraform destroy against the dir: %s", dir)
 	terraformDestroy := exec.Command("terraform", destroyArgs...)
 	terraformDestroy.Dir = dir
 	var stdoutput bytes.Buffer
-	terraformDestroy.Stdout = os.Stdout
+	terraformDestroy.Stdout = &stdoutput
 	terraformDestroy.Stderr = os.Stderr
 	err = terraformDestroy.Run()
-	var output string = h.Strip(stdoutput.String(), "\n")
+	output = h.Strip(stdoutput.String(), "\n")
 	if err != nil {
 		Logger.Errorf(output)
 		err = fmt.Errorf("%s: %s", err.Error(), output)
 		return
 	}
 	Logger.Debugf(output)
-	return err
+	return
 }
 
 func runTerraformOutput(ctx context.Context, dir string) (map[string]interface{}, error) {

--- a/tests/utils/exec/vpc-tags.go
+++ b/tests/utils/exec/vpc-tags.go
@@ -54,7 +54,7 @@ func (vpctag *VPCTagService) Destroy(createArgs ...*VPCTagArgs) error {
 		destroyArgs = createArgs[0]
 	}
 	args := combineStructArgs(destroyArgs)
-	err := runTerraformDestroyWithArgs(vpctag.Context, vpctag.ManifestDir, args)
+	_, err := runTerraformDestroyWithArgs(vpctag.Context, vpctag.ManifestDir, args)
 
 	return err
 }

--- a/tests/utils/exec/vpc.go
+++ b/tests/utils/exec/vpc.go
@@ -84,7 +84,7 @@ func (vpc *VPCService) Destroy(createArgs ...*VPCArgs) error {
 		destroyArgs = createArgs[0]
 	}
 	args := combineStructArgs(destroyArgs)
-	err := runTerraformDestroyWithArgs(vpc.Context, vpc.ManifestDir, args)
+	_, err := runTerraformDestroyWithArgs(vpc.Context, vpc.ManifestDir, args)
 
 	return err
 }
@@ -134,6 +134,6 @@ func DestroyAWSVPC(vpcArgs *VPCArgs, arg ...string) error {
 	args := map[string]interface{}{}
 	json.Unmarshal(parambytes, &args)
 	combinedArgs := combineArgs(args, arg...)
-	err := runTerraformDestroyWithArgs(context.TODO(), CON.AWSVPCDir, combinedArgs)
+	_, err := runTerraformDestroyWithArgs(context.TODO(), CON.AWSVPCDir, combinedArgs)
 	return err
 }

--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -143,6 +143,11 @@ func DigBool(object interface{}, keys ...interface{}) bool {
 	}
 }
 
+func DigObject(object interface{}, keys ...interface{}) interface{} {
+	value := Dig(object, keys)
+	return value
+}
+
 func Dig(object interface{}, keys []interface{}) interface{} {
 	if object == nil || len(keys) == 0 {
 		return nil

--- a/tests/utils/helper/tf_helper.go
+++ b/tests/utils/helper/tf_helper.go
@@ -1,0 +1,46 @@
+package helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	con "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+)
+
+// Get the resoources state from the terraform.tfstate file by resource type and name
+func GetResource(manifestDir string, resourceType string, resoureName string) (interface{}, error) {
+	// Check if there is a terraform.tfstate file in the manifest directory
+	if _, err := os.Stat(manifestDir + "/terraform.tfstate"); err == nil {
+		// Read the terraform.tfstate file
+		data, err := os.ReadFile(manifestDir + "/terraform.tfstate")
+		if err != nil {
+			return nil, fmt.Errorf("failed to readFile %s folder,%v", manifestDir+"/terraform.tfstate", err)
+		}
+		// Unmarshal the data from the terraform.tfstate file
+		var state map[string]interface{}
+		err = json.Unmarshal(data, &state)
+		if err != nil {
+			return nil, fmt.Errorf("failed to Unmarshal state %v", err)
+		}
+		//Find resource by resource type and resource name
+		for _, resource := range state["resources"].([]interface{}) {
+			if DigString(resource, "type") == resourceType && DigString(resource, "name") == resoureName {
+				return resource, err
+			}
+		}
+
+		return nil, fmt.Errorf("no resource named %s of type %s is found", resoureName, resourceType)
+
+	}
+	return nil, fmt.Errorf("terraform.tfstate file doesn't exist in %s folder", manifestDir)
+}
+
+// Make sure the default machinepool imported by checking if there is terraform.tfstate in DefaultMachinePoolDir
+func MakeSureDefaultMachinePoolImported() (imported bool, err error) {
+	_, err = GetResource(con.DefaultMachinePoolDir, "rhcs_machine_pool", "dmp")
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
- new automated 69073 69009 69727
- Add default-machine-pool folder for testing
- Add default machinepool resource "rhcs_machine_pool":"dmp"
- Add MachinePoolService.Plan function for runming `terraform plan` and add output as the return value for Create/Destroy function
- Add functions to build default machinepool arguments from the cluster/default machinepool state 
- Add two helper functions in tf_helper.go
I comment out the day-0 test case until there is day-0 job. Testing on local is passed.
Here are logs bellow:
`
yuwan1-mac:terraform-provider-rhcs yuwan$ ginkgo --focus @OCP-69073 ./tests/e2e/
time="2023-12-05T20:29:11+08:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2023-12-05T20:29:11+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true version:latest zones:]"
Running Suite: e2e tests suite - /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/e2e
=====================================================================================================
Random Seed: 1701779349

Will run 1 of 20 specs
Stime="2023-12-05T20:29:11+08:00" level=info msg="Running terraform init against the dir /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:29:11+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:29:15+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:29:18+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:29:23+08:00" level=error msg="rhcs_machine_pool.mp: Refreshing state... [id=worker]\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_machine_pool.mp will be updated in-place\n  ~ resource \"rhcs_machine_pool\" \"mp\" {\n        id                      = \"worker\"\n        name                    = \"worker\"\n      ~ replicas                = 3 -> 0\n        # (6 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\n\nChanges to Outputs:\n  ~ replicas            = 3 -> 0\nrhcs_machine_pool.mp: Modifying... [id=worker]\n\nError: Failed to update machine pool\n\n  with rhcs_machine_pool.mp,\n  on main.tf line 15, in resource \"rhcs_machine_pool\" \"mp\":\n  15: resource \"rhcs_machine_pool\" \"mp\" {\n\nFailed to update machine pool 'worker'  on cluster\n'27tihchdh26h9b2lbm5acfskgjrqm5nq': status is 400, identifier is '400', code\nis 'CLUSTERS-MGMT-400' and operation identifier is\n'547343c1-c4c9-472d-8323-e279d37206bd': Machine pool 'worker' for cluster\n'27tihchdh26h9b2lbm5acfskgjrqm5nq' can't be updated with provided params. At\nleast one machine pool able to run OCP workload is required. Pool should not\nhave taints, should not use spot instances and minimum replica count should\nbe '2' for single zone or '3' for multi-zone"
time="2023-12-05T20:29:23+08:00" level=info msg="Running terraform plan against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:29:28+08:00" level=info msg="Running terraform destroy against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
•SSSSSSSSSSSSSSSSSS

Ran 1 of 20 Specs in 21.052 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 19 Skipped
PASS

Ginkgo ran 1 suite in 22.821676095s
Test Suite Passed



yuwan1-mac:terraform-provider-rhcs yuwan$ ginkgo --focus @OCP-69009 ./tests/e2e/
time="2023-12-05T20:59:35+08:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2023-12-05T20:59:35+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true version:latest zones:]"
Running Suite: e2e tests suite - /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/e2e
=====================================================================================================
Random Seed: 1701781174

Will run 1 of 21 specs
SSSSSSSSSSSSSSSSSSStime="2023-12-05T20:59:35+08:00" level=info msg="Running terraform init against the dir /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:59:36+08:00" level=info msg="Running terraform init against the dir /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-05T20:59:36+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:59:38+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:59:44+08:00" level=error msg="rhcs_machine_pool.mp: Refreshing state... [id=worker]\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_machine_pool.mp will be updated in-place\n  ~ resource \"rhcs_machine_pool\" \"mp\" {\n        id                      = \"worker\"\n        name                    = \"worker\"\n      + taints                  = [\n          + {\n              + key           = \"k1\"\n              + schedule_type = \"NoExecute\"\n              + value         = \"val\"\n            },\n          + {\n              + key           = \"k2\"\n              + schedule_type = \"NoSchedule\"\n              + value         = \"val2\"\n            },\n        ]\n        # (7 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\n\nChanges to Outputs:\n  + taints              = [\n      + {\n          + key           = \"k1\"\n          + schedule_type = \"NoExecute\"\n          + value         = \"val\"\n        },\n      + {\n          + key           = \"k2\"\n          + schedule_type = \"NoSchedule\"\n          + value         = \"val2\"\n        },\n    ]\nrhcs_machine_pool.mp: Modifying... [id=worker]\n\nError: Failed to update machine pool\n\n  with rhcs_machine_pool.mp,\n  on main.tf line 15, in resource \"rhcs_machine_pool\" \"mp\":\n  15: resource \"rhcs_machine_pool\" \"mp\" {\n\nFailed to update machine pool 'worker'  on cluster\n'27tihchdh26h9b2lbm5acfskgjrqm5nq': status is 400, identifier is '400', code\nis 'CLUSTERS-MGMT-400' and operation identifier is\n'ceb51dd8-c022-4253-baa7-a58500d697ca': Machine pool 'worker' for cluster\n'27tihchdh26h9b2lbm5acfskgjrqm5nq' can't be updated with provided params. At\nleast one machine pool able to run OCP workload is required. Pool should not\nhave taints, should not use spot instances and minimum replica count should\nbe '2' for single zone or '3' for multi-zone"
time="2023-12-05T20:59:44+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:59:51+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T20:59:58+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-05T21:00:06+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T21:00:12+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T21:00:15+08:00" level=info msg="Running terraform destroy against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
•S

Ran 1 of 21 Specs in 44.992 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 20 Skipped
PASS

Ginkgo ran 1 suite in 46.624752003s
Test Suite Passed


yuwan1-mac:terraform-provider-rhcs yuwan$ ginkgo --focus @OCP-69727 ./tests/e2e/
time="2023-12-05T21:25:29+08:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2023-12-05T21:25:29+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true version:latest zones:]"
Running Suite: e2e tests suite - /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/e2e
=====================================================================================================
Random Seed: 1701782727

Will run 1 of 22 specs
SSSSSSSSStime="2023-12-05T21:25:29+08:00" level=info msg="Running terraform init against the dir /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T21:25:30+08:00" level=info msg="Running terraform init against the dir /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-05T21:25:30+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T21:25:38+08:00" level=info msg="Running terraform destroy against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T21:25:42+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-05T21:25:55+08:00" level=info msg="Running terraform apply against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
time="2023-12-05T21:25:59+08:00" level=info msg="Running terraform destroy against the dir: /Users/yuwan/gopath/src/github.com/terraform-provider-rhcs/tests/tf-manifests/rhcs/default-machine-pool"
•SSSSSSSSSSSS

Ran 1 of 22 Specs in 35.834 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 21 Skipped
PASS

Ginkgo ran 1 suite in 37.859672623s
Test Suite Passed
`