### PR TITLE
Add ROSA HCP support

### DIFF
--- a/provider/clusterdata/cluster_data_source.go
+++ b/provider/clusterdata/cluster_data_source.go
@@ -1,0 +1,115 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterdata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+type ClusterDataSource struct {
+	collection *cmv1.ClustersClient
+}
+
+var _ datasource.DataSource = &ClusterDataSource{}
+var _ datasource.DataSourceWithConfigure = &ClusterDataSource{}
+
+func New() datasource.DataSource {
+	return &ClusterDataSource{}
+}
+
+func (r *ClusterDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cluster_data"
+}
+
+func (r *ClusterDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Cluster data.",
+		Attributes: map[string]schema.Attribute{
+			"cluster": schema.StringAttribute{
+				Description: "Identifier of the cluster.",
+				Required:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the cluster.",
+				Computed:    true,
+			},
+			"api_url": schema.StringAttribute{
+				Description: "URL of the API server.",
+				Computed:    true,
+			},
+			"console_url": schema.StringAttribute{
+				Description: "URL of the console.",
+				Computed:    true,
+			},
+		},
+	}
+	return
+}
+
+func (r *ClusterDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured:
+	if req.ProviderData == nil {
+		return
+	}
+
+	// Cast the provider data to the specific implementation:
+	connection := req.ProviderData.(*sdk.Connection)
+
+	// Get the collection of cloud providers:
+	r.collection = connection.ClustersMgmt().V1().Clusters()
+}
+
+func (r *ClusterDataSource) Read(ctx context.Context, request datasource.ReadRequest,
+	response *datasource.ReadResponse) {
+	// Get the state:
+	state := &ClusterDataState{}
+	diags := request.Config.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Fetch the complete list of groups of the cluster:
+	get, err := r.collection.Cluster(state.Cluster.ValueString()).Get().SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't find cluster",
+			fmt.Sprintf(
+				"Can't find cluster with identifier '%s': %v",
+				state.Cluster.ValueString(), err,
+			),
+		)
+		return
+	}
+	object := get.Body()
+
+	// Populate the state:
+	state.Name = types.StringValue(object.Name())
+	state.APIURL = types.StringValue(object.API().URL())
+	state.ConsoleURL = types.StringValue(object.Console().URL())
+
+	// Save the state:
+	diags = response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}

--- a/provider/clusterdata/cluster_data_state.go
+++ b/provider/clusterdata/cluster_data_state.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterdata
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ClusterDataState struct {
+	Cluster    types.String `tfsdk:"cluster"`
+	Name       types.String `tfsdk:"name"`
+	APIURL     types.String `tfsdk:"api_url"`
+	ConsoleURL types.String `tfsdk:"console_url"`
+}

