### PR TITLE
add rhcs_rosa_classic cluster import test case

### DIFF
--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -631,7 +631,7 @@ var _ = Describe("TF Test", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			Context("Author:smiron-High-OCP-65981 @OCP-65981 @smiron", func() {
+			Context("Author:smiron-Medium-OCP-65981 @OCP-65981 @smiron", func() {
 				It("OCP-65981 - rhcs_identity_provider resource can be imported by the terraform import command",
 					ci.Day2, ci.Medium, ci.FeatureIDP, ci.FeatureImport, func() {
 						By("Create sample idp to test the import functionality")


### PR DESCRIPTION
Test case: https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-65684 
I noticed that there are parts of this specific test case that cannot be automated, are complicated and also interfere with other automated test cases that will run after (such as destroying the resource), hence, this test case will test the process of importing the cluster and checking the operation was successful. 
the negative part of this test will be automated on a separate PR.
we can open a discussion on that if there are other opinions ofcourse :)