### PR TITLE
Automate OCP-64906 :: Verify custom properties are set post cluster creation

### DIFF
--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -56,6 +56,21 @@ var _ = Describe("TF Test", func() {
 				Expect(hasValue).To(Equal(true))
 			})
 		})
+		Context("Author:smiron-Medium-OCP-64906 @OCP-64906 @smiron", func() {
+			It("Verify custom properties is set post cluster creation", CI.Day1Post, CI.Medium, func() {
+				By("Check custom_property field is present under cluster's properties")
+				getResp, err := CMS.RetrieveClusterDetail(CI.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResp.Body().Properties()["custom_property"]).To(Equal("test"))
+
+				By("Check rosa_tf_commit is present under cluster's properties")
+				Expect(getResp.Body().Properties()["rosa_tf_commit"]).ShouldNot(BeEmpty())
+
+				By("Check rosa_tf_version is present under cluster's properties")
+				Expect(getResp.Body().Properties()["rosa_tf_version"]).ShouldNot(BeEmpty())
+			})
+		})
+
 		Context("Author:smiron-High-OCP-63140 @OCP-63140 @smiron", func() {
 			It("Verify fips is enabled/disabled post cluster creation", CI.Day1Post, CI.High, func() {
 				Expect(cluster.FIPS()).To(Equal(profile.FIPS))

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -60,6 +60,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   multi_az           = var.multi_az
   properties = {
     rosa_creator_arn = data.aws_caller_identity.current.arn
+    custom_property = "test"
   }
   sts                                             = local.sts_roles
   replicas                                        = var.replicas


### PR DESCRIPTION
Polarion test case - https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-64906
custom_properties that are checked: custom_property, rosa_tf_version, rosa_tf_commit

<img width="909" alt="image" src="https://github.com/terraform-redhat/terraform-provider-rhcs/assets/54883783/06e128ca-0296-42d2-8627-fde77783e5ab">