--- a/provider/clusterrosahcp/cluster_rosa_hcp_resource.go
+++ b/provider/clusterrosahcp/cluster_rosa_hcp_resource.go
@@ -1,0 +1,1776 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package clusterrosahcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	semver "github.com/hashicorp/go-version"
+	ver "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	ocm_errors "github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/properties"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/proxy"
+
+	"github.com/terraform-redhat/terraform-provider-rhcs/build"
+	ocmr "github.com/terraform-redhat/terraform-provider-rhcs/internal/ocm/resource"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterrosahcp/upgrade"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/identityprovider"
+)
+
+const (
+	defaultTimeoutInMinutes   = int64(60)
+	nonPositiveTimeoutSummary = "Can't poll cluster state with a non-positive timeout"
+	nonPositiveTimeoutFormat  = "Can't poll state of cluster with identifier '%s', the timeout that was set is not a positive number"
+	pollingIntervalInMinutes  = 2
+
+	awsCloudProvider      = "aws"
+	rosaProduct           = "rosa"
+	MinVersion            = "4.10.0"
+	maxClusterNameLength  = 15
+	tagsPrefix            = "rosa_"
+	tagsOpenShiftVersion  = tagsPrefix + "openshift_version"
+	lowestHttpTokensVer   = "4.11.0"
+	propertyRosaTfVersion = tagsPrefix + "tf_version"
+	propertyRosaTfCommit  = tagsPrefix + "tf_commit"
+	waitTimeoutInMinutes  = 60
+)
+
+var OCMProperties = map[string]string{
+	propertyRosaTfVersion: build.Version,
+	propertyRosaTfCommit:  build.Commit,
+}
+
+type ClusterRosaHcpResource struct {
+	clusterCollection *cmv1.ClustersClient
+	versionCollection *cmv1.VersionsClient
+}
+
+var _ resource.ResourceWithConfigure = &ClusterRosaHcpResource{}
+var _ resource.ResourceWithImportState = &ClusterRosaHcpResource{}
+
+func New() resource.Resource {
+	return &ClusterRosaHcpResource{}
+}
+
+func (r *ClusterRosaHcpResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cluster_rosa_hcp"
+}
+
+func (r *ClusterRosaHcpResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "OpenShift managed cluster using rosa sts.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Unique identifier of the cluster.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					// This passes the state through to the plan, preventing
+					// "known after apply" since we know it won't change.
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"external_id": schema.StringAttribute{
+				Description: "Unique external identifier of the cluster.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the cluster. Cannot exceed 15 characters in length.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(15),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"cloud_region": schema.StringAttribute{
+				Description: "Cloud region identifier, for example 'us-east-1'.",
+				Required:    true,
+			},
+			"sts": schema.SingleNestedAttribute{
+				Description: "STS configuration.",
+				Attributes:  stsResource(),
+				Optional:    true,
+			},
+			"multi_az": schema.BoolAttribute{
+				Description: "Indicates if the cluster should be deployed to " +
+					"multiple availability zones. Default value is 'false'.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"disable_workload_monitoring": schema.BoolAttribute{
+				Description: "Enables you to monitor your own projects in isolation from Red Hat " +
+					"Site Reliability Engineer (SRE) platform metrics.",
+				Optional: true,
+			},
+			"disable_scp_checks": schema.BoolAttribute{
+				Description: "Enables you to monitor your own projects in isolation from Red Hat " +
+					"Site Reliability Engineer (SRE) platform metrics.",
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"properties": schema.MapAttribute{
+				Description: "User defined properties.",
+				ElementType: types.StringType,
+				Optional:    true,
+				Computed:    true,
+				Validators:  []validator.Map{propertiesValidator},
+			},
+			"ocm_properties": schema.MapAttribute{
+				Description: "Merged properties defined by OCM and the user defined 'properties'.",
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"tags": schema.MapAttribute{
+				Description: "Apply user defined tags to all cluster resources created in AWS.",
+				ElementType: types.StringType,
+				Optional:    true,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.RequiresReplace(),
+				},
+			},
+			"ccs_enabled": schema.BoolAttribute{
+				Description: "Enables customer cloud subscription (Immutable with ROSA)",
+				Computed:    true,
+			},
+			"hypershift_enabled": schema.BoolAttribute{
+				Description: "Enables hypershift.",
+				Computed:    true,
+			},
+			"etcd_encryption": schema.BoolAttribute{
+				Description: "Encrypt etcd data. Note that all AWS storage is already encrypted.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"api_url": schema.StringAttribute{
+				Description: "URL of the API server.",
+				Computed:    true,
+			},
+			"console_url": schema.StringAttribute{
+				Description: "URL of the console.",
+				Computed:    true,
+			},
+			"domain": schema.StringAttribute{
+				Description: "DNS domain of cluster.",
+				Computed:    true,
+			},
+			"infra_id": schema.StringAttribute{
+				Description: "The ROSA cluster infrastructure ID.",
+				Computed:    true,
+			},
+			"base_dns_domain": schema.StringAttribute{
+				Description: "Base DNS domain name previously reserved and matching the hosted " +
+					"zone name of the private Route 53 hosted zone associated with intended shared " +
+					"VPC, e.g., '1vo8.p1.openshiftapps.com'.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"replicas": schema.Int64Attribute{
+				Description: "Number of worker/compute nodes to provision. Single zone clusters need at least 2 nodes, " +
+					"multizone clusters need at least 3 nodes. (only valid during cluster creation)",
+				Optional: true,
+			},
+			"compute_machine_type": schema.StringAttribute{
+				Description: "Identifies the machine type used by the default/initial worker nodes, " +
+					"for example `m5.xlarge`. Use the `rhcs_machine_types` data " +
+					"source to find the possible values. (only valid during cluster creation)",
+				Optional: true,
+			},
+			"worker_disk_size": schema.Int64Attribute{
+				Description: "Compute node root disk size, in GiB. (only valid during cluster creation)",
+				Optional:    true,
+			},
+			"default_mp_labels": schema.MapAttribute{
+				Description: "This value is the default/initial machine pool labels. Format should be a comma-separated list of '{\"key1\"=\"value1\", \"key2\"=\"value2\"}'. " +
+					"(only valid during cluster creation)",
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"aws_account_id": schema.StringAttribute{
+				Description: "Identifier of the AWS account.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"billing_account_id": schema.StringAttribute{
+				Description: "Identifier of the billing account.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"aws_subnet_ids": schema.ListAttribute{
+				Description: "AWS subnet IDs.",
+				ElementType: types.StringType,
+				Optional:    true,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+			},
+			"aws_additional_compute_security_group_ids": schema.ListAttribute{
+				Description: "AWS additional compute security group ids.",
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"kms_key_arn": schema.StringAttribute{
+				Description: "The key ARN is the Amazon Resource Name (ARN) of a AWS Key Management Service (KMS) Key. It is a unique, " +
+					"fully qualified identifier for the AWS KMS Key. A key ARN includes the AWS account, Region, and the key ID" +
+					"(optional).",
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"fips": schema.BoolAttribute{
+				Description: "Create cluster that uses FIPS Validated / Modules in Process cryptographic libraries.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"aws_private_link": schema.BoolAttribute{
+				Description: "Provides private connectivity from your cluster's VPC to Red Hat SRE, without exposing traffic to the public internet.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"private": schema.BoolAttribute{
+				Description: "Restrict cluster API endpoint and application routes to, private connectivity. This requires that PrivateLink be enabled and by extension, your own VPC.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"availability_zones": schema.ListAttribute{
+				Description: "Availability zones.",
+				ElementType: types.StringType,
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(availabilityZoneValidator),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+					listplanmodifier.RequiresReplace(),
+				},
+			},
+			"machine_cidr": schema.StringAttribute{
+				Description: "Block of IP addresses for nodes.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"proxy": schema.SingleNestedAttribute{
+				Description: "proxy",
+				Attributes:  proxy.ProxyResource(),
+				Optional:    true,
+				Validators:  []validator.Object{proxy.ProxyValidator()},
+			},
+			"service_cidr": schema.StringAttribute{
+				Description: "Block of IP addresses for the cluster service network.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"pod_cidr": schema.StringAttribute{
+				Description: "Block of IP addresses for pods.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"host_prefix": schema.Int64Attribute{
+				Description: "Length of the prefix of the subnet assigned to each node.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+					int64planmodifier.RequiresReplace(),
+				},
+			},
+			"channel_group": schema.StringAttribute{
+				Description: "Name of the channel group where you select the OpenShift cluster version, for example 'stable'. For ROSA, only 'stable' is supported.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(ocm.DefaultChannelGroup),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"version": schema.StringAttribute{
+				Description: "Desired version of OpenShift for the cluster, for example '4.11.0'. If version is greater than the currently running version, an upgrade will be scheduled.",
+				Optional:    true,
+			},
+			"current_version": schema.StringAttribute{
+				Description: "The currently running version of OpenShift on the cluster, for example '4.11.0'.",
+				Computed:    true,
+			},
+			"disable_waiting_in_destroy": schema.BoolAttribute{
+				Description: "Disable addressing cluster state in the destroy resource. Default value is false, and so a `destroy` will wait for the cluster to be deleted.",
+				Optional:    true,
+			},
+			"destroy_timeout": schema.Int64Attribute{
+				Description: "This value sets the maximum duration in minutes to allow for destroying resources. Default value is 60 minutes.",
+				Optional:    true,
+			},
+			"state": schema.StringAttribute{
+				Description: "State of the cluster.",
+				Computed:    true,
+			},
+			"upgrade_acknowledgements_for": schema.StringAttribute{
+				Description: "Indicates acknowledgement of agreements required to upgrade the cluster version between" +
+					" minor versions (e.g. a value of \"4.12\" indicates acknowledgement of any agreements required to " +
+					"upgrade to OpenShift 4.12.z from 4.11 or before).",
+				Optional: true,
+			},
+			"admin_credentials": schema.SingleNestedAttribute{
+				Description: "Admin user credentials",
+				Attributes: map[string]schema.Attribute{
+					"username": schema.StringAttribute{
+						Description: "Admin username that will be created with the cluster.",
+						Required:    true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+						Validators: identityprovider.HTPasswdUsernameValidators,
+					},
+					"password": schema.StringAttribute{
+						Description: "Admin password that will be created with the cluster.",
+						Required:    true,
+						Sensitive:   true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+						Validators: identityprovider.HTPasswdPasswordValidators,
+					},
+				},
+				Optional: true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
+			},
+			"private_hosted_zone": schema.SingleNestedAttribute{
+				Description: "Used in a shared VPC topology. HostedZone attributes",
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{
+						Description: "ID assigned by AWS to private Route 53 hosted zone associated with intended shared VPC, " +
+							"e.g. 'Z05646003S02O1ENCDCSN'.",
+						Required: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+					},
+					"role_arn": schema.StringAttribute{
+						Description: "AWS IAM role ARN with a policy attached, granting permissions necessary to " +
+							"create and manage Route 53 DNS records in private Route 53 hosted zone associated with " +
+							"intended shared VPC.",
+						Required: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+					},
+				},
+				Optional: true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.Object{
+					objectvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("sts")),
+					objectvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("base_dns_domain")),
+					objectvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("availability_zones")),
+					objectvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("aws_subnet_ids")),
+					privateHZValidator,
+				},
+			},
+			"wait_for_create_complete": schema.BoolAttribute{
+				Description: "Wait until the cluster is either in a ready state or in an error state. The waiter has a timeout of 60 minutes, with the default value set to false",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func (r *ClusterRosaHcpResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	connection, ok := req.ProviderData.(*sdk.Connection)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *sdk.Connaction, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.clusterCollection = connection.ClustersMgmt().V1().Clusters()
+	r.versionCollection = connection.ClustersMgmt().V1().Versions()
+}
+
+const (
+	errHeadline = "Can't build cluster"
+)
+
+func createHcpClusterObject(ctx context.Context,
+	state *ClusterRosaHcpState, diags diag.Diagnostics) (*cmv1.Cluster, error) {
+
+	ocmClusterResource := ocmr.NewCluster()
+	builder := ocmClusterResource.GetClusterBuilder()
+	clusterName := state.Name.ValueString()
+	if len(clusterName) > maxClusterNameLength {
+		errDescription := fmt.Sprintf("Expected a valid value for 'name' maximum of 15 characters in length. Provided Cluster name '%s' is of length '%d'",
+			clusterName, len(clusterName),
+		)
+		tflog.Error(ctx, errDescription)
+
+		diags.AddError(
+			errHeadline,
+			errDescription,
+		)
+		return nil, errors.New(errHeadline + "\n" + errDescription)
+	}
+
+	builder.Name(state.Name.ValueString())
+	builder.CloudProvider(cmv1.NewCloudProvider().ID(awsCloudProvider))
+	builder.Product(cmv1.NewProduct().ID(rosaProduct))
+	builder.Region(cmv1.NewCloudRegion().ID(state.CloudRegion.ValueString()))
+	multiAZ := common.BoolWithFalseDefault(state.MultiAZ)
+	builder.MultiAZ(multiAZ)
+
+	// Set default properties
+	properties := make(map[string]string)
+	for k, v := range OCMProperties {
+		properties[k] = v
+	}
+	if common.HasValue(state.Properties) {
+		propertiesElements, err := common.OptionalMap(ctx, state.Properties)
+		if err != nil {
+			errDescription := fmt.Sprintf("Expected a valid Map for 'properties' '%v'",
+				diags.Errors()[0].Detail(),
+			)
+			tflog.Error(ctx, errDescription)
+
+			diags.AddError(
+				errHeadline,
+				errDescription,
+			)
+			return nil, errors.New(errHeadline + "\n" + errDescription)
+		}
+
+		for k, v := range propertiesElements {
+			properties[k] = v
+		}
+	}
+	builder.Properties(properties)
+
+	if common.HasValue(state.EtcdEncryption) {
+		builder.EtcdEncryption(state.EtcdEncryption.ValueBool())
+	}
+
+	if common.HasValue(state.ExternalID) {
+		builder.ExternalID(state.ExternalID.ValueString())
+	}
+
+	if common.HasValue(state.DisableWorkloadMonitoring) {
+		builder.DisableUserWorkloadMonitoring(state.DisableWorkloadMonitoring.ValueBool())
+	}
+
+	if !common.IsStringAttributeUnknownOrEmpty(state.BaseDNSDomain) {
+		dnsBuilder := cmv1.NewDNS()
+		dnsBuilder.BaseDomain(state.BaseDNSDomain.ValueString())
+		builder.DNS(dnsBuilder)
+	}
+
+	replicas := common.OptionalInt64(state.Replicas)
+	computeMachineType := common.OptionalString(state.ComputeMachineType)
+	labels, err := common.OptionalMap(ctx, state.DefaultMPLabels)
+	if err != nil {
+		return nil, err
+	}
+	availabilityZones, err := common.StringListToArray(ctx, state.AvailabilityZones)
+	if err != nil {
+		return nil, err
+	}
+	workerDiskSize := common.OptionalInt64(state.WorkerDiskSize)
+
+	if err = ocmClusterResource.CreateHcpNodes(replicas, computeMachineType,
+		labels, availabilityZones, multiAZ, workerDiskSize); err != nil {
+		return nil, err
+	}
+
+	// ccs should be enabled in ocm rosa clusters
+	ccs := cmv1.NewCCS()
+	ccs.Enabled(true)
+
+	if common.HasValue(state.DisableSCPChecks) && state.DisableSCPChecks.ValueBool() {
+		ccs.DisableSCPChecks(true)
+	}
+	builder.CCS(ccs)
+
+	// hypershift should be enabled in ocm rosa HCP clusters
+	hypershift := cmv1.NewHypershift()
+	hypershift.Enabled(true)
+	builder.Hypershift(hypershift)
+
+	kmsKeyARN := common.OptionalString(state.KMSKeyArn)
+	awsAccountID := common.OptionalString(state.AWSAccountID)
+	billingAccountID := common.OptionalString(state.BillingAccountID)
+
+	var privateHostedZoneID, privateHostedZoneRoleARN *string = nil, nil
+	if state.PrivateHostedZone != nil &&
+		!common.IsStringAttributeUnknownOrEmpty(state.PrivateHostedZone.ID) &&
+		!common.IsStringAttributeUnknownOrEmpty(state.PrivateHostedZone.RoleARN) {
+		privateHostedZoneRoleARN = state.PrivateHostedZone.RoleARN.ValueStringPointer()
+		privateHostedZoneID = state.PrivateHostedZone.ID.ValueStringPointer()
+	}
+	isPrivateLink := common.BoolWithFalseDefault(state.AWSPrivateLink)
+	isPrivate := common.BoolWithFalseDefault(state.Private)
+	awsSubnetIDs, err := common.StringListToArray(ctx, state.AWSSubnetIDs)
+	if err != nil {
+		return nil, err
+	}
+	awsAdditionalComputeSecurityGroupIds, err := common.StringListToArray(ctx, state.AWSAdditionalComputeSecurityGroupIds)
+	if err != nil {
+		return nil, err
+	}
+
+	var stsBuilder *cmv1.STSBuilder
+	if state.Sts != nil {
+		stsBuilder = ocmr.CreateSTS(state.Sts.RoleARN.ValueString(), state.Sts.SupportRoleArn.ValueString(),
+			state.Sts.InstanceIAMRoles.MasterRoleARN.ValueString(), state.Sts.InstanceIAMRoles.WorkerRoleARN.ValueString(),
+			state.Sts.OperatorRolePrefix.ValueString(), common.OptionalString(state.Sts.OIDCConfigID))
+	}
+
+	awsTags, err := common.OptionalMap(ctx, state.Tags)
+	if err != nil {
+		return nil, err
+	}
+	if err := ocmClusterResource.CreateHcpAWSBuilder(awsTags, kmsKeyARN, isPrivateLink,
+		awsAccountID, billingAccountID, stsBuilder, awsSubnetIDs, privateHostedZoneID, privateHostedZoneRoleARN,
+		awsAdditionalComputeSecurityGroupIds); err != nil {
+		return nil, err
+	}
+
+	if err := ocmClusterResource.SetAPIPrivacy(isPrivate, isPrivateLink, stsBuilder != nil); err != nil {
+		return nil, err
+	}
+
+	if common.HasValue(state.FIPS) && state.FIPS.ValueBool() {
+		builder.FIPS(true)
+	}
+
+	network := cmv1.NewNetwork()
+	if common.HasValue(state.MachineCIDR) {
+		network.MachineCIDR(state.MachineCIDR.ValueString())
+	}
+	if common.HasValue(state.ServiceCIDR) {
+		network.ServiceCIDR(state.ServiceCIDR.ValueString())
+	}
+	if common.HasValue(state.PodCIDR) {
+		network.PodCIDR(state.PodCIDR.ValueString())
+	}
+	if common.HasValue(state.HostPrefix) {
+		network.HostPrefix(int(state.HostPrefix.ValueInt64()))
+	}
+	if !network.Empty() {
+		builder.Network(network)
+	}
+
+	channelGroup := ocm.DefaultChannelGroup
+	if common.HasValue(state.ChannelGroup) {
+		channelGroup = state.ChannelGroup.ValueString()
+	}
+
+	if common.HasValue(state.Version) {
+		// TODO: update it to support all cluster versions
+		isSupported, err := common.IsGreaterThanOrEqual(state.Version.ValueString(), MinVersion)
+		if err != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error validating required cluster version %s", err))
+			errDescription := fmt.Sprintf(
+				"Can't check if cluster version is supported '%s': %v",
+				state.Version.ValueString(), err,
+			)
+			diags.AddError(
+				errHeadline,
+				errDescription,
+			)
+			return nil, errors.New(errHeadline + "\n" + errDescription)
+		}
+		if !isSupported {
+			description := fmt.Sprintf("Cluster version %s is not supported (minimal supported version is %s)", state.Version.ValueString(), MinVersion)
+			tflog.Error(ctx, description)
+			diags.AddError(
+				errHeadline,
+				description,
+			)
+			return nil, errors.New(errHeadline + "\n" + description)
+		}
+		vBuilder := cmv1.NewVersion()
+		versionID := fmt.Sprintf("openshift-v%s", state.Version.ValueString())
+		// When using a channel group other than the default, the channel name
+		// must be appended to the version ID or the API server will return an
+		// error stating unexpected channel group.
+		if channelGroup != ocm.DefaultChannelGroup {
+			versionID = versionID + "-" + channelGroup
+		}
+		vBuilder.ID(versionID)
+		vBuilder.ChannelGroup(channelGroup)
+		builder.Version(vBuilder)
+	}
+
+	if state.AdminCredentials != nil {
+		htpasswdUsers := []*cmv1.HTPasswdUserBuilder{}
+		htpasswdUsers = append(htpasswdUsers, cmv1.NewHTPasswdUser().
+			Username(state.AdminCredentials.Username.ValueString()).Password(state.AdminCredentials.Password.ValueString()))
+		htpassUserList := cmv1.NewHTPasswdUserList().Items(htpasswdUsers...)
+		htPasswdIDP := cmv1.NewHTPasswdIdentityProvider().Users(htpassUserList)
+		builder.Htpasswd(htPasswdIDP)
+	}
+
+	builder, err = buildProxy(state, builder)
+	if err != nil {
+		tflog.Error(ctx, "Failed to build the Proxy's attributes")
+		return nil, err
+	}
+
+	object, err := builder.Build()
+	return object, err
+}
+
+func buildProxy(state *ClusterRosaHcpState, builder *cmv1.ClusterBuilder) (*cmv1.ClusterBuilder, error) {
+	if state.Proxy != nil {
+		proxy := cmv1.NewProxy()
+		proxyIsEmpty := true
+
+		if !common.IsStringAttributeUnknownOrEmpty(state.Proxy.HttpProxy) {
+			proxy.HTTPProxy(state.Proxy.HttpProxy.ValueString())
+			proxyIsEmpty = false
+		}
+		if !common.IsStringAttributeUnknownOrEmpty(state.Proxy.HttpsProxy) {
+			proxy.HTTPSProxy(state.Proxy.HttpsProxy.ValueString())
+			proxyIsEmpty = false
+		}
+		if !common.IsStringAttributeUnknownOrEmpty(state.Proxy.NoProxy) {
+			proxy.NoProxy(state.Proxy.NoProxy.ValueString())
+			proxyIsEmpty = false
+		}
+		if !proxyIsEmpty {
+			builder.Proxy(proxy)
+		}
+
+		if !common.IsStringAttributeUnknownOrEmpty(state.Proxy.AdditionalTrustBundle) {
+			builder.AdditionalTrustBundle(state.Proxy.AdditionalTrustBundle.ValueString())
+		}
+
+	}
+
+	return builder, nil
+}
+
+// getAndValidateVersionInChannelGroup ensures that the cluster version is
+// available in the channel group
+func (r *ClusterRosaHcpResource) getAndValidateVersionInChannelGroup(ctx context.Context, state *ClusterRosaHcpState) (string, error) {
+	channelGroup := ocm.DefaultChannelGroup
+	if common.HasValue(state.ChannelGroup) {
+		channelGroup = state.ChannelGroup.ValueString()
+	}
+
+	versionList, err := r.getVersionList(ctx, channelGroup)
+	if err != nil {
+		return "", err
+	}
+
+	version := versionList[0]
+	if common.HasValue(state.Version) {
+		version = state.Version.ValueString()
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Validating if cluster version %s is in the list of supported versions: %v", version, versionList))
+	for _, v := range versionList {
+		if v == version {
+			return version, nil
+		}
+	}
+
+	return "", fmt.Errorf("version %s is not in the list of supported versions: %v", version, versionList)
+}
+
+func getOcmVersionMinor(ver string) string {
+	version, err := semver.NewVersion(ver)
+	if err != nil {
+		segments := strings.Split(ver, ".")
+		return fmt.Sprintf("%s.%s", segments[0], segments[1])
+	}
+	segments := version.Segments()
+	return fmt.Sprintf("%d.%d", segments[0], segments[1])
+}
+
+// getVersionList returns a list of versions for the given channel group, sorted by
+// descending semver
+func (r *ClusterRosaHcpResource) getVersionList(ctx context.Context, channelGroup string) (versionList []string, err error) {
+	vs, err := r.getVersions(ctx, channelGroup)
+	if err != nil {
+		err = fmt.Errorf("Failed to retrieve versions: %s", err)
+		return
+	}
+
+	for _, v := range vs {
+		versionList = append(versionList, v.RawID())
+	}
+
+	if len(versionList) == 0 {
+		err = fmt.Errorf("Could not find versions")
+		return
+	}
+
+	return
+}
+func (r *ClusterRosaHcpResource) getVersions(ctx context.Context, channelGroup string) (versions []*cmv1.Version, err error) {
+	page := 1
+	size := 100
+	filter := strings.Join([]string{
+		"enabled = 'true'",
+		"rosa_enabled = 'true'",
+		fmt.Sprintf("channel_group = '%s'", channelGroup),
+	}, " AND ")
+	for {
+		var response *cmv1.VersionsListResponse
+		response, err = r.versionCollection.List().
+			Search(filter).
+			Order("default desc, id desc").
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			tflog.Debug(ctx, err.Error())
+			return nil, err
+		}
+		versions = append(versions, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+
+	// Sort list in descending order
+	sort.Slice(versions, func(i, j int) bool {
+		a, erra := ver.NewVersion(versions[i].RawID())
+		b, errb := ver.NewVersion(versions[j].RawID())
+		if erra != nil || errb != nil {
+			return false
+		}
+		return a.GreaterThan(b)
+	})
+
+	return
+}
+
+func (r *ClusterRosaHcpResource) createAdminCredentials(ctx context.Context, response *resource.CreateResponse,
+	state *ClusterRosaHcpState, resource *cmv1.ClusterClient) {
+
+	// Wait till the cluster is ready:
+	err := common.WaitTillClusterReady(ctx, r.clusterCollection, state.ID.ValueString())
+	if err != nil {
+		response.Diagnostics.AddWarning(
+			"Can't poll cluster state",
+			fmt.Sprintf(
+				"Can't poll state of cluster with identifier '%s': %v",
+				state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+
+	// Create the identity provider:
+	idpBuilder := cmv1.NewIdentityProvider()
+	idpBuilder.Name(state.AdminCredentials.Username.ValueString())
+	idpBuilder.MappingMethod(cmv1.IdentityProviderMappingMethodClaim)
+	idpBuilder.Type(cmv1.IdentityProviderTypeHtpasswd)
+	htpasswdIDP := cmv1.NewHTPasswdIdentityProvider().Users(cmv1.NewHTPasswdUserList().Items(
+		cmv1.NewHTPasswdUser().Username(state.AdminCredentials.Username.ValueString()).Password(state.AdminCredentials.Password.ValueString()),
+	))
+	idpBuilder.Htpasswd(htpasswdIDP)
+
+	idpObject, err := idpBuilder.Build()
+	if err != nil {
+		response.Diagnostics.AddWarning(
+			"Can't build identity provider",
+			fmt.Sprintf(
+				"Can't build identity provider for cluster '%s': %v",
+				state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+
+	collection := resource.IdentityProviders()
+	idp, err := collection.Add().Body(idpObject).SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddWarning(
+			"Can't create identity provider",
+			fmt.Sprintf(
+				"Can't create identity provider '%s' for cluster '%s': %v",
+				state.AdminCredentials.Username.ValueString(), state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Created identity provider '%s' for cluster '%s'", idp.Body().ID(), state.ID.ValueString()))
+
+	// Create the membership:
+	userBuilder := cmv1.NewUser()
+	userBuilder.ID(state.AdminCredentials.Username.ValueString())
+	userObject, err := userBuilder.Build()
+	if err != nil {
+		response.Diagnostics.AddWarning(
+			"Can't build group membership user",
+			fmt.Sprintf(
+				"Can't build group membership user '%s' for cluster '%s': %v",
+				state.AdminCredentials.Username.ValueString(), state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+
+	groupCollection := resource.Groups().Group("cluster-admins").Users()
+	group, err := groupCollection.Add().Body(userObject).SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddWarning(
+			"Can't create group membership",
+			fmt.Sprintf(
+				"Can't create group membership '%s' for cluster '%s': %v",
+				"cluster-admins", state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Created group membership '%s' for cluster '%s'", group.Body().ID(), state.ID.ValueString()))
+}
+
+func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.CreateRequest,
+	response *resource.CreateResponse) {
+	tflog.Debug(ctx, "begin create()")
+
+	// Get the plan:
+	state := &ClusterRosaHcpState{}
+	diags := request.Plan.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	summary := "Can't build cluster"
+
+	// In case version with "openshift-v" prefix was used here,
+	// Give a meaningful message to inform the user that it not supported any more
+	if common.HasValue(state.Version) && strings.HasPrefix(state.Version.ValueString(), "openshift-v") {
+		response.Diagnostics.AddError(
+			summary,
+			"Openshift version must be provided without the \"openshift-v\" prefix",
+		)
+		return
+	}
+
+	object, err := createHcpClusterObject(ctx, state, diags)
+	if err != nil {
+		response.Diagnostics.AddError(
+			summary,
+			fmt.Sprintf(
+				"Can't build cluster with name '%s': %v",
+				state.Name.ValueString(), err,
+			),
+		)
+		return
+	}
+
+	add, err := r.clusterCollection.Add().Body(object).SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			summary,
+			fmt.Sprintf(
+				"Can't create cluster with name '%s': %v",
+				state.Name.ValueString(), err,
+			),
+		)
+		return
+	}
+	object = add.Body()
+
+	state.ID = types.StringValue(object.ID())
+
+	// Create Admin Credentials and logs warnings if hitting errors
+	if state.AdminCredentials != nil {
+		resource := r.clusterCollection.Cluster(object.ID())
+		r.createAdminCredentials(ctx, response, state, resource)
+	}
+
+	if common.HasValue(state.WaitForCreateComplete) && state.WaitForCreateComplete.ValueBool() {
+		object, err = common.RetryClusterComputeReadiness(3, 30*time.Second, object.ID(),
+			ctx, waitTimeoutInMinutes, r.clusterCollection)
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Waiting for cluster creation finished with error",
+				fmt.Sprintf("Waiting for cluster creation finished with the error %v", err),
+			)
+			if object == nil {
+				return
+			}
+		}
+
+	}
+
+	// Save the state:
+	err = populateRosaHcpClusterState(ctx, object, state, common.DefaultHttpClient{})
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't populate cluster state",
+			fmt.Sprintf(
+				"Received error %v", err,
+			),
+		)
+		return
+	}
+
+	diags = response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}
+
+func (r *ClusterRosaHcpResource) Read(ctx context.Context, request resource.ReadRequest,
+	response *resource.ReadResponse) {
+	tflog.Debug(ctx, "begin Read()")
+	// Get the current state:
+	state := &ClusterRosaHcpState{}
+	diags := request.State.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Find the cluster:
+	get, err := r.clusterCollection.Cluster(state.ID.ValueString()).Get().SendContext(ctx)
+	if err != nil && get.Status() == http.StatusNotFound {
+		tflog.Warn(ctx, fmt.Sprintf("cluster (%s) not found, removing from state",
+			state.ID.ValueString(),
+		))
+		response.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
+		response.Diagnostics.AddError(
+			"Can't find cluster",
+			fmt.Sprintf(
+				"Can't find cluster with identifier '%s': %v",
+				state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+
+	object := get.Body()
+
+	// Save the state:
+	err = populateRosaHcpClusterState(ctx, object, state, common.DefaultHttpClient{})
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't populate cluster state",
+			fmt.Sprintf(
+				"Received error %v", err,
+			),
+		)
+		return
+	}
+
+	diags = response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}
+
+func (r *ClusterRosaHcpResource) Update(ctx context.Context, request resource.UpdateRequest,
+	response *resource.UpdateResponse) {
+	var diags diag.Diagnostics
+
+	tflog.Debug(ctx, "begin update()")
+
+	// Get the state:
+	state := &ClusterRosaHcpState{}
+	diags = request.State.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the plan:
+	plan := &ClusterRosaHcpState{}
+	diags = request.Plan.Get(ctx, plan)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	clusterState := "Unknown"
+	if common.HasValue(state.State) && state.State.ValueString() != "" {
+		clusterState = state.State.ValueString()
+	}
+	if clusterState != string(cmv1.ClusterStateReady) {
+		response.Diagnostics.AddError(
+			"Update cluster operation is only supported while cluster is ready",
+			fmt.Sprintf(
+				"Update cluster operation is only supported while cluster is ready, cluster state is %s", clusterState,
+			),
+		)
+		return
+	}
+
+	// Schedule a cluster upgrade if a newer version is requested
+	if err := r.upgradeClusterIfNeeded(ctx, state, plan); err != nil {
+		response.Diagnostics.AddError(
+			"Can't upgrade cluster",
+			fmt.Sprintf("Can't upgrade cluster version with identifier: `%s`, %v", state.ID.ValueString(), err),
+		)
+		return
+	}
+
+	clusterBuilder := cmv1.NewCluster()
+
+	clusterBuilder, err := updateProxy(state, plan, clusterBuilder)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't update cluster",
+			fmt.Sprintf(
+				"Can't update proxy's configuration for cluster with identifier: `%s`, %v",
+				state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+
+	_, shouldPatchDisableWorkloadMonitoring := common.ShouldPatchBool(state.DisableWorkloadMonitoring, plan.DisableWorkloadMonitoring)
+	if shouldPatchDisableWorkloadMonitoring {
+		clusterBuilder.DisableUserWorkloadMonitoring(plan.DisableWorkloadMonitoring.ValueBool())
+	}
+
+	patchProperties := shouldPatchProperties(state, plan)
+	if patchProperties {
+		propertiesElements, err := common.OptionalMap(ctx, plan.Properties)
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Can't upgrade cluster",
+				fmt.Sprintf("Can't upgrade cluster version with identifier: `%s`, %v", state.ID.ValueString(), err),
+			)
+			return
+		}
+		if propertiesElements != nil {
+			for k, v := range OCMProperties {
+				propertiesElements[k] = v
+			}
+			clusterBuilder.Properties(propertiesElements)
+		}
+	}
+
+	clusterSpec, err := clusterBuilder.Build()
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't build cluster patch",
+			fmt.Sprintf(
+				"Can't build patch for cluster with identifier '%s': %v",
+				state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+
+	update, err := r.clusterCollection.Cluster(state.ID.ValueString()).Update().
+		Body(clusterSpec).
+		SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't update cluster",
+			fmt.Sprintf(
+				"Can't update cluster with identifier '%s': %v",
+				state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+
+	object := update.Body()
+
+	// Update the state:
+	err = populateRosaHcpClusterState(ctx, object, plan, common.DefaultHttpClient{})
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't populate cluster state",
+			fmt.Sprintf(
+				"Received error %v", err,
+			),
+		)
+		return
+	}
+
+	diags = response.State.Set(ctx, plan)
+	response.Diagnostics.Append(diags...)
+}
+
+// Upgrades the cluster if the desired (plan) version is greater than the
+// current version
+func (r *ClusterRosaHcpResource) upgradeClusterIfNeeded(ctx context.Context, state, plan *ClusterRosaHcpState) error {
+	if common.IsStringAttributeUnknownOrEmpty(plan.Version) || common.IsStringAttributeUnknownOrEmpty(state.CurrentVersion) {
+		// No version information, nothing to do
+		tflog.Debug(ctx, "Insufficient cluster version information to determine if upgrade should be performed.")
+		return nil
+	}
+
+	tflog.Debug(ctx, "Cluster versions",
+		map[string]interface{}{
+			"current_version": state.CurrentVersion.ValueString(),
+			"plan-version":    plan.Version.ValueString(),
+			"state-version":   state.Version.ValueString(),
+		})
+
+	// See if the user has changed the requested version for this run
+	requestedVersionChanged := true
+	if !common.IsStringAttributeUnknownOrEmpty(plan.Version) && !common.IsStringAttributeUnknownOrEmpty(state.Version) {
+		if plan.Version.ValueString() == state.Version.ValueString() {
+			requestedVersionChanged = false
+		}
+	}
+
+	// Check the versions to see if we need to upgrade
+	currentVersion, err := semver.NewVersion(state.CurrentVersion.ValueString())
+	if err != nil {
+		return fmt.Errorf("failed to parse current cluster version: %v", err)
+	}
+	// For backward compatibility
+	// In case version format with "openshift-v" was already used
+	// remove the prefix to adapt the right format and avoid failure
+	fixedVersion := strings.TrimPrefix(plan.Version.ValueString(), "openshift-v")
+	desiredVersion, err := semver.NewVersion(fixedVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse desired cluster version: %v", err)
+	}
+	if currentVersion.GreaterThan(desiredVersion) {
+		tflog.Debug(ctx, "No cluster version upgrade needed.")
+		if requestedVersionChanged {
+			// User changed the version they want, but actual is higher. We
+			// don't support downgrades.
+			return fmt.Errorf("cluster version is already above the requested version")
+		}
+		return nil
+	}
+	cancelingUpgradeOnly := desiredVersion.Equal(currentVersion)
+
+	if !cancelingUpgradeOnly {
+		if err = r.validateUpgrade(ctx, state, plan); err != nil {
+			return err
+		}
+	}
+
+	// Fetch existing upgrade policies
+	upgrades, err := upgrade.GetScheduledUpgrades(ctx, r.clusterCollection, state.ID.ValueString())
+	if err != nil {
+		return fmt.Errorf("failed to get upgrade policies: %v", err)
+	}
+
+	// Stop if an upgrade is already in progress
+	correctUpgradePending, err := upgrade.CheckAndCancelUpgrades(ctx, r.clusterCollection, upgrades, desiredVersion)
+	if err != nil {
+		return err
+	}
+
+	// Schedule a new upgrade
+	if !correctUpgradePending && !cancelingUpgradeOnly {
+		ackString := plan.UpgradeAcksFor.ValueString()
+		if err = scheduleUpgrade(ctx, r.clusterCollection, state.ID.ValueString(), desiredVersion, ackString); err != nil {
+			return err
+		}
+	}
+
+	state.Version = plan.Version
+	state.UpgradeAcksFor = plan.UpgradeAcksFor
+	return nil
+}
+
+func (r *ClusterRosaHcpResource) validateUpgrade(ctx context.Context, state, plan *ClusterRosaHcpState) error {
+	// Make sure the desired version is available
+	versionId := fmt.Sprintf("openshift-v%s", state.CurrentVersion.ValueString())
+	if common.HasValue(state.ChannelGroup) && state.ChannelGroup.ValueString() != ocm.DefaultChannelGroup {
+		versionId += "-" + state.ChannelGroup.ValueString()
+	}
+	availableVersions, err := upgrade.GetAvailableUpgradeVersions(ctx, r.versionCollection, versionId)
+	if err != nil {
+		return fmt.Errorf("failed to get available upgrades: %v", err)
+	}
+	trimmedDesiredVersion := strings.TrimPrefix(plan.Version.ValueString(), "openshift-v")
+	desiredVersion, err := semver.NewVersion(trimmedDesiredVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse desired version: %v", err)
+	}
+	found := false
+	for _, v := range availableVersions {
+		sem, err := semver.NewVersion(v.RawID())
+		if err != nil {
+			return fmt.Errorf("failed to parse available upgrade version: %v", err)
+		}
+		if desiredVersion.Equal(sem) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		avail := []string{}
+		for _, v := range availableVersions {
+			avail = append(avail, v.RawID())
+		}
+		return fmt.Errorf("desired version (%s) is not in the list of available upgrades (%v)", desiredVersion, avail)
+	}
+
+	return nil
+}
+
+// Ensure user has acked upgrade gates and schedule the upgrade
+func scheduleUpgrade(ctx context.Context, client *cmv1.ClustersClient, clusterID string, desiredVersion *semver.Version, userAckString string) error {
+	// Gate agreements are checked when the upgrade is scheduled, resulting
+	// in an error return. ROSA cli does this by scheduling once w/ dryRun
+	// to look for un-acked agreements.
+	clusterClient := client.Cluster(clusterID)
+	upgradePoliciesClient := clusterClient.UpgradePolicies()
+	gates, description, err := upgrade.CheckMissingAgreements(desiredVersion.String(), clusterID, upgradePoliciesClient)
+	if err != nil {
+		return fmt.Errorf("failed to check for missing upgrade agreements: %v", err)
+	}
+	// User ack is required if we have any non-STS-only gates
+	userAckRequired := false
+	for _, gate := range gates {
+		if !gate.STSOnly() {
+			userAckRequired = true
+		}
+	}
+	targetMinorVersion := getOcmVersionMinor(desiredVersion.String())
+	if userAckRequired && userAckString != targetMinorVersion { // User has not acknowledged mandatory gates, stop here.
+		return fmt.Errorf("%s\nTo acknowledge these items, please add \"upgrade_acknowledgements_for = %s\""+
+			" and re-apply the changes", description, targetMinorVersion)
+	}
+
+	// Ack all gates to OCM
+	for _, gate := range gates {
+		gateID := gate.ID()
+		tflog.Debug(ctx, "Acknowledging version gate", map[string]interface{}{"gateID": gateID})
+		gateAgreementsClient := clusterClient.GateAgreements()
+		err := upgrade.AckVersionGate(gateAgreementsClient, gateID)
+		if err != nil {
+			return fmt.Errorf("failed to acknowledge version gate '%s' for cluster '%s': %v",
+				gateID, clusterID, err)
+		}
+	}
+
+	// Schedule an upgrade
+	tenMinFromNow := time.Now().UTC().Add(10 * time.Minute)
+	newPolicy, err := cmv1.NewUpgradePolicy().
+		ScheduleType("manual").
+		Version(desiredVersion.String()).
+		NextRun(tenMinFromNow).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create upgrade policy: %v", err)
+	}
+	_, err = clusterClient.UpgradePolicies().
+		Add().
+		Body(newPolicy).
+		SendContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to schedule upgrade: %v", err)
+	}
+	return nil
+}
+
+func updateProxy(state, plan *ClusterRosaHcpState, clusterBuilder *cmv1.ClusterBuilder) (*cmv1.ClusterBuilder, error) {
+	if !reflect.DeepEqual(state.Proxy, plan.Proxy) {
+		var err error
+		if plan.Proxy == nil {
+			plan.Proxy = &proxy.Proxy{}
+		}
+		clusterBuilder, err = buildProxy(plan, clusterBuilder)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return clusterBuilder, nil
+}
+
+func (r *ClusterRosaHcpResource) Delete(ctx context.Context, request resource.DeleteRequest,
+	response *resource.DeleteResponse) {
+	tflog.Debug(ctx, "begin delete()")
+
+	// Get the state:
+	state := &ClusterRosaHcpState{}
+	diags := request.State.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Send the request to delete the cluster:
+	resource := r.clusterCollection.Cluster(state.ID.ValueString())
+	_, err := resource.Delete().SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't delete cluster",
+			fmt.Sprintf(
+				"Can't delete cluster with identifier '%s': %v",
+				state.ID.ValueString(), err,
+			),
+		)
+		return
+	}
+	if common.HasValue(state.DisableWaitingInDestroy) && state.DisableWaitingInDestroy.ValueBool() {
+		tflog.Info(ctx, "Waiting for destroy to be completed, is disabled")
+	} else {
+		timeout := defaultTimeoutInMinutes
+		if common.HasValue(state.DestroyTimeout) {
+			if state.DestroyTimeout.ValueInt64() <= 0 {
+				response.Diagnostics.AddWarning(nonPositiveTimeoutSummary, fmt.Sprintf(nonPositiveTimeoutFormat, state.ID.ValueString()))
+			} else {
+				timeout = state.DestroyTimeout.ValueInt64()
+			}
+		}
+		isNotFound, err := r.retryClusterNotFoundWithTimeout(3, 1*time.Minute, ctx, timeout, resource)
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Can't poll cluster state",
+				fmt.Sprintf(
+					"Can't poll state of cluster with identifier '%s': %v",
+					state.ID.ValueString(), err,
+				),
+			)
+			return
+		}
+
+		if !isNotFound {
+			response.Diagnostics.AddWarning(
+				"Cluster wasn't deleted yet",
+				fmt.Sprintf("The cluster with identifier '%s' is not deleted yet, but the polling finisehd due to a timeout", state.ID.ValueString()),
+			)
+		}
+
+	}
+	// Remove the state:
+	response.State.RemoveResource(ctx)
+}
+
+func (r *ClusterRosaHcpResource) ImportState(ctx context.Context, request resource.ImportStateRequest,
+	response *resource.ImportStateResponse) {
+	tflog.Debug(ctx, "begin importstate()")
+
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), request, response)
+}
+
+// populateRosaHcpClusterState copies the data from the API object to the Terraform state.
+func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, state *ClusterRosaHcpState, httpClient common.HttpClient) error {
+	state.ID = types.StringValue(object.ID())
+	state.ExternalID = types.StringValue(object.ExternalID())
+	object.API()
+	state.Name = types.StringValue(object.Name())
+	state.CloudRegion = types.StringValue(object.Region().ID())
+	state.MultiAZ = types.BoolValue(object.MultiAZ())
+	if props, ok := object.GetProperties(); ok {
+		propertiesMap := map[string]string{}
+		ocmPropertiesMap := map[string]string{}
+		for k, v := range props {
+			ocmPropertiesMap[k] = v
+			if _, isDefault := OCMProperties[k]; !isDefault {
+				propertiesMap[k] = v
+			}
+		}
+		mapValue, err := common.ConvertStringMapToMapType(propertiesMap)
+		if err != nil {
+			return err
+		} else {
+			state.Properties = mapValue
+		}
+		mapValue, err = common.ConvertStringMapToMapType(ocmPropertiesMap)
+		if err != nil {
+			return err
+		} else {
+			state.OCMProperties = mapValue
+		}
+	}
+	state.APIURL = types.StringValue(object.API().URL())
+	state.ConsoleURL = types.StringValue(object.Console().URL())
+	state.Domain = types.StringValue(fmt.Sprintf("%s.%s", object.Name(), object.DNS().BaseDomain()))
+	state.BaseDNSDomain = types.StringValue(object.DNS().BaseDomain())
+	state.InfraID = types.StringValue(object.InfraID())
+
+	disableUserWorkload, ok := object.GetDisableUserWorkloadMonitoring()
+	if ok && disableUserWorkload {
+		state.DisableWorkloadMonitoring = types.BoolValue(true)
+	}
+
+	isFips, ok := object.GetFIPS()
+	if ok && isFips {
+		state.FIPS = types.BoolValue(true)
+	}
+
+	if azs, ok := object.Nodes().GetAvailabilityZones(); ok {
+		listValue, err := common.StringArrayToList(azs)
+		if err != nil {
+			return err
+		}
+		state.AvailabilityZones = listValue
+	} else {
+		state.AvailabilityZones = types.ListNull(types.StringType)
+	}
+
+	state.CCSEnabled = types.BoolValue(object.CCS().Enabled())
+
+	disableSCPChecks, ok := object.CCS().GetDisableSCPChecks()
+	if ok && disableSCPChecks {
+		state.DisableSCPChecks = types.BoolValue(true)
+	}
+
+	state.HypershiftEnabled = types.BoolValue(object.Hypershift().Enabled())
+
+	state.EtcdEncryption = types.BoolValue(object.EtcdEncryption())
+
+	// Note: The API does not currently return account id, but we try to get it
+	// anyway. Failing that, we fetch the creator ARN from the properties like
+	// rosa cli does.
+	awsAccountID, ok := object.AWS().GetAccountID()
+	if ok {
+		state.AWSAccountID = types.StringValue(awsAccountID)
+	} else {
+		// rosa cli gets it from the properties, so we do the same
+		if creatorARN, ok := object.Properties()[properties.CreatorARN]; ok {
+			if arn, err := arn.Parse(creatorARN); err == nil {
+				state.AWSAccountID = types.StringValue(arn.AccountID)
+			}
+		}
+
+	}
+
+	billingAccountID, ok := object.AWS().GetBillingAccountID()
+	if ok {
+		state.BillingAccountID = types.StringValue(billingAccountID)
+	}
+
+	awsPrivateLink, ok := object.AWS().GetPrivateLink()
+	if ok {
+		state.AWSPrivateLink = types.BoolValue(awsPrivateLink)
+	} else {
+		state.AWSPrivateLink = types.BoolValue(true)
+	}
+	listeningMethod, ok := object.API().GetListening()
+	if ok {
+		state.Private = types.BoolValue(listeningMethod == cmv1.ListeningMethodInternal)
+	} else {
+		state.Private = types.BoolValue(true)
+	}
+	kmsKeyArn, ok := object.AWS().GetKMSKeyArn()
+	if ok {
+		state.KMSKeyArn = types.StringValue(kmsKeyArn)
+	}
+
+	sts, ok := object.AWS().GetSTS()
+	if ok {
+		if state.Sts == nil {
+			state.Sts = &Sts{}
+		}
+		oidc_endpoint_url := strings.TrimPrefix(sts.OIDCEndpointURL(), "https://")
+
+		state.Sts.OIDCEndpointURL = types.StringValue(oidc_endpoint_url)
+		state.Sts.RoleARN = types.StringValue(sts.RoleARN())
+		state.Sts.SupportRoleArn = types.StringValue(sts.SupportRoleARN())
+		instanceIAMRoles := sts.InstanceIAMRoles()
+		if instanceIAMRoles != nil {
+			state.Sts.InstanceIAMRoles.MasterRoleARN = types.StringValue(instanceIAMRoles.MasterRoleARN())
+			state.Sts.InstanceIAMRoles.WorkerRoleARN = types.StringValue(instanceIAMRoles.WorkerRoleARN())
+		}
+		// TODO: fix a bug in uhc-cluster-services
+		if common.IsStringAttributeUnknownOrEmpty(state.Sts.OperatorRolePrefix) {
+			operatorRolePrefix, ok := sts.GetOperatorRolePrefix()
+			if ok {
+				state.Sts.OperatorRolePrefix = types.StringValue(operatorRolePrefix)
+			}
+		}
+		thumbprint, err := common.GetThumbprint(sts.OIDCEndpointURL(), httpClient)
+		if err != nil {
+			tflog.Error(ctx, fmt.Sprintf("cannot get thumbprint %v", err))
+			state.Sts.Thumbprint = types.StringValue("")
+		} else {
+			state.Sts.Thumbprint = types.StringValue(thumbprint)
+		}
+		oidcConfig, ok := sts.GetOidcConfig()
+		if ok && oidcConfig != nil {
+			state.Sts.OIDCConfigID = types.StringValue(oidcConfig.ID())
+		}
+	}
+
+	subnetIds, ok := object.AWS().GetSubnetIDs()
+	if ok {
+		awsSubnetIds, err := common.StringArrayToList(subnetIds)
+		if err != nil {
+			return err
+		}
+		state.AWSSubnetIDs = awsSubnetIds
+	}
+
+	additionalComputeSecurityGroupIds, ok := object.AWS().GetAdditionalComputeSecurityGroupIds()
+	if ok {
+		awsAdditionalSecurityGroupIds, err := common.StringArrayToList(additionalComputeSecurityGroupIds)
+		if err != nil {
+			return err
+		}
+		state.AWSAdditionalComputeSecurityGroupIds = awsAdditionalSecurityGroupIds
+	}
+
+	hasProxy := true
+	hasAdditionalTrustBundle := true
+
+	proxyObj, ok := object.GetProxy()
+	if ok {
+		if state.Proxy == nil {
+			state.Proxy = &proxy.Proxy{}
+		}
+		httpProxy, ok := proxyObj.GetHTTPProxy()
+		if ok {
+			state.Proxy.HttpProxy = types.StringValue(httpProxy)
+		}
+
+		httpsProxy, ok := proxyObj.GetHTTPSProxy()
+		if ok {
+			state.Proxy.HttpsProxy = types.StringValue(httpsProxy)
+		}
+
+		noProxy, ok := proxyObj.GetNoProxy()
+		if ok {
+			state.Proxy.NoProxy = types.StringValue(noProxy)
+		}
+	} else {
+		// We cannot set the proxy to nil because the attribute state.Proxy.AdditionalTrustBundle might contain a value.
+		// Due to the sensitivity of this attribute, the backend returns the value `REDUCTED` for a non-empty AdditionalTrustBundle
+		// and if state.Proxy is null it will override the actual value.
+		hasProxy = false
+	}
+
+	trustBundle, ok := object.GetAdditionalTrustBundle()
+	if ok {
+		// If AdditionalTrustBundle is not empty, the ocm-backend always "REDUCTED" (sensitive value)
+		// Therefore, we would like to update the state only if the current state is Null or Empty
+		// it can happen after `import` command or when it was updated from a different cli tool
+		if state.Proxy == nil || common.IsStringAttributeKnownAndEmpty(state.Proxy.AdditionalTrustBundle) {
+			if state.Proxy == nil {
+				state.Proxy = &proxy.Proxy{}
+			}
+			state.Proxy.AdditionalTrustBundle = types.StringValue(trustBundle)
+		}
+	} else {
+		hasAdditionalTrustBundle = false
+	}
+
+	// Set state.Proxy to be null only if `object.Proxy()` and `object.AdditionalTrustBundle()` are empty
+	if !hasProxy && !hasAdditionalTrustBundle {
+		state.Proxy = nil
+	}
+
+	machineCIDR, ok := object.Network().GetMachineCIDR()
+	if ok {
+		state.MachineCIDR = types.StringValue(machineCIDR)
+	} else {
+		state.MachineCIDR = types.StringNull()
+	}
+	serviceCIDR, ok := object.Network().GetServiceCIDR()
+	if ok {
+		state.ServiceCIDR = types.StringValue(serviceCIDR)
+	} else {
+		state.ServiceCIDR = types.StringNull()
+	}
+	podCIDR, ok := object.Network().GetPodCIDR()
+	if ok {
+		state.PodCIDR = types.StringValue(podCIDR)
+	} else {
+		state.PodCIDR = types.StringNull()
+	}
+	hostPrefix, ok := object.Network().GetHostPrefix()
+	if ok {
+		state.HostPrefix = types.Int64Value(int64(hostPrefix))
+	} else {
+		state.HostPrefix = types.Int64Null()
+	}
+	channel_group, ok := object.Version().GetChannelGroup()
+	if ok {
+		state.ChannelGroup = types.StringValue(channel_group)
+	}
+
+	if awsObj, ok := object.GetAWS(); ok {
+		id := awsObj.PrivateHostedZoneID()
+		arn := awsObj.PrivateHostedZoneRoleARN()
+
+		if len(id) > 0 && len(arn) > 0 {
+			state.PrivateHostedZone = &PrivateHostedZone{
+				RoleARN: types.StringValue(arn),
+				ID:      types.StringValue(id),
+			}
+		}
+	}
+
+	version, ok := object.Version().GetID()
+	// If we're using a non-default channel group, it will have been appended to
+	// the version ID. Remove it before saving state.
+	version = strings.TrimSuffix(version, fmt.Sprintf("-%s", channel_group))
+	version = strings.TrimPrefix(version, "openshift-v")
+	if ok {
+		tflog.Debug(ctx, fmt.Sprintf("actual cluster version: %v", version))
+		state.CurrentVersion = types.StringValue(version)
+	} else {
+		tflog.Debug(ctx, "Unknown cluster version")
+		state.CurrentVersion = types.StringNull()
+
+	}
+	state.State = types.StringValue(string(object.State()))
+	state.Name = types.StringValue(object.Name())
+	state.CloudRegion = types.StringValue(object.Region().ID())
+
+	return nil
+}
+
+func (r *ClusterRosaHcpResource) retryClusterNotFoundWithTimeout(attempts int, sleep time.Duration, ctx context.Context, timeout int64,
+	resource *cmv1.ClusterClient) (bool, error) {
+	isNotFound, err := r.waitTillClusterIsNotFoundWithTimeout(ctx, timeout, resource)
+	if err != nil {
+		if attempts--; attempts > 0 {
+			time.Sleep(sleep)
+			return r.retryClusterNotFoundWithTimeout(attempts, 2*sleep, ctx, timeout, resource)
+		}
+		return isNotFound, err
+	}
+
+	return isNotFound, nil
+}
+
+func (r *ClusterRosaHcpResource) waitTillClusterIsNotFoundWithTimeout(ctx context.Context, timeout int64,
+	resource *cmv1.ClusterClient) (bool, error) {
+	timeoutInMinutes := time.Duration(timeout) * time.Minute
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutInMinutes)
+	defer cancel()
+	_, err := resource.Poll().
+		Interval(pollingIntervalInMinutes * time.Minute).
+		Status(http.StatusNotFound).
+		StartContext(pollCtx)
+	sdkErr, ok := err.(*ocm_errors.Error)
+	if ok && sdkErr.Status() == http.StatusNotFound {
+		tflog.Info(ctx, "Cluster was removed")
+		return true, nil
+	}
+	if err != nil {
+		tflog.Error(ctx, "Can't poll cluster deletion")
+		return false, err
+	}
+
+	return false, nil
+}
+
+func shouldPatchProperties(state, plan *ClusterRosaHcpState) bool {
+	// User defined properties needs update
+	if _, should := common.ShouldPatchMap(state.Properties, plan.Properties); should {
+		return true
+	}
+
+	extractedDefaults := map[string]string{}
+	for k, v := range state.OCMProperties.Elements() {
+		if _, ok := state.Properties.Elements()[k]; !ok {
+			extractedDefaults[k] = v.(types.String).ValueString()
+		}
+	}
+
+	if len(extractedDefaults) != len(OCMProperties) {
+		return true
+	}
+
+	for k, v := range OCMProperties {
+		if _, ok := extractedDefaults[k]; !ok {
+			return true
+		} else if extractedDefaults[k] != v {
+			return true
+		}
+
+	}
+
+	return false
+
+}

