### PR TITLE
OCM-4483: add unified_ path for account/operator case

### DIFF
--- a/tests/ci/profiles/tf_cluster_profile.yml
+++ b/tests/ci/profiles/tf_cluster_profile.yml
@@ -27,6 +27,7 @@ profiles:
     imdsv2: "optional"
     oidc_config: "managed"
     admin_enabled: false
+    unified_acc_role_path: ""
 # rosa-sts-ad :: creating unmanaged oidc config cluster 
 - as: rosa-sts-ad
   cluster:
@@ -57,6 +58,7 @@ profiles:
     admin_enabled: true
     additional_sg_number: 4
     worker_disk_size: 200
+    unified_acc_role_path: "/unified/"
 # rosa-sts-up :: creating a managed cluster for upgrade purpose
 - as: rosa-sts-up
   cluster:

--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/rosa/pkg/aws"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	ci "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
@@ -276,6 +277,13 @@ var _ = Describe("TF Test", func() {
 						Expect(cluster.Nodes().ComputeRootVolume().AWS().Size()).To(Equal(profile.WorkerDiskSize))
 					}
 				})
+		})
+		Context("Author:amalykhi-Medium-OCP-63138 @OCP-63138 @amalykhi", func() {
+			It("Create sts cluster with account roles/policies unified path", ci.Day1Post, ci.Medium, func() {
+				unifiedPath, err := aws.GetPathFromAccountRole(cluster, aws.AccountRoles[aws.InstallerAccountRole].Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(profile.UnifiedAccRolesPath).Should(ContainSubstring(unifiedPath))
+			})
 		})
 	})
 })

--- a/tests/tf-manifests/aws/account-roles/main.tf
+++ b/tests/tf-manifests/aws/account-roles/main.tf
@@ -41,4 +41,5 @@ module "create_account_roles" {
   rosa_openshift_version = local.major_version
   account_role_policies  = data.rhcs_policies.all_policies.account_role_policies
   operator_role_policies = data.rhcs_policies.all_policies.operator_role_policies
+  path                   = var.path
 }

--- a/tests/tf-manifests/aws/account-roles/variables.tf
+++ b/tests/tf-manifests/aws/account-roles/variables.tf
@@ -26,3 +26,9 @@ variable "channel_group" {
   type    = string
   default = "stable"
 }
