### PR TITLE
V1.4.0 zone fix - remove hardcoded AZones

### DIFF
--- a/tests/ci/profiles/tf_cluster_profile.yml
+++ b/tests/ci/profiles/tf_cluster_profile.yml
@@ -48,7 +48,7 @@ profiles:
     labeling: true
     tagging: true
     channel_group: candidate
-    zones: "a,b,c"
+    zones: ""
     imdsv2: "required"
     oidc_config: "un-managed"
 - as: rosa-sts-up


### PR DESCRIPTION
Error https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/46462/rehearse-46462-pull-ci-terraform-redhat-terraform-provider-rhcs-v1.4.0-branch-rosa-sts-advanced-critical-high-presubmit/1734178562728005632/artifacts/rosa-sts-advanced-critical-high-presubmit/rhcs-e2e-setup/build-log.txt
 Creation complete after 1s [id=eipalloc-0353722ac0c8921f2]\nmodule.vpc.aws_default_security_group.this[0]: Creation complete after 2s [id=sg-0d2c5d14f040fd1a3]\nmodule.vpc.aws_route.public_internet_gateway[0]: Creation complete after 1s [id=r-rtb-0752f0a09f046d20a1080289494]\nmodule.vpc.aws_default_network_acl.this[0]: Creation complete after 2s [id=acl-0abacabb6cba56bbf]\n\nError: creating EC2 Subnet: InvalidParameterValue: Value (ap-northeast-1b) for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: ap-northeast-1a, ap-northeast-1c, ap-northeast-1d.\n\tstatus code: 400, request id: b553bbb5-b804-40c6-9113-37a862ffae6c\n\n  with module.vpc.aws_subnet.public[1],\n  on .terraform/modules/vpc/main.tf line 97, in resource \"aws_subnet\" \"public\":\n  97: resource \"aws_subnet\" \"public\" {\n\n\nError: creating EC2 Subnet: InvalidParameterValue: Value (ap-northeast-1b) for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: ap-northeast-1a, ap-northeast-1c, ap-northeast-1d.\n\tstatus code: 400, request id: 4c4f2ffe-55bb-47fc-83ac-ae03bedd2431\n\n  with module.vpc.aws_subnet.private[1],\n  on .terraform/modules/vpc/main.tf line 224, in resource \"aws_subnet\" \"private\":\n 224: resource \"aws_subnet\" \"private\" {\n"
time="2023-12-11T11:56:30Z" level=info msg="Running terraform destroy against the dir: /tmp/secret/tf-manifests/aws/vpc"