### PR TITLE
add import negative tests

### DIFF
--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -791,26 +791,36 @@ var _ = Describe("TF Test", func() {
 		Describe("Validate terraform Import operations", func() {
 			var (
 				googleIdpName         = "google-idp"
+				gitLabIdpName         = "gitlab-idp"
 				googleIDPClientSecret string
 				googleIDPClientId     string
+				gitlabIDPClientId     string
+				gitlabIDPClientSecret string
 			)
 
 			BeforeEach(func() {
 				idpService.google = *exe.NewIDPService(con.GoogleDir)        // init new google service
+				idpService.gitlab = *exe.NewIDPService(con.GitlabDir)        // init new gitlab service
 				importService = *exe.NewImportService(con.ImportResourceDir) // init new import service
 			})
 
 			AfterEach(func() {
 				err := idpService.google.Destroy()
 				Expect(err).ToNot(HaveOccurred())
+
+				err = idpService.gitlab.Destroy()
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			Context("Author:smiron-Medium-OCP-65981 @OCP-65981 @smiron", func() {
 				It("OCP-65981 - rhcs_identity_provider resource can be imported by the terraform import command",
 					ci.Day2, ci.Medium, ci.FeatureIDP, ci.FeatureImport, func() {
-						By("Create sample idp to test the import functionality")
+
+						By("Create sample idps to test the import functionality")
 						googleIDPClientSecret = h.GenerateRandomStringWithSymbols(20)
 						googleIDPClientId = h.GenerateRandomStringWithSymbols(30)
+						gitlabIDPClientId = h.GenerateRandomStringWithSymbols(20)
+						gitlabIDPClientSecret = h.GenerateRandomStringWithSymbols(30)
 
 						idpParam := &exe.IDPArgs{
 							Token:        token,
@@ -820,15 +830,24 @@ var _ = Describe("TF Test", func() {
 							ClientSecret: googleIDPClientSecret,
 							HostedDomain: con.HostedDomain,
 						}
-
 						Expect(idpService.google.Apply(idpParam, false)).To(Succeed())
+
+						idpParam = &exe.IDPArgs{
+							Token:        token,
+							ClusterID:    clusterID,
+							Name:         gitLabIdpName,
+							ClientID:     gitlabIDPClientId,
+							ClientSecret: gitlabIDPClientSecret,
+							URL:          con.GitLabURL,
+						}
+						Expect(idpService.gitlab.Apply(idpParam, false)).To(Succeed())
 
 						By("Run the command to import the idp")
 						importParam := &exe.ImportArgs{
 							Token:        token,
 							ClusterID:    clusterID,
 							ResourceKind: "rhcs_identity_provider",
-							ResourceName: "idp_import",
+							ResourceName: "idp_google_import",
 							ObjectName:   googleIdpName,
 						}
 						Expect(importService.Import(importParam)).To(Succeed())
@@ -838,6 +857,34 @@ var _ = Describe("TF Test", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(output).To(ContainSubstring(googleIDPClientId))
 						Expect(output).To(ContainSubstring(con.HostedDomain))
+
+						By("Validate terraform import with no idp object name returns error")
+						var unknownIdpName = "unknown_idp_name"
+						importParam = &exe.ImportArgs{
+							Token:        token,
+							ClusterID:    clusterID,
+							ResourceKind: "rhcs_identity_provider",
+							ResourceName: "idp_google_import",
+							ObjectName:   unknownIdpName,
+						}
+
+						err = importService.Import(importParam)
+						Expect(err.Error()).To(ContainSubstring("identity provider '%s' not found", unknownIdpName))
+
+						By("Validate terraform import with no clusterID returns error")
+
+						var unknownClusterID = h.GenerateRandomStringWithSymbols(20)
+						importParam = &exe.ImportArgs{
+							Token:        token,
+							ClusterID:    unknownClusterID,
+							ResourceKind: "rhcs_identity_provider",
+							ResourceName: "idp_gitlab_import",
+							ObjectName:   gitLabIdpName,
+						}
+
+						err = importService.Import(importParam)
+						Expect(err.Error()).To(ContainSubstring("'%s' not found", unknownClusterID))
+
 					})
 			})
 		})

--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -17,6 +17,7 @@ import (
 	con "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
 	exe "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/exec"
 	H "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/openshift"
 )
 
@@ -162,6 +163,18 @@ var _ = Describe("TF Test", func() {
 					Expect(output).To(ContainSubstring(profile.ClusterName))
 					Expect(output).To(ContainSubstring(profile.Region))
 					Expect(output).To(ContainSubstring(profile.ChannelGroup))
+
+					By("Validate terraform import with no clusterID returns error")
+					var unknownClusterID = h.GenerateRandomStringWithSymbols(20)
+					importParam = &exe.ImportArgs{
+						Token:        token,
+						ClusterID:    unknownClusterID,
+						ResourceKind: "rhcs_cluster_rosa_classic",
+						ResourceName: "rosa_import_no_cluster_id",
+					}
+
+					err = importService.Import(importParam)
+					Expect(err.Error()).To(ContainSubstring("Cannot import non-existent remote object"))
 
 					// skip due to bug :: OCM-5246
 					// Expect(output).To(ContainSubstring(profile.ComputeMachineType))

--- a/tests/tf-manifests/rhcs/resource-import/main.tf
+++ b/tests/tf-manifests/rhcs/resource-import/main.tf
@@ -12,5 +12,7 @@ provider "rhcs" {
 }
 
 resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster_import" {}
-resource "rhcs_identity_provider" "idp_import" {}
+resource "rhcs_cluster_rosa_classic" "rosa_import_no_cluster_id" {}
+resource "rhcs_identity_provider" "idp_google_import" {}
+resource "rhcs_identity_provider" "idp_gitlab_import" {}
 resource "rhcs_machine_pool" "mp_import" {}


### PR DESCRIPTION
Adding negative scenarios to the terraform import feature.

**rosa-classic import execution** ([OCP-65684](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-65684)):

<img width="887" alt="image" src="https://github.com/terraform-redhat/terraform-provider-rhcs/assets/54883783/0fd9e158-dd71-451e-a240-a4abbf33a37d">

<br></br>
**idp import execution** ([OCP-65981](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-65981)):

<img width="826" alt="image" src="https://github.com/terraform-redhat/terraform-provider-rhcs/assets/54883783/c5d2f99d-51fd-4cee-bbf2-0d92699adf1d">