--- a/provider/clusterrosahcp/cluster_rosa_hcp_state.go
+++ b/provider/clusterrosahcp/cluster_rosa_hcp_state.go
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterrosahcp
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/proxy"
+)
+
+type ClusterRosaHcpState struct {
+	APIURL                               types.String       `tfsdk:"api_url"`
+	AWSAccountID                         types.String       `tfsdk:"aws_account_id"`
+	BillingAccountID                     types.String       `tfsdk:"billing_account_id"`
+	AWSSubnetIDs                         types.List         `tfsdk:"aws_subnet_ids"`
+	AWSAdditionalComputeSecurityGroupIds types.List         `tfsdk:"aws_additional_compute_security_group_ids"`
+	AWSPrivateLink                       types.Bool         `tfsdk:"aws_private_link"`
+	Private                              types.Bool         `tfsdk:"private"`
+	Sts                                  *Sts               `tfsdk:"sts"`
+	CCSEnabled                           types.Bool         `tfsdk:"ccs_enabled"`
+	HypershiftEnabled                    types.Bool         `tfsdk:"hypershift_enabled"`
+	EtcdEncryption                       types.Bool         `tfsdk:"etcd_encryption"`
+	ChannelGroup                         types.String       `tfsdk:"channel_group"`
+	CloudRegion                          types.String       `tfsdk:"cloud_region"`
+	ComputeMachineType                   types.String       `tfsdk:"compute_machine_type"`
+	WorkerDiskSize                       types.Int64        `tfsdk:"worker_disk_size"`
+	DefaultMPLabels                      types.Map          `tfsdk:"default_mp_labels"`
+	Replicas                             types.Int64        `tfsdk:"replicas"`
+	ConsoleURL                           types.String       `tfsdk:"console_url"`
+	Domain                               types.String       `tfsdk:"domain"`
+	InfraID                              types.String       `tfsdk:"infra_id"`
+	HostPrefix                           types.Int64        `tfsdk:"host_prefix"`
+	ID                                   types.String       `tfsdk:"id"`
+	FIPS                                 types.Bool         `tfsdk:"fips"`
+	KMSKeyArn                            types.String       `tfsdk:"kms_key_arn"`
+	ExternalID                           types.String       `tfsdk:"external_id"`
+	MachineCIDR                          types.String       `tfsdk:"machine_cidr"`
+	MultiAZ                              types.Bool         `tfsdk:"multi_az"`
+	DisableWorkloadMonitoring            types.Bool         `tfsdk:"disable_workload_monitoring"`
+	DisableSCPChecks                     types.Bool         `tfsdk:"disable_scp_checks"`
+	AvailabilityZones                    types.List         `tfsdk:"availability_zones"`
+	Name                                 types.String       `tfsdk:"name"`
+	PodCIDR                              types.String       `tfsdk:"pod_cidr"`
+	Properties                           types.Map          `tfsdk:"properties"`
+	OCMProperties                        types.Map          `tfsdk:"ocm_properties"`
+	Tags                                 types.Map          `tfsdk:"tags"`
+	ServiceCIDR                          types.String       `tfsdk:"service_cidr"`
+	Proxy                                *proxy.Proxy       `tfsdk:"proxy"`
+	State                                types.String       `tfsdk:"state"`
+	Version                              types.String       `tfsdk:"version"`
+	CurrentVersion                       types.String       `tfsdk:"current_version"`
+	DisableWaitingInDestroy              types.Bool         `tfsdk:"disable_waiting_in_destroy"`
+	DestroyTimeout                       types.Int64        `tfsdk:"destroy_timeout"`
+	UpgradeAcksFor                       types.String       `tfsdk:"upgrade_acknowledgements_for"`
+	AdminCredentials                     *AdminCredentials  `tfsdk:"admin_credentials"`
+	PrivateHostedZone                    *PrivateHostedZone `tfsdk:"private_hosted_zone"`
+	BaseDNSDomain                        types.String       `tfsdk:"base_dns_domain"`
+	WaitForCreateComplete                types.Bool         `tfsdk:"wait_for_create_complete"`
+}
+
+type Sts struct {
+	OIDCEndpointURL    types.String    `tfsdk:"oidc_endpoint_url"`
+	OIDCConfigID       types.String    `tfsdk:"oidc_config_id"`
+	Thumbprint         types.String    `tfsdk:"thumbprint"`
+	RoleARN            types.String    `tfsdk:"role_arn"`
+	SupportRoleArn     types.String    `tfsdk:"support_role_arn"`
+	InstanceIAMRoles   InstanceIAMRole `tfsdk:"instance_iam_roles"`
+	OperatorRolePrefix types.String    `tfsdk:"operator_role_prefix"`
+}
+
+type InstanceIAMRole struct {
+	MasterRoleARN types.String `tfsdk:"master_role_arn"`
+	WorkerRoleARN types.String `tfsdk:"worker_role_arn"`
+}
+
+type AdminCredentials struct {
+	Username types.String `tfsdk:"username"`
+	Password types.String `tfsdk:"password"`
+}
+
+type PrivateHostedZone struct {
+	ID      types.String `tfsdk:"id"`
+	RoleARN types.String `tfsdk:"role_arn"`
+}