+
+variable "path" {
+  description = "(Optional) The arn path for the account/operator roles as well as their policies."
+  type        = string
+  default     = null
+}

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/main.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/main.tf
@@ -41,7 +41,6 @@ module "oidc_config_input_resources" {
   count   = var.oidc_config == "un-managed" ? 1 : 0
   source  = "terraform-redhat/rosa-sts/aws"
   version = ">= 0.0.14"
-
   create_oidc_config_resources = var.oidc_config == "un-managed"
 
   bucket_name             = rhcs_rosa_oidc_config_input.oidc_input[0].bucket_name
@@ -52,20 +51,23 @@ module "oidc_config_input_resources" {
   private_key_secret_name = rhcs_rosa_oidc_config_input.oidc_input[0].private_key_secret_name
 }
 
+locals {
+  path = coalesce(var.path, "/")
+}
+
 # Create unmanaged OIDC config in OCM
 resource "rhcs_rosa_oidc_config" "oidc_config_unmanaged" {
   count              = var.oidc_config == "un-managed" ? 1 : 0
   managed            = false
   secret_arn         = module.oidc_config_input_resources[0].secret_arn
   issuer_url         = rhcs_rosa_oidc_config_input.oidc_input[0].issuer_url
-  installer_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role"
+  installer_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Installer-Role"
 }
 
 data "rhcs_rosa_operator_roles" "operator_roles" {
   operator_role_prefix = var.operator_role_prefix
-  account_role_prefix  = var.account_role_prefix
+  account_role_prefix  = var.account_role_prefix 
 }
-
 
 # Create oidc provider and operator roles on AWS
 module "operator_roles_and_oidc_provider" {
@@ -79,4 +81,5 @@ module "operator_roles_and_oidc_provider" {
   rh_oidc_provider_thumbprint = var.oidc_config == "managed" ? rhcs_rosa_oidc_config.oidc_config_managed[0].thumbprint : rhcs_rosa_oidc_config.oidc_config_unmanaged[0].thumbprint
   rh_oidc_provider_url        = var.oidc_config == "managed" ? rhcs_rosa_oidc_config.oidc_config_managed[0].oidc_endpoint_url : rhcs_rosa_oidc_config.oidc_config_unmanaged[0].oidc_endpoint_url
   operator_roles_properties   = data.rhcs_rosa_operator_roles.operator_roles.operator_iam_roles
+  path = local.path
 }

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/variables.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/variables.tf
@@ -17,15 +17,24 @@ variable "operator_role_prefix" {
   type    = string
   default = ""
 }
+
 variable "oidc_config" {
   type    = string
   default = ""
 }
+
 variable "aws_region" {
   type    = string
   default = "us-east-2"
 }
+
 variable "rhcs_environment" {
   type    = string
   default = "staging"
+}
+
+variable "path" {
+  description = "(Optional) The arn path for the account/operator roles as well as their policies."
+  type        = string
+  default     = null
 }

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -35,12 +35,13 @@ locals {
 }
 
 locals {
+  path = coalesce(var.path, "/")
   sts_roles = {
-    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Installer-Role",
-    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Support-Role",
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Installer-Role",
+    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Support-Role",
     instance_iam_roles = {
-      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-ControlPlane-Role",
-      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.account_role_prefix}-Worker-Role"
+      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-ControlPlane-Role",
+      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Worker-Role"
     },
     operator_role_prefix = var.operator_role_prefix
     oidc_config_id       = var.oidc_config_id

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -207,3 +207,9 @@ variable "additional_control_plane_security_groups" {
   type    = list(string)
   default = null
 }
+
+variable "path" {
+  description = "(Optional) The arn path for the account/operator roles as well as their policies."
+  type        = string
+  default     = null
+}

--- a/tests/utils/exec/account-roles.go
+++ b/tests/utils/exec/account-roles.go
@@ -9,12 +9,13 @@ import (
 )
 
 type AccountRolesArgs struct {
-	AccountRolePrefix string `json:"account_role_prefix,omitempty"`
-	OCMENV            string `json:"rhcs_environment,omitempty"`
-	OpenshiftVersion  string `json:"openshift_version,omitempty"`
-	Token             string `json:"token,omitempty"`
-	URL               string `json:"url,omitempty"`
-	ChannelGroup      string `json:"channel_group,omitempty"`
+	AccountRolePrefix   string `json:"account_role_prefix,omitempty"`
+	OCMENV              string `json:"rhcs_environment,omitempty"`
+	OpenshiftVersion    string `json:"openshift_version,omitempty"`
+	Token               string `json:"token,omitempty"`
+	URL                 string `json:"url,omitempty"`
+	ChannelGroup        string `json:"channel_group,omitempty"`
+	UnifiedAccRolesPath string `json:"path,omitempty"`
 }
 
 type AccountRolesOutput struct {

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -41,6 +41,7 @@ type ClusterCreationArgs struct {
 	AdminCredentials                     map[string]string `json:"admin_credentials,omitempty"`
 	DisableUWM                           bool              `json:"disable_workload_monitoring,omitempty"`
 	Proxy                                *Proxy            `json:"proxy,omitempty"`
+	UnifiedAccRolesPath                  string            `json:"path,omitempty"`
 }
 type Proxy struct {
 	HTTPProxy             string `json:"http_proxy,omitempty"`

--- a/tests/utils/exec/oidc-provider-operator-roles.go
+++ b/tests/utils/exec/oidc-provider-operator-roles.go
@@ -9,13 +9,14 @@ import (
 )
 
 type OIDCProviderOperatorRolesArgs struct {
-	AccountRolePrefix  string `json:"account_role_prefix,omitempty"`
-	OperatorRolePrefix string `json:"operator_role_prefix,omitempty"`
-	Token              string `json:"token,omitempty"`
-	URL                string `json:"url,omitempty"`
-	OIDCConfig         string `json:"oidc_config,omitempty"`
-	AWSRegion          string `json:"aws_region,omitempty"`
-	OCMENV             string `json:"rhcs_environment,omitempty"`
+	AccountRolePrefix   string `json:"account_role_prefix,omitempty"`
+	OperatorRolePrefix  string `json:"operator_role_prefix,omitempty"`
+	Token               string `json:"token,omitempty"`
+	URL                 string `json:"url,omitempty"`
+	OIDCConfig          string `json:"oidc_config,omitempty"`
+	AWSRegion           string `json:"aws_region,omitempty"`
+	OCMENV              string `json:"rhcs_environment,omitempty"`
+	UnifiedAccRolesPath string `json:"path,omitempty"`
 }
 
 type OIDCProviderOperatorRolesOutput struct {


### PR DESCRIPTION
Ran 1 of 44 Specs in 1.704 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 42 Skipped
PASS

Ginkgo ran 1 suite in 2.954991039s
Test Suite Passed
https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-63138

https://issues.redhat.com/browse/OCM-4483