### PR TITLE
OCM-5346 | fix: Do not wait for clusters in terminal states to be ready

### DIFF
--- a/provider/kubeletconfig/kubeletconfig_resource.go
+++ b/provider/kubeletconfig/kubeletconfig_resource.go
@@ -100,7 +100,7 @@ func (k *KubeletConfigResource) Create(ctx context.Context, req resource.CreateR
 	if err := k.clusterWait.WaitForClusterToBeReady(ctx, clusterId); err != nil {
 		resp.Diagnostics.AddError(
 			"Cluster is not ready",
-			fmt.Sprintf("Cluster with id '%s' is not in the ready plan: %v", clusterId, err),
+			fmt.Sprintf("Cluster with id '%s' is not in the ready state: %v", clusterId, err),
 		)
 		return
 	}


### PR DESCRIPTION
This PR updates the cluster wait functions to ensure that we only wait for a cluster that is in a state that can become `ready`. A cluster that is in a state `error` or `uninstalling` will never become `ready` and we can shortcut the waiting function.