--- a/provider/clusterrosahcp/sts.go
+++ b/provider/clusterrosahcp/sts.go
@@ -1,0 +1,65 @@
+package clusterrosahcp
+
+import (
+	tfrschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+func stsResource() map[string]tfrschema.Attribute {
+	return map[string]tfrschema.Attribute{
+		"oidc_endpoint_url": tfrschema.StringAttribute{
+			Description: "OIDC Endpoint URL",
+			Optional:    true,
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{
+				// This passes the state through to the plan, so that the OIDC
+				// provider URL will not be "unknown" at plan-time, resulting in
+				// the oidc provider being needlessly replaced. This should be
+				// OK, since the OIDC provider URL is not expected to change.
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"oidc_config_id": tfrschema.StringAttribute{
+			Description: "OIDC Configuration ID",
+			Optional:    true,
+		},
+		"thumbprint": tfrschema.StringAttribute{
+			Description: "SHA1-hash value of the root CA of the issuer URL",
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{
+				// This passes the state through to the plan, so that the OIDC
+				// thumbprint will not be "unknown" at plan-time, resulting in
+				// the oidc provider being needlessly replaced. This should be
+				// OK, since the thumbprint is not expected to change.
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"role_arn": tfrschema.StringAttribute{
+			Description: "Installer Role",
+			Required:    true,
+		},
+		"support_role_arn": tfrschema.StringAttribute{
+			Description: "Support Role",
+			Required:    true,
+		},
+		"instance_iam_roles": tfrschema.SingleNestedAttribute{
+			Description: "Instance IAM Roles",
+			Attributes: map[string]tfrschema.Attribute{
+				"master_role_arn": tfrschema.StringAttribute{
+					Description: "Master/Control Plane Node Role ARN",
+					Required:    true,
+				},
+				"worker_role_arn": tfrschema.StringAttribute{
+					Description: "Worker/Compute Node Role ARN",
+					Required:    true,
+				},
+			},
+			Required: true,
+		},
+		"operator_role_prefix": tfrschema.StringAttribute{
+			Description: "Operator IAM Role prefix",
+			Required:    true,
+		},
+	}
+}

--- a/provider/clusterrosahcp/upgrade/cluster_upgrade.go
+++ b/provider/clusterrosahcp/upgrade/cluster_upgrade.go
@@ -1,0 +1,248 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	semver "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
+	"github.com/zgalor/weberr"
+)
+
+// ClusterUpgrade bundles the description of the upgrade with its current state
+type ClusterUpgrade struct {
+	policy      *cmv1.UpgradePolicy
+	policyState *cmv1.UpgradePolicyState
+}
+
+func (cu *ClusterUpgrade) State() cmv1.UpgradePolicyStateValue {
+	return cu.policyState.Value()
+}
+
+func (cu *ClusterUpgrade) Version() string {
+	return cu.policy.Version()
+}
+
+func (cu *ClusterUpgrade) NextRun() time.Time {
+	return cu.policy.NextRun()
+}
+
+func (cu *ClusterUpgrade) Delete(ctx context.Context, client *cmv1.ClustersClient) error {
+	_, err := client.Cluster(cu.policy.ClusterID()).UpgradePolicies().UpgradePolicy(cu.policy.ID()).Delete().SendContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to delete upgrade policy: %v", err)
+	}
+	return nil
+}
+
+// Get the available upgrade versions that are reachable from a given starting
+// version
+func GetAvailableUpgradeVersions(ctx context.Context, client *cmv1.VersionsClient, fromVersionId string) ([]*cmv1.Version, error) {
+	// Retrieve info about the current version
+	resp, err := client.Version(fromVersionId).Get().SendContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get version information: %v", err)
+	}
+	version := resp.Body()
+
+	// Cycle through the available upgrades and find the ones that are ROSA enabled
+	availableUpgradeVersions := []*cmv1.Version{}
+	for _, v := range version.AvailableUpgrades() {
+		id := ocm.CreateVersionID(v, version.ChannelGroup())
+		resp, err := client.Version(id).
+			Get().
+			Send()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get version information: %v", err)
+		}
+		availableVersion := resp.Body()
+		if availableVersion.ROSAEnabled() {
+			availableUpgradeVersions = append(availableUpgradeVersions, availableVersion)
+		}
+	}
+
+	return availableUpgradeVersions, nil
+}
+
+// Get the list of upgrade policies associated with a cluster
+func GetScheduledUpgrades(ctx context.Context, client *cmv1.ClustersClient, clusterId string) ([]ClusterUpgrade, error) {
+	upgrades := []ClusterUpgrade{}
+
+	// Get the upgrade policies for the cluster
+	upgradePolicies := []*cmv1.UpgradePolicy{}
+	upgradeClient := client.Cluster(clusterId).UpgradePolicies()
+	page := 1
+	size := 100
+	for {
+		resp, err := upgradeClient.List().
+			Page(page).
+			Size(size).
+			SendContext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list upgrade policies: %v", err)
+		}
+		upgradePolicies = append(upgradePolicies, resp.Items().Slice()...)
+		if resp.Size() < size {
+			break
+		}
+		page++
+	}
+
+	// For each upgrade policy, get its state
+	for _, policy := range upgradePolicies {
+		// We only care about OSD upgrades (i.e., not CVE upgrades)
+		if policy.UpgradeType() != "OSD" {
+			continue
+		}
+		resp, err := upgradeClient.UpgradePolicy(policy.ID()).
+			State().
+			Get().
+			SendContext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get upgrade policy state: %v", err)
+		}
+		upgrades = append(upgrades, ClusterUpgrade{
+			policy:      policy,
+			policyState: resp.Body(),
+		})
+	}
+
+	return upgrades, nil
+}
+
+// Check the provided list of upgrades, canceling pending upgrades that are not
+// for the correct version, and returning an error if there is already an
+// upgrade in progress that is not for the desired version
+func CheckAndCancelUpgrades(ctx context.Context, client *cmv1.ClustersClient, upgrades []ClusterUpgrade, desiredVersion *semver.Version) (bool, error) {
+	correctUpgradePending := false
+	tenMinFromNow := time.Now().UTC().Add(10 * time.Minute)
+
+	for _, upgrade := range upgrades {
+		tflog.Debug(ctx, fmt.Sprintf("Found existing upgrade policy to %s in state %s", upgrade.Version(), upgrade.State()))
+		toVersion, err := semver.NewVersion(upgrade.Version())
+		if err != nil {
+			return false, fmt.Errorf("failed to parse upgrade version: %v", err)
+		}
+		switch upgrade.State() {
+		case cmv1.UpgradePolicyStateValueDelayed, cmv1.UpgradePolicyStateValueStarted:
+			if desiredVersion.Equal(toVersion) {
+				correctUpgradePending = true
+			} else {
+				return false, fmt.Errorf("a cluster upgrade is already in progress")
+			}
+		case cmv1.UpgradePolicyStateValuePending, cmv1.UpgradePolicyStateValueScheduled:
+			if desiredVersion.Equal(toVersion) && upgrade.NextRun().Before(tenMinFromNow) {
+				correctUpgradePending = true
+			} else {
+				// The upgrade is not one we want, so cancel it
+				if err := upgrade.Delete(ctx, client); err != nil {
+					return false, fmt.Errorf("failed to delete upgrade policy: %v", err)
+				}
+			}
+		}
+	}
+	return correctUpgradePending, nil
+}
+
+func AckVersionGate(
+	gateAgreementsClient *cmv1.VersionGateAgreementsClient,
+	gateID string) error {
+	agreement, err := cmv1.NewVersionGateAgreement().
+		VersionGate(cmv1.NewVersionGate().ID(gateID)).
+		Build()
+	if err != nil {
+		return err
+	}
+	response, err := gateAgreementsClient.Add().Body(agreement).Send()
+	if err != nil {
+		return common.HandleErr(response.Error(), err)
+	}
+	return nil
+}
+
+// Construct a list of missing gate agreements for upgrade to a given cluster version
+// Returns: a list of all un-acked gate agreements, a string describing the ones that need user ack, and an error
+func CheckMissingAgreements(version string,
+	clusterKey string, upgradePoliciesClient *cmv1.UpgradePoliciesClient) ([]*cmv1.VersionGate, string, error) {
+	upgradePolicyBuilder := cmv1.NewUpgradePolicy().
+		ScheduleType("manual").
+		Version(version)
+	upgradePolicy, err := upgradePolicyBuilder.Build()
+	if err != nil {
+		return []*cmv1.VersionGate{}, "", fmt.Errorf("failed to build upgrade policy: %v", err)
+	}
+
+	// check if the cluster upgrade requires gate agreements
+	gates, err := getMissingGateAgreements(upgradePolicy, upgradePoliciesClient)
+	if err != nil {
+		return []*cmv1.VersionGate{}, "", fmt.Errorf("failed to check for missing gate agreements upgrade for "+
+			"cluster '%s': %v", clusterKey, err)
+	}
+	str := "\nMissing required acknowledgements to schedule upgrade." +
+		"\nRead the below description and acknowledge to proceed with upgrade." +
+		"\nDescription:"
+	counter := 1
+	for _, gate := range gates {
+		if !gate.STSOnly() { // STS-only gates don't require user acknowledgement
+			str = fmt.Sprintf("%s\n%d) %s\n", str, counter, gate.Description())
+
+			if gate.WarningMessage() != "" {
+				str = fmt.Sprintf("%s   Warning:     %s\n", str, gate.WarningMessage())
+			}
+			str = fmt.Sprintf("%s   URL:         %s\n", str, gate.DocumentationURL())
+			counter++
+		}
+	}
+	return gates, str, nil
+}
+
+func getMissingGateAgreements(
+	upgradePolicy *cmv1.UpgradePolicy,
+	upgradePoliciesClient *cmv1.UpgradePoliciesClient) ([]*cmv1.VersionGate, error) {
+	response, err := upgradePoliciesClient.Add().Parameter("dryRun", true).Body(upgradePolicy).Send()
+
+	if err != nil {
+		if response.Error() != nil {
+			// parse gates list
+			errorDetails, ok := response.Error().GetDetails()
+			if !ok {
+				return []*cmv1.VersionGate{}, common.HandleErr(response.Error(), err)
+			}
+			data, err := json.Marshal(errorDetails)
+			if err != nil {
+				return []*cmv1.VersionGate{}, common.HandleErr(response.Error(), err)
+			}
+			gates, err := cmv1.UnmarshalVersionGateList(data)
+			if err != nil {
+				return []*cmv1.VersionGate{}, common.HandleErr(response.Error(), err)
+			}
+			// return original error if invaild version gate detected
+			if len(gates) > 0 && gates[0].ID() == "" {
+				errType := weberr.ErrorType(response.Error().Status())
+				return []*cmv1.VersionGate{}, errType.Set(weberr.Errorf(response.Error().Reason()))
+			}
+			return gates, nil
+		}
+	}
+	return []*cmv1.VersionGate{}, nil
+}

