### PR TITLE
OCM-5233 | fix: remove immutable from compute SGs

### DIFF
--- a/provider/cluster/cluster_resource.go
+++ b/provider/cluster/cluster_resource.go
@@ -151,9 +151,6 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Description: "AWS additional compute security group ids.",
 				ElementType: types.StringType,
 				Optional:    true,
-				PlanModifiers: []planmodifier.List{
-					common.Immutable(),
-				},
 			},
 			"aws_additional_infra_security_group_ids": schema.ListAttribute{
 				Description: "AWS additional infra security group ids.",

--- a/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosaclassic/cluster_rosa_classic_resource.go
@@ -278,9 +278,6 @@ func (r *ClusterRosaClassicResource) Schema(ctx context.Context, req resource.Sc
 				Description: "AWS additional compute security group ids.",
 				ElementType: types.StringType,
 				Optional:    true,
-				PlanModifiers: []planmodifier.List{
-					common.Immutable(),
-				},
 			},
 			"aws_additional_infra_security_group_ids": schema.ListAttribute{
 				Description: "AWS additional infra security group ids.",

--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -898,7 +898,6 @@ func (r *MachinePoolResource) populateState(object *cmv1.MachinePool, state *Mac
 			}
 		} else {
 			state.UseSpotInstances = types.BoolNull()
-			state.MaxReplicas = types.Int64Null()
 		}
 		if additionalSecurityGroups, ok := getAWS.GetAdditionalSecurityGroupIds(); ok {
 			additionalSecurityGroupsList, err := common.StringArrayToList(additionalSecurityGroups)


### PR DESCRIPTION
Related issue: [OCM-5233](https://issues.redhat.com//browse/OCM-5233)

Immutable doesn't allow updates to the state even though we are not really updating or tracking this in the state at all