### PR TITLE
OCM-5345 | fix: Allow pod_pids_limit to be set via a variable

### DIFF
--- a/provider/kubeletconfig/kubeletconfig_validators.go
+++ b/provider/kubeletconfig/kubeletconfig_validators.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
 )
 
 const (
@@ -49,6 +50,10 @@ func (p PidsLimitValidator) MarkdownDescription(_ context.Context) string {
 }
 
 func (p PidsLimitValidator) ValidateInt64(_ context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+
+	if !common.HasValue(req.ConfigValue) {
+		return
+	}
 
 	requestedPidsLimit := req.ConfigValue.ValueInt64()
 	if requestedPidsLimit < MinPodPidsLimit {

--- a/provider/kubeletconfig/kubeletconfig_validators_test.go
+++ b/provider/kubeletconfig/kubeletconfig_validators_test.go
@@ -109,5 +109,27 @@ var _ = Describe("KubeletConfig Validators", func() {
 			Expect(resp.Diagnostics.HasError()).To(BeFalse())
 			Expect(resp.Diagnostics.Errors().ErrorsCount()).To(Equal(0))
 		})
+
+		It("Passes validation if podPidsLimit is currently unknown", func() {
+			req := validator.Int64Request{
+				Path:        path.Root("pod_pids_limit"),
+				ConfigValue: types.Int64Unknown(),
+			}
+
+			pidsLimitValidator.ValidateInt64(ctx, req, resp)
+			Expect(resp.Diagnostics.HasError()).To(BeFalse())
+			Expect(resp.Diagnostics.Errors().ErrorsCount()).To(Equal(0))
+		})
+
+		It("Passes validation if podPidsLimit is currently null", func() {
+			req := validator.Int64Request{
+				Path:        path.Root("pod_pids_limit"),
+				ConfigValue: types.Int64Null(),
+			}
+
+			pidsLimitValidator.ValidateInt64(ctx, req, resp)
+			Expect(resp.Diagnostics.HasError()).To(BeFalse())
+			Expect(resp.Diagnostics.Errors().ErrorsCount()).To(Equal(0))
+		})
 	})
 })


### PR DESCRIPTION
This PR updates the validator for the `pod_pids_limit` field of `KubeletConfig` to defer validation when the value is currently unknown or null. 

`null` values are handled by TF itself with a much clearer error message. `unknown` values are possible during the `configure` method of the provider when the value is set via a variable, see: https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values#when-can-a-value-be-unknown-or-null