--- a/provider/clusterrosahcp/validators.go
+++ b/provider/clusterrosahcp/validators.go
@@ -1,0 +1,74 @@
+package clusterrosahcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common/attrvalidators"
+)
+
+var availabilityZoneValidator = attrvalidators.NewStringValidator("AZ should be valid for cloud_region", func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	az := req.ConfigValue.ValueString()
+	regionAttr := basetypes.StringValue{}
+	err := req.Config.GetAttribute(ctx, path.Root("cloud_region"), &regionAttr)
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid AZ", "Failed to fetch cloud_region")
+		return
+	}
+	region := regionAttr.ValueString()
+	if !strings.Contains(az, region) {
+		msg := fmt.Sprintf("Invalid AZ '%s' for region '%s'.", az, region)
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid AZ", msg)
+		return
+	}
+})
+
+var privateHZValidator = attrvalidators.NewObjectValidator("proxy map should not include an hard coded OCM proxy",
+	func(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+		if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+			return
+		}
+
+		privateHZ := PrivateHostedZone{}
+		d := req.ConfigValue.As(ctx, &privateHZ, basetypes.ObjectAsOptions{})
+		if d.HasError() {
+			// No attribute to validate
+			return
+		}
+		errSum := "Invalid private_hosted_zone attribute assignment"
+
+		// validate ID and ARN are not empty
+		if common.IsStringAttributeKnownAndEmpty(privateHZ.ID) || common.IsStringAttributeKnownAndEmpty(privateHZ.RoleARN) {
+			resp.Diagnostics.AddError(errSum, "Invalid configuration. 'private_hosted_zone.id' and 'private_hosted_zone.role_arn' are required")
+			return
+		}
+
+	})
+
+var propertiesValidator = attrvalidators.NewMapValidator("properties map should not include an hard coded OCM properties",
+	func(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+		if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+			return
+		}
+		propertiesElements := make(map[string]types.String, len(req.ConfigValue.Elements()))
+		d := req.ConfigValue.ElementsAs(ctx, &propertiesElements, false)
+		if d.HasError() {
+			// No attribute to validate
+			return
+		}
+
+		for k := range propertiesElements {
+			if _, isDefaultKey := OCMProperties[k]; isDefaultKey {
+				errHead := "Invalid property key."
+				errDesc := fmt.Sprintf("Can not override reserved properties keys. %s is a reserved property key", k)
+				resp.Diagnostics.AddError(errHead, errDesc)
+				return
+			}
+		}
+	})

--- a/provider/ocm_policies/ocm_policies_data_source.go
+++ b/provider/ocm_policies/ocm_policies_data_source.go
@@ -37,6 +37,10 @@ const (
 	IngressOperator          = "openshift_ingress_operator_cloud_credentials_policy"
 	SharedVpcIngressOperator = "shared_vpc_openshift_ingress_operator_cloud_credentials_policy"
 	MachineAPI               = "openshift_machine_api_aws_cloud_credentials_policy"
+	CapaController           = "openshift_capa_controller_manager_credentials_policy"
+	ControlPlane             = "openshift_control_plane_operator_credentials_policy"
+	KmsProvider              = "openshift_kms_provider_credentials_policy"
+	KubeController           = "openshift_kube_controller_manager_credentials_policy"
 
 	// Policy IDs from type account roles
 	Installer            = "sts_installer_permission_policy"
@@ -86,6 +90,18 @@ func (s *OcmPoliciesDataSource) Schema(ctx context.Context, req datasource.Schem
 						Computed: true,
 					},
 					MachineAPI: schema.StringAttribute{
+						Computed: true,
+					},
+					CapaController: schema.StringAttribute{
+						Computed: true,
+					},
+					ControlPlane: schema.StringAttribute{
+						Computed: true,
+					},
+					KmsProvider: schema.StringAttribute{
+						Computed: true,
+					},
+					KubeController: schema.StringAttribute{
 						Computed: true,
 					},
 				},
@@ -161,6 +177,14 @@ func (s *OcmPoliciesDataSource) Read(ctx context.Context, req datasource.ReadReq
 			operatorRolePolicies.SharedVpcIngressOperator = types.StringValue(awsPolicy.Details())
 		case MachineAPI:
 			operatorRolePolicies.MachineAPI = types.StringValue(awsPolicy.Details())
+		case CapaController:
+			operatorRolePolicies.CapaController = types.StringValue(awsPolicy.Details())
+		case ControlPlane:
+			operatorRolePolicies.ControlPlane = types.StringValue(awsPolicy.Details())
+		case KmsProvider:
+			operatorRolePolicies.KmsProvider = types.StringValue(awsPolicy.Details())
+		case KubeController:
+			operatorRolePolicies.KubeController = types.StringValue(awsPolicy.Details())
 		// account roles
 		case Installer:
 			accountRolePolicies.Installer = types.StringValue(awsPolicy.Details())

--- a/provider/ocm_policies/ocm_policies_state.go
+++ b/provider/ocm_policies/ocm_policies_state.go
@@ -31,6 +31,10 @@ type OperatorRolePolicies struct {
 	IngressOperator          types.String `tfsdk:"openshift_ingress_operator_cloud_credentials_policy"`
 	SharedVpcIngressOperator types.String `tfsdk:"shared_vpc_openshift_ingress_operator_cloud_credentials_policy"`
 	MachineAPI               types.String `tfsdk:"openshift_machine_api_aws_cloud_credentials_policy"`
+	CapaController           types.String `tfsdk:"openshift_capa_controller_manager_credentials_policy"`
+	ControlPlane             types.String `tfsdk:"openshift_control_plane_operator_credentials_policy"`
+	KmsProvider              types.String `tfsdk:"openshift_kms_provider_credentials_policy"`
+	KubeController           types.String `tfsdk:"openshift_kube_controller_manager_credentials_policy"`
 }
 
 type AccountRolePolicies struct {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -34,7 +34,9 @@ import (
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/cloudprovider"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/cluster"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterautoscaler"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterdata"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterrosaclassic"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterrosahcp"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterwaiter"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/defaultingress"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/dnsdomain"
@@ -206,6 +208,7 @@ func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
 		oidcconfig.New,
 		oidcconfiginput.New,
 		clusterrosaclassic.New,
+		clusterrosahcp.New,
 		identityprovider.New,
 		cluster.New,
 		clusterautoscaler.New,
@@ -222,5 +225,6 @@ func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSour
 		rosa_operator_roles.New,
 		versions.New,
 		info.New,
+		clusterdata.New,
 	}
 }

--- a/provider/rosa_operator_roles/rosa_operator_roles_state.go
+++ b/provider/rosa_operator_roles/rosa_operator_roles_state.go
@@ -22,6 +22,7 @@ type RosaOperatorRolesState struct {
 	OperatorRolePrefix types.String       `tfsdk:"operator_role_prefix"`
 	AccountRolePrefix  types.String       `tfsdk:"account_role_prefix"`
 	OperatorIAMRoles   []*OperatorIAMRole `tfsdk:"operator_iam_roles"`
+	HypershiftEnabled  types.Bool         `tfsdk:"hypershift_enabled"`
 }
 
 type OperatorIAMRole struct {


### PR DESCRIPTION
### Added:
cluster_rosa_hcp_resource.go          # Create ROSA HCP cluster
cluster_rosa_hcp_state.go                # Create ROSA HCP cluster
cluster_data_source.go                      # Retrive cluster api_url and console_url
cluster_data_state.go                         # Retrive cluster api_url and console_url

### Modified:
cluster.go
cluster_waiter.go
ocm_policies_data_source.go
ocm_policies_state.go
rosa_operator_roles_data_source.go
rosa_operator_roles_state.go
provider.go