### PR TITLE
kubeletconfig automation Finished automation of OCP-70128  and OCP-70129 and remove token from manifests file

### DIFF
--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -128,7 +128,6 @@ func PrepareAccountRoles(token string, accountRolePrefix string, accountRolesPat
 	args := &EXE.AccountRolesArgs{
 		AccountRolePrefix:   accountRolePrefix,
 		OpenshiftVersion:    openshiftVersion,
-		Token:               token,
 		ChannelGroup:        channelGroup,
 		UnifiedAccRolesPath: accountRolesPath,
 	}
@@ -148,7 +147,6 @@ func PrepareOIDCProviderAndOperatorRoles(token string, oidcConfigType string, op
 	args := &EXE.OIDCProviderOperatorRolesArgs{
 		AccountRolePrefix:   accountRolePrefix,
 		OperatorRolePrefix:  operatorRolePrefix,
-		Token:               token,
 		OIDCConfig:          oidcConfigType,
 		AWSRegion:           awsRegion,
 		UnifiedAccRolesPath: accountRolesPath,
@@ -200,7 +198,7 @@ func GenerateClusterCreationArgsByProfile(token string, profile *Profile) (clust
 	profile.Version = PrepareVersion(RHCSConnection, profile.Version, profile.ChannelGroup, profile)
 
 	clusterArgs = &EXE.ClusterCreationArgs{
-		Token:            token,
+		// Token:            token,
 		OpenshiftVersion: profile.Version,
 	}
 
@@ -424,7 +422,7 @@ func DestroyRHCSClusterByProfile(token string, profile *Profile) error {
 	clusterService, err := EXE.NewClusterService(profile.ManifestsDIR)
 	Expect(err).ToNot(HaveOccurred())
 	clusterArgs := &EXE.ClusterCreationArgs{
-		Token:              token,
+		// Token:              token,
 		AWSRegion:          profile.Region,
 		AccountRolePrefix:  "",
 		OperatorRolePrefix: "",
@@ -470,7 +468,6 @@ func DestroyRHCSClusterByProfile(token string, profile *Profile) error {
 			return err
 		}
 		args := &EXE.OIDCProviderOperatorRolesArgs{
-			Token:      token,
 			OIDCConfig: profile.OIDCConfig,
 			AWSRegion:  profile.Region,
 		}
@@ -484,9 +481,7 @@ func DestroyRHCSClusterByProfile(token string, profile *Profile) error {
 		if err != nil {
 			return err
 		}
-		accargs := &EXE.AccountRolesArgs{
-			Token: token,
-		}
+		accargs := &EXE.AccountRolesArgs{}
 		err = accService.Destroy(accargs)
 		if err != nil {
 			return err

--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -422,7 +422,6 @@ func DestroyRHCSClusterByProfile(token string, profile *Profile) error {
 	clusterService, err := EXE.NewClusterService(profile.ManifestsDIR)
 	Expect(err).ToNot(HaveOccurred())
 	clusterArgs := &EXE.ClusterCreationArgs{
-		// Token:              token,
 		AWSRegion:          profile.Region,
 		AccountRolePrefix:  "",
 		OperatorRolePrefix: "",

--- a/tests/e2e/account_roles_test.go
+++ b/tests/e2e/account_roles_test.go
@@ -34,7 +34,6 @@ var _ = Describe("RHCS account roles Test", func() {
 				args := &EXE.AccountRolesArgs{
 					AccountRolePrefix: "",
 					OpenshiftVersion:  profile.MajorVersion,
-					Token:             token,
 					ChannelGroup:      profile.ChannelGroup,
 				}
 				accRoleOutput, err := accService.Apply(args, true)
@@ -48,7 +47,6 @@ var _ = Describe("RHCS account roles Test", func() {
 				args := &EXE.AccountRolesArgs{
 					AccountRolePrefix: "OCP-63316",
 					OpenshiftVersion:  profile.MajorVersion,
-					Token:             token,
 					ChannelGroup:      profile.ChannelGroup,
 				}
 				_, err := accService.Apply(args, true)

--- a/tests/e2e/general_day_two_test.go
+++ b/tests/e2e/general_day_two_test.go
@@ -24,9 +24,7 @@ var _ = Describe("TF day2 scenrios", func() {
 			ci.Day2, ci.Medium, ci.FeatureIDP, func() {
 
 				By("Create/Apply dns-domain resource by terraform")
-				dnsArgs := &exe.DnsDomainArgs{
-					Token: token,
-				}
+				dnsArgs := &exe.DnsDomainArgs{}
 				err := dnsService.Create(dnsArgs)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -42,9 +40,7 @@ var _ = Describe("TF day2 scenrios", func() {
 			ci.Day2, ci.Medium, ci.FeatureIDP, func() {
 
 				By("Creating/Applying rhcs-info resource by terraform")
-				rhcsInfoArgs := &exe.RhcsInfoArgs{
-					Token: token,
-				}
+				rhcsInfoArgs := &exe.RhcsInfoArgs{}
 				Expect(rhcsInfoService.Create(rhcsInfoArgs)).ShouldNot(HaveOccurred())
 
 				By("Comparing rhcs-info state output to OCM API output")
@@ -53,7 +49,6 @@ var _ = Describe("TF day2 scenrios", func() {
 
 				// Address the resource's kind and name for the state command
 				rhcsInfoArgs = &exe.RhcsInfoArgs{
-					Token:        token,
 					ResourceKind: "rhcs_info",
 					ResourceName: "info",
 				}

--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -66,7 +66,6 @@ var _ = Describe("TF Test", func() {
 							By("Create htpasswd idp for an existing cluster")
 
 							idpParam := &exe.IDPArgs{
-								Token:         token,
 								ClusterID:     clusterID,
 								Name:          "OCP-63151-htpasswd-idp-test",
 								HtpasswdUsers: htpasswdMap,
@@ -129,7 +128,6 @@ var _ = Describe("TF Test", func() {
 							By("Create LDAP idp for an existing cluster")
 
 							idpParam := &exe.IDPArgs{
-								Token:      token,
 								ClusterID:  clusterID,
 								Name:       "OCP-63332-ldap-idp-test",
 								CA:         "",
@@ -184,7 +182,6 @@ var _ = Describe("TF Test", func() {
 						By("Create GitLab idp for an existing cluster")
 
 						idpParam := &exe.IDPArgs{
-							Token:        token,
 							ClusterID:    clusterID,
 							Name:         "OCP-64028-gitlab-idp-test",
 							ClientID:     gitlabIDPClientId,
@@ -222,7 +219,6 @@ var _ = Describe("TF Test", func() {
 						By("Create GitHub idp for an existing cluster")
 
 						idpParam := &exe.IDPArgs{
-							Token:         token,
 							ClusterID:     clusterID,
 							Name:          "OCP-64027-github-idp-test",
 							ClientID:      githubIDPClientId,
@@ -260,7 +256,6 @@ var _ = Describe("TF Test", func() {
 						By("Create Google idp for an existing cluster")
 
 						idpParam := &exe.IDPArgs{
-							Token:        token,
 							ClusterID:    clusterID,
 							Name:         "OCP-64029-google-idp-test",
 							ClientID:     googleIDPClientId,
@@ -301,7 +296,6 @@ var _ = Describe("TF Test", func() {
 						By("Applying google & ldap idps users using terraform")
 
 						idpParam := &exe.IDPArgs{
-							Token:        token,
 							ClusterID:    clusterID,
 							Name:         "OCP-64030",
 							ClientID:     googleIDPClientId,
@@ -381,7 +375,6 @@ var _ = Describe("TF Test", func() {
 								"password": h.GenerateRandomStringWithSymbols(15)}}
 
 						idpParam := &exe.IDPArgs{
-							Token:         token,
 							ClusterID:     clusterID,
 							Name:          "OCP-66408-htpasswd-multi-test",
 							HtpasswdUsers: htpasswdMap,
@@ -472,7 +465,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create htpasswd idp without/empty name field")
 					idpParam := &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "",
 						HtpasswdUsers: htpasswdMap,
@@ -488,7 +480,6 @@ var _ = Describe("TF Test", func() {
 					htpasswdMap = []interface{}{map[string]string{
 						"username": userName, "password": password}}
 					idpParam = &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "htpasswd-idp-test",
 						HtpasswdUsers: htpasswdMap,
@@ -503,7 +494,6 @@ var _ = Describe("TF Test", func() {
 					htpasswdMap = []interface{}{map[string]string{
 						"username": userName}}
 					idpParam = &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "htpasswd-idp-test",
 						HtpasswdUsers: htpasswdMap,
@@ -514,7 +504,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create ldap idp without/empty name field")
 					idpParam = &exe.IDPArgs{
-						Token:      token,
 						ClusterID:  clusterID,
 						Name:       "",
 						CA:         "",
@@ -531,7 +520,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create ldap idp without url field")
 					idpParam = &exe.IDPArgs{
-						Token:      token,
 						ClusterID:  clusterID,
 						Name:       "ldap-idp-test",
 						CA:         "",
@@ -546,7 +534,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create ldap idp without attributes field")
 					idpParam = &exe.IDPArgs{
-						Token:     token,
 						ClusterID: clusterID,
 						Name:      "ldap-idp-test",
 						CA:        "",
@@ -560,7 +547,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create github idp without/empty name field")
 					idpParam = &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "",
 						ClientID:      githubIDPClientId,
@@ -575,7 +561,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create github idp without/empty client_id field")
 					idpParam = &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "github-idp-test",
 						ClientID:      "",
@@ -589,7 +574,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create github idp without/empty client_secret field")
 					idpParam = &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "github-idp-test",
 						ClientID:      githubIDPClientId,
@@ -603,7 +587,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create gitlab idp without/empty name field")
 					idpParam = &exe.IDPArgs{
-						Token:        token,
 						ClusterID:    clusterID,
 						Name:         "",
 						ClientID:     gitlabIDPClientId,
@@ -618,7 +601,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create gitlab idp without/empty client_id field")
 					idpParam = &exe.IDPArgs{
-						Token:        token,
 						ClusterID:    clusterID,
 						Name:         "gitlab-idp-test",
 						ClientID:     "",
@@ -632,7 +614,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create gitlab idp without/empty client_secret field")
 					idpParam = &exe.IDPArgs{
-						Token:        token,
 						ClusterID:    clusterID,
 						Name:         "gitlab-idp-test",
 						ClientID:     gitlabIDPClientId,
@@ -646,7 +627,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create gitlab idp without url field")
 					idpParam = &exe.IDPArgs{
-						Token:        token,
 						ClusterID:    clusterID,
 						Name:         "gitlab-idp-test",
 						URL:          "",
@@ -660,7 +640,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create google idp without/empty name field")
 					idpParam = &exe.IDPArgs{
-						Token:        token,
 						ClusterID:    clusterID,
 						Name:         "",
 						ClientID:     googleIDPClientId,
@@ -674,7 +653,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create google idp without/empty client_id field")
 					idpParam = &exe.IDPArgs{
-						Token:        token,
 						ClusterID:    clusterID,
 						Name:         "google-idp-test",
 						ClientID:     "",
@@ -687,7 +665,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Create google idp without/empty client_secret field")
 					idpParam = &exe.IDPArgs{
-						Token:        token,
 						ClusterID:    clusterID,
 						Name:         "google-idp-test",
 						ClientID:     googleIDPClientId,
@@ -706,7 +683,6 @@ var _ = Describe("TF Test", func() {
 					htpasswdMap = []interface{}{map[string]string{}}
 
 					idpParam := &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "OCP-66409-htpasswd-idp-test",
 						HtpasswdUsers: htpasswdMap,
@@ -733,7 +709,6 @@ var _ = Describe("TF Test", func() {
 							"password": passwordInvalid}}
 
 					idpParam := &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "OCP-66410-htpasswd-idp-test",
 						HtpasswdUsers: htpasswdMap,
@@ -753,7 +728,6 @@ var _ = Describe("TF Test", func() {
 						map[string]string{"username": usernameInvalid,
 							"password": passwordInvalid}}
 					idpParam = &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "OCP-66410-htpasswd-idp-test",
 						HtpasswdUsers: htpasswdMap,
@@ -773,7 +747,6 @@ var _ = Describe("TF Test", func() {
 						map[string]string{"username": userName, "password": password}}
 
 					idpParam := &exe.IDPArgs{
-						Token:         token,
 						ClusterID:     clusterID,
 						Name:          "OCP-66411-htpasswd-idp-test",
 						HtpasswdUsers: htpasswdMap,
@@ -822,7 +795,6 @@ var _ = Describe("TF Test", func() {
 						gitlabIDPClientSecret = h.GenerateRandomStringWithSymbols(30)
 
 						idpParam := &exe.IDPArgs{
-							Token:        token,
 							ClusterID:    clusterID,
 							Name:         googleIdpName,
 							ClientID:     googleIDPClientId,
@@ -832,7 +804,6 @@ var _ = Describe("TF Test", func() {
 						Expect(idpService.google.Apply(idpParam, false)).To(Succeed())
 
 						idpParam = &exe.IDPArgs{
-							Token:        token,
 							ClusterID:    clusterID,
 							Name:         gitLabIdpName,
 							ClientID:     gitlabIDPClientId,
@@ -843,7 +814,6 @@ var _ = Describe("TF Test", func() {
 
 						By("Run the command to import the idp")
 						importParam := &exe.ImportArgs{
-							Token:        token,
 							ClusterID:    clusterID,
 							ResourceKind: "rhcs_identity_provider",
 							ResourceName: "idp_google_import",
@@ -860,7 +830,6 @@ var _ = Describe("TF Test", func() {
 						By("Validate terraform import with no idp object name returns error")
 						var unknownIdpName = "unknown_idp_name"
 						importParam = &exe.ImportArgs{
-							Token:        token,
 							ClusterID:    clusterID,
 							ResourceKind: "rhcs_identity_provider",
 							ResourceName: "idp_google_import",
@@ -874,7 +843,6 @@ var _ = Describe("TF Test", func() {
 
 						var unknownClusterID = h.GenerateRandomStringWithSymbols(20)
 						importParam = &exe.ImportArgs{
-							Token:        token,
 							ClusterID:    unknownClusterID,
 							ResourceKind: "rhcs_identity_provider",
 							ResourceName: "idp_gitlab_import",

--- a/tests/e2e/kubelet_config_test.go
+++ b/tests/e2e/kubelet_config_test.go
@@ -1,0 +1,100 @@
+package e2e
+
+import (
+
+	// nolint
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ci "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
+	cms "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/cms"
+	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	exe "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/exec"
+)
+
+var _ = Describe("TF Test", func() {
+
+	Describe("Pod pids limite test", func() {
+		var kcService *exe.KubeletConfigService
+		BeforeEach(func() {
+			var err error
+			kcService, err = exe.NewKubeletConfigService(CON.KubeletConfigDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		AfterEach(func() {
+			_, err := kcService.Destroy()
+			Expect(err).ToNot(HaveOccurred())
+		})
+		Context("Author:xueli-High-OCP-70128 @OCP-70128 @xueli", func() {
+			It("Author:xueli-High-OCP-70128 Create kubeletconfig to the cluster", ci.Day2, ci.High, func() {
+				By("Create kubeletconfig")
+				podPidsLimit := 12345
+				kcArgs := &exe.KubeletConfigArgs{
+					PodPidsLimit: podPidsLimit,
+					Cluster:      clusterID,
+				}
+
+				_, err := kcService.Apply(kcArgs, false)
+				Expect(err).ToNot(HaveOccurred())
+				defer func() {
+					_, err = kcService.Destroy()
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				By("Verify the created kubeletconfig")
+				kubeletConfig, err := cms.RetrieveKubeletConfig(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kubeletConfig.PodPidsLimit()).To(Equal(podPidsLimit))
+
+				By("Update kubeletConfig")
+				podPidsLimit = 12346
+				kcArgs.PodPidsLimit = podPidsLimit
+
+				_, err = kcService.Apply(kcArgs, false)
+				Expect(err).ToNot(HaveOccurred())
+				defer func() {
+					_, err = kcService.Destroy()
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				By("Verify the created kubeletconfig")
+				kubeletConfig, err = cms.RetrieveKubeletConfig(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kubeletConfig.PodPidsLimit()).To(Equal(podPidsLimit))
+
+				By("Destroy the kubeletconfig")
+				_, err = kcService.Destroy()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verify the created kubeletconfig")
+				_, err = cms.RetrieveKubeletConfig(ci.RHCSConnection, clusterID)
+				Expect(err).To(HaveOccurred())
+
+			})
+		})
+		Context("Author:xueli-High-OCP-70129 @OCP-70129 @xueli", func() {
+			It("Author:xueli-High-OCP-70129 Create kubeletconfig via terraform provider will validate well", ci.Day2, ci.Medium, func() {
+				By("Create kubeletconfig")
+				podPidsLimit := 1
+				kcArgs := &exe.KubeletConfigArgs{
+					PodPidsLimit: podPidsLimit,
+					Cluster:      clusterID,
+				}
+
+				output, err := kcService.Plan(kcArgs)
+				Expect(err).To(HaveOccurred())
+				Expect(output).Should(ContainSubstring("The requested podPidsLimit of '%d' is below the minimum allowable value of", kcArgs.PodPidsLimit))
+
+				kcArgs.PodPidsLimit = 1234567890
+				output, err = kcService.Plan(kcArgs)
+				Expect(err).To(HaveOccurred())
+				Expect(output).Should(ContainSubstring("The requested podPidsLimit of '%d' is above the default maximum value", kcArgs.PodPidsLimit))
+
+				kcArgs.PodPidsLimit = 1234567
+				output, err = kcService.Plan(kcArgs)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output).Should(ContainSubstring("The requested podPidsLimit of '%d' is above the default maximum of", kcArgs.PodPidsLimit))
+			})
+		})
+	})
+})

--- a/tests/e2e/kubelet_config_test.go
+++ b/tests/e2e/kubelet_config_test.go
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("TF Test", func() {
 
-	Describe("Pod pids limite test", func() {
+	Describe("Pod pids limit test", func() {
 		var kcService *exe.KubeletConfigService
 		BeforeEach(func() {
 			var err error

--- a/tests/e2e/machine_pool_test.go
+++ b/tests/e2e/machine_pool_test.go
@@ -26,20 +26,6 @@ var _ = Describe("TF Test", func() {
 			_, err := mpService.Destroy()
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("MachinePoolExampleNegative", func() {
-			replicas := 3
-			MachinePoolArgs := &exe.MachinePoolArgs{
-				Token:       token,
-				Cluster:     clusterID,
-				Replicas:    &replicas,
-				MachineType: "invalid",
-				Name:        "testmp",
-			}
-
-			_, err := mpService.Apply(MachinePoolArgs, false)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("is not supported for cloud provider 'aws'"))
-		})
 		Context("Author:amalykhi-High-OCP-64757 @OCP-64757 @amalykhi", func() {
 			It("Author:amalykhi-High-OCP-64757 Create a second machine pool", ci.Day2, ci.High, ci.FeatureMachinepool, func() {
 				By("Create a second machine pool")
@@ -47,7 +33,6 @@ var _ = Describe("TF Test", func() {
 				machineType := "r5.xlarge"
 				name := "ocp-64757"
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: machineType,
@@ -80,7 +65,6 @@ var _ = Describe("TF Test", func() {
 				updatingLabels := map[string]string{"fo1": "bar3", "fo3": "baz3"}
 				emptyLabels := map[string]string{}
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: machineType,
@@ -125,7 +109,6 @@ var _ = Describe("TF Test", func() {
 				machineType := "r5.xlarge"
 				name := "ocp-68296"
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:              token,
 					Cluster:            clusterID,
 					MinReplicas:        &minReplicas,
 					MaxReplicas:        &maxReplicas,
@@ -157,7 +140,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Disable autoscaling of the machinepool")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: machineType,
@@ -186,7 +168,6 @@ var _ = Describe("TF Test", func() {
 				taints := []map[string]string{taint0, taint1}
 				emptyTaints := []map[string]string{}
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: machineType,
@@ -250,7 +231,6 @@ var _ = Describe("TF Test", func() {
 				)
 				By("Create machinepool with invalid name")
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &invalidMpReplicas,
 					Name:        invalidMachinepoolName,
@@ -262,7 +242,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Create machinepool with invalid replica value")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &invalidMpReplicas,
 					Name:        machinepoolName,
@@ -274,7 +253,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Create machinepool with invalid instance type")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &mpReplicas,
 					Name:        machinepoolName,
@@ -286,7 +264,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Create machinepool with setting replicas and enable-autoscaling at the same time")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:              token,
 					Cluster:            clusterID,
 					Replicas:           &mpReplicas,
 					Name:               machinepoolName,
@@ -299,7 +276,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Create machinepool with setting min-replicas large than max-replicas")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:              token,
 					Cluster:            clusterID,
 					MinReplicas:        &maxReplicas,
 					MaxReplicas:        &minReplicas,
@@ -313,7 +289,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Create machinepool with setting min-replicas and max-replicas but without setting --enable-autoscaling")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					MinReplicas: &minReplicas,
 					MaxReplicas: &maxReplicas,
@@ -329,7 +304,6 @@ var _ = Describe("TF Test", func() {
 				if profile.MultiAZ {
 					By("Create machinepool with setting min-replicas and max-replicas not multiple 3 for multi-az")
 					MachinePoolArgs = &exe.MachinePoolArgs{
-						Token:              token,
 						Cluster:            clusterID,
 						MinReplicas:        &minReplicas,
 						MaxReplicas:        &invalidMaxReplicas4Mutilcluster,
@@ -342,7 +316,6 @@ var _ = Describe("TF Test", func() {
 					Expect(err.Error()).Should(ContainSubstring("Multi AZ clusters require that the number of replicas be a\nmultiple of 3"))
 
 					MachinePoolArgs = &exe.MachinePoolArgs{
-						Token:              token,
 						Cluster:            clusterID,
 						MinReplicas:        &invalidMinReplicas4Mutilcluster,
 						MaxReplicas:        &maxReplicas,
@@ -371,7 +344,6 @@ var _ = Describe("TF Test", func() {
 				machineType := "r5.xlarge"
 				name := "ocp-65063"
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:            token,
 					Cluster:          clusterID,
 					Replicas:         &replicas,
 					MachineType:      machineType,
@@ -393,7 +365,6 @@ var _ = Describe("TF Test", func() {
 				By("Create additional machinepool with subnet id specified")
 				awsSubnetIds := getResp.Body().AWS().SubnetIDs()
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: machineType,
@@ -414,7 +385,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Create additional machinepool with multi_availability_zone=false specified")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:            token,
 					Cluster:          clusterID,
 					Replicas:         &replicas,
 					MachineType:      machineType,
@@ -458,7 +428,6 @@ var _ = Describe("TF Test", func() {
 				name := "ocp-65071"
 				newZonePrivateSubnet := vpcOutput.ClusterPrivateSubnets[2]
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: machineType,
@@ -490,7 +459,6 @@ var _ = Describe("TF Test", func() {
 				name := "ocp-69144"
 				diskSize := 249
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: machineType,
@@ -513,7 +481,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Update disksize will create another machinepool")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: machineType,
@@ -532,7 +499,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Create another machinepool without disksize will create another machinepool with default value")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: "m5.2xlarge",
@@ -587,7 +553,6 @@ var _ = Describe("TF Test", func() {
 					sgIDs = sgIDs[0:4]
 				}
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:                    token,
 					Cluster:                  clusterID,
 					Replicas:                 &replicas,
 					MachineType:              machineType,
@@ -612,7 +577,6 @@ var _ = Describe("TF Test", func() {
 
 				By("Update security groups is not allowed to a machinepool")
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:                    token,
 					Cluster:                  clusterID,
 					Replicas:                 &replicas,
 					MachineType:              machineType,
@@ -632,7 +596,6 @@ var _ = Describe("TF Test", func() {
 				By("Create another machinepool without additional sg ")
 				name = "add-69146"
 				MachinePoolArgs = &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: "m5.2xlarge",
@@ -681,7 +644,7 @@ var _ = Describe("TF Test, default machinepool day-2 testing", func() {
 				Expect(resource).NotTo(BeNil())
 				defaultMachinePoolArgs, err = exe.BuildDefaultMachinePoolArgsFromClusterState(resource)
 				defaultMachinePoolArgs.Cluster = clusterID
-				defaultMachinePoolArgs.Token = token
+
 				Expect(err).NotTo(HaveOccurred())
 				_, err = dmpService.Apply(&defaultMachinePoolArgs, false)
 				Expect(err).ToNot(HaveOccurred())
@@ -709,7 +672,7 @@ var _ = Describe("TF Test, default machinepool day-2 testing", func() {
 				defaultMachinepoolArgFromMachinepool, err := exe.BuildDefaultMachinePoolArgsFromDefaultMachinePoolState(defaultMachinePoolResource)
 				Expect(err).NotTo(HaveOccurred())
 				defaultMachinepoolArgFromMachinepool.Cluster = clusterID
-				defaultMachinepoolArgFromMachinepool.Token = token
+
 				dmpArgFromMachinepoolForTesting := defaultMachinepoolArgFromMachinepool
 
 				By("Create machinepool with the default machinepool name 'worker' when it does exist")
@@ -772,7 +735,7 @@ var _ = Describe("TF Test, default machinepool day-2 testing", func() {
 					defaultMachinepoolArgFromMachinepool, err := exe.BuildDefaultMachinePoolArgsFromDefaultMachinePoolState(defaultMachinePoolResource)
 					Expect(err).NotTo(HaveOccurred())
 					defaultMachinepoolArgFromMachinepool.Cluster = clusterID
-					defaultMachinepoolArgFromMachinepool.Token = token
+
 					dmpArgFromMachinepoolForTesting := defaultMachinepoolArgFromMachinepool
 
 					By("Edit the taints without additional machinepool")
@@ -829,7 +792,6 @@ var _ = Describe("TF Test, default machinepool day-2 testing", func() {
 					name := "amp-69009"
 
 					MachinePoolArgs := &exe.MachinePoolArgs{
-						Token:       token,
 						Cluster:     clusterID,
 						Replicas:    &replicas,
 						MachineType: machineType,
@@ -882,7 +844,7 @@ var _ = Describe("TF Test, day-3 default machinepool testing", func() {
 				Expect(resource).NotTo(BeNil())
 				defaultMachinePoolArgs, err = exe.BuildDefaultMachinePoolArgsFromClusterState(resource)
 				defaultMachinePoolArgs.Cluster = clusterID
-				defaultMachinePoolArgs.Token = token
+
 				Expect(err).NotTo(HaveOccurred())
 				_, err = dmpService.Apply(&defaultMachinePoolArgs, false)
 				Expect(err).ToNot(HaveOccurred())
@@ -896,7 +858,6 @@ var _ = Describe("TF Test, day-3 default machinepool testing", func() {
 				defaultMachinepoolArgFromMachinepool, err := exe.BuildDefaultMachinePoolArgsFromDefaultMachinePoolState(defaultMachinePoolResource)
 				Expect(err).NotTo(HaveOccurred())
 				defaultMachinepoolArgFromMachinepool.Cluster = clusterID
-				defaultMachinepoolArgFromMachinepool.Token = token
 
 				By("Destroy default machinepool without additional machinepool existing")
 				resp, err := cms.ListMachinePool(ci.RHCSConnection, clusterID)
@@ -915,7 +876,6 @@ var _ = Describe("TF Test, day-3 default machinepool testing", func() {
 				name := "amp-69727"
 
 				MachinePoolArgs := &exe.MachinePoolArgs{
-					Token:       token,
 					Cluster:     clusterID,
 					Replicas:    &replicas,
 					MachineType: machineType,

--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -247,22 +247,22 @@ var _ = Describe("TF Test", func() {
 				Expect(err).ToNot(HaveOccurred())
 				args := map[string]*exe.ClusterCreationArgs{
 					"aws_additional_compute_security_group_ids": {
-						// 						AdditionalComputeSecurityGroups:      outPut.AdditionalComputeSecurityGroups[0:1],
+						AdditionalComputeSecurityGroups:      outPut.AdditionalComputeSecurityGroups[0:1],
 						AdditionalInfraSecurityGroups:        outPut.AdditionalInfraSecurityGroups,
 						AdditionalControlPlaneSecurityGroups: outPut.AdditionalControlPlaneSecurityGroups,
 						AWSRegion:                            profile.Region,
 					},
 					"aws_additional_infra_security_group_ids": {
-						// 						AdditionalInfraSecurityGroups:        outPut.AdditionalInfraSecurityGroups[0:1],
+						AdditionalInfraSecurityGroups:        outPut.AdditionalInfraSecurityGroups[0:1],
 						AdditionalComputeSecurityGroups:      outPut.AdditionalComputeSecurityGroups,
 						AdditionalControlPlaneSecurityGroups: outPut.AdditionalControlPlaneSecurityGroups,
 						AWSRegion:                            profile.Region,
 					},
 					"aws_additional_control_plane_security_group_ids": {
-						// 						AdditionalControlPlaneSecurityGroups: outPut.AdditionalControlPlaneSecurityGroups[0:1],
-						AdditionalComputeSecurityGroups: outPut.AdditionalComputeSecurityGroups,
-						AdditionalInfraSecurityGroups:   outPut.AdditionalInfraSecurityGroups,
-						AWSRegion:                       profile.Region,
+						AdditionalControlPlaneSecurityGroups: outPut.AdditionalControlPlaneSecurityGroups[0:1],
+						AdditionalComputeSecurityGroups:      outPut.AdditionalComputeSecurityGroups,
+						AdditionalInfraSecurityGroups:        outPut.AdditionalInfraSecurityGroups,
+						AWSRegion:                            profile.Region,
 					},
 				}
 				for keyword, updatingArgs := range args {

--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -149,7 +149,6 @@ var _ = Describe("TF Test", func() {
 
 					By("Run the command to import rosa_classic resource")
 					importParam := &exe.ImportArgs{
-						Token:        token,
 						ClusterID:    clusterID,
 						ResourceKind: "rhcs_cluster_rosa_classic",
 						ResourceName: "rosa_sts_cluster_import",
@@ -168,7 +167,6 @@ var _ = Describe("TF Test", func() {
 					By("Validate terraform import with no clusterID returns error")
 					var unknownClusterID = h.GenerateRandomStringWithSymbols(20)
 					importParam = &exe.ImportArgs{
-						Token:        token,
 						ClusterID:    unknownClusterID,
 						ResourceKind: "rhcs_cluster_rosa_classic",
 						ResourceName: "rosa_import_no_cluster_id",
@@ -249,25 +247,22 @@ var _ = Describe("TF Test", func() {
 				Expect(err).ToNot(HaveOccurred())
 				args := map[string]*exe.ClusterCreationArgs{
 					"aws_additional_compute_security_group_ids": {
-						Token:                                token,
-						AdditionalComputeSecurityGroups:      outPut.AdditionalComputeSecurityGroups[0:1],
+						// 						AdditionalComputeSecurityGroups:      outPut.AdditionalComputeSecurityGroups[0:1],
 						AdditionalInfraSecurityGroups:        outPut.AdditionalInfraSecurityGroups,
 						AdditionalControlPlaneSecurityGroups: outPut.AdditionalControlPlaneSecurityGroups,
 						AWSRegion:                            profile.Region,
 					},
 					"aws_additional_infra_security_group_ids": {
-						Token:                                token,
-						AdditionalInfraSecurityGroups:        outPut.AdditionalInfraSecurityGroups[0:1],
+						// 						AdditionalInfraSecurityGroups:        outPut.AdditionalInfraSecurityGroups[0:1],
 						AdditionalComputeSecurityGroups:      outPut.AdditionalComputeSecurityGroups,
 						AdditionalControlPlaneSecurityGroups: outPut.AdditionalControlPlaneSecurityGroups,
 						AWSRegion:                            profile.Region,
 					},
 					"aws_additional_control_plane_security_group_ids": {
-						Token:                                token,
-						AdditionalControlPlaneSecurityGroups: outPut.AdditionalControlPlaneSecurityGroups[0:1],
-						AdditionalComputeSecurityGroups:      outPut.AdditionalComputeSecurityGroups,
-						AdditionalInfraSecurityGroups:        outPut.AdditionalInfraSecurityGroups,
-						AWSRegion:                            profile.Region,
+						// 						AdditionalControlPlaneSecurityGroups: outPut.AdditionalControlPlaneSecurityGroups[0:1],
+						AdditionalComputeSecurityGroups: outPut.AdditionalComputeSecurityGroups,
+						AdditionalInfraSecurityGroups:   outPut.AdditionalInfraSecurityGroups,
+						AWSRegion:                       profile.Region,
 					},
 				}
 				for keyword, updatingArgs := range args {

--- a/tests/tf-manifests/aws/account-roles/main.tf
+++ b/tests/tf-manifests/aws/account-roles/main.tf
@@ -12,7 +12,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.url
 }
 

--- a/tests/tf-manifests/aws/account-roles/variables.tf
+++ b/tests/tf-manifests/aws/account-roles/variables.tf
@@ -13,9 +13,6 @@ variable "account_role_prefix" {
   default = ""
 }
 
-variable "token" {
-  type = string
-}
 
 variable "url" {
   type    = string

--- a/tests/tf-manifests/aws/add-account-roles/main.tf
+++ b/tests/tf-manifests/aws/add-account-roles/main.tf
@@ -12,7 +12,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.url
 }
 

--- a/tests/tf-manifests/aws/add-account-roles/variables.tf
+++ b/tests/tf-manifests/aws/add-account-roles/variables.tf
@@ -13,9 +13,6 @@ variable "account_role_prefix" {
   default = ""
 }
 
-variable "token" {
-  type = string
-}
 
 variable "url" {
   type    = string

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/main.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/main.tf
@@ -13,7 +13,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.url
 }
 provider "aws" {

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/variables.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/variables.tf
@@ -4,9 +4,6 @@ variable "account_role_prefix" {
   default = ""
 }
 
-variable "token" {
-  type = string
-}
 
 variable "url" {
   type    = string

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -12,7 +12,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.url
 }
 provider "aws" {

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -1,7 +1,3 @@
-variable "token" {
-  type      = string
-  sensitive = true
-}
 
 variable "url" {
   type    = string

--- a/tests/tf-manifests/rhcs/default-machine-pool/main.tf
+++ b/tests/tf-manifests/rhcs/default-machine-pool/main.tf
@@ -8,7 +8,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.url
 }
 

--- a/tests/tf-manifests/rhcs/default-machine-pool/variable.tf
+++ b/tests/tf-manifests/rhcs/default-machine-pool/variable.tf
@@ -45,9 +45,6 @@ variable "use_spot_instances" {
   default = false
 }
 
-variable "token" {
-  type = string
-}
 variable "url" {
   type    = string
   default = "https://api.stage.openshift.com"

--- a/tests/tf-manifests/rhcs/dns/main.tf
+++ b/tests/tf-manifests/rhcs/dns/main.tf
@@ -8,7 +8,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url = var.url
 }
 

--- a/tests/tf-manifests/rhcs/dns/variable.tf
+++ b/tests/tf-manifests/rhcs/dns/variable.tf
@@ -1,6 +1,3 @@
-variable "token" {
-  type = string
-}
 variable "url" {
   type    = string
   default = "https://api.stage.openshift.com"

--- a/tests/tf-manifests/rhcs/idps/github/main.tf
+++ b/tests/tf-manifests/rhcs/idps/github/main.tf
@@ -23,7 +23,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.url
 }
 resource "rhcs_identity_provider" "github_idp" {

--- a/tests/tf-manifests/rhcs/idps/github/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/github/variables.tf
@@ -1,8 +1,3 @@
-variable "token" {
-  type        = string
-  description = "RHCS token - You can get it here: https://console.redhat.com/openshift/token"
-}
-
 variable "cluster_id" {
   type        = string
   description = "The OCP cluster ID"

--- a/tests/tf-manifests/rhcs/idps/gitlab/main.tf
+++ b/tests/tf-manifests/rhcs/idps/gitlab/main.tf
@@ -23,7 +23,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.gateway
 }
 locals {

--- a/tests/tf-manifests/rhcs/idps/gitlab/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/gitlab/variables.tf
@@ -1,7 +1,3 @@
-variable "token" {
-  type      = string
-  sensitive = true
-}
 variable "gateway" {
   type    = string
   default = "https://api.stage.openshift.com"

--- a/tests/tf-manifests/rhcs/idps/google/main.tf
+++ b/tests/tf-manifests/rhcs/idps/google/main.tf
@@ -23,7 +23,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.url
 }
 resource "rhcs_identity_provider" "google_idp" {

--- a/tests/tf-manifests/rhcs/idps/google/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/google/variables.tf
@@ -1,7 +1,3 @@
-variable "token" {
-  type      = string
-  sensitive = true
-}
 variable "url" {
   type        = string
   description = "Provide RHCS environment by setting a value to url"

--- a/tests/tf-manifests/rhcs/idps/htpasswd/main.tf
+++ b/tests/tf-manifests/rhcs/idps/htpasswd/main.tf
@@ -24,7 +24,6 @@ terraform {
 
 
 provider "rhcs" {
-  token = var.token
   url   = var.url
 }
 

--- a/tests/tf-manifests/rhcs/idps/htpasswd/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/htpasswd/variables.tf
@@ -1,7 +1,3 @@
-variable "token" {
-  type      = string
-  sensitive = true
-}
 variable "url" {
   type    = string
   default = "https://api.stage.openshift.com"

--- a/tests/tf-manifests/rhcs/idps/ldap/main.tf
+++ b/tests/tf-manifests/rhcs/idps/ldap/main.tf
@@ -24,7 +24,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.gateway
 }
 

--- a/tests/tf-manifests/rhcs/idps/ldap/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/ldap/variables.tf
@@ -1,7 +1,3 @@
-variable "token" {
-  type      = string
-  sensitive = true
-}
 variable "gateway" {
   type    = string
   default = "https://api.stage.openshift.com"

--- a/tests/tf-manifests/rhcs/idps/multi-idp/main.tf
+++ b/tests/tf-manifests/rhcs/idps/multi-idp/main.tf
@@ -23,7 +23,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.gateway
 }
 

--- a/tests/tf-manifests/rhcs/idps/multi-idp/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/multi-idp/variables.tf
@@ -1,8 +1,3 @@
-variable "token" {
-  type      = string
-  sensitive = true
-}
-
 variable "gateway" {
   type    = string
   default = "https://api.stage.openshift.com"

--- a/tests/tf-manifests/rhcs/idps/openid/main.tf
+++ b/tests/tf-manifests/rhcs/idps/openid/main.tf
@@ -24,7 +24,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.gateway
 }
 

--- a/tests/tf-manifests/rhcs/idps/openid/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/openid/variables.tf
@@ -1,7 +1,3 @@
-variable "token" {
-  type      = string
-  sensitive = true
-}
 variable "gateway" {
   type    = string
   default = "https://api.stage.openshift.com"

--- a/tests/tf-manifests/rhcs/kubelet-config/main.tf
+++ b/tests/tf-manifests/rhcs/kubelet-config/main.tf
@@ -6,7 +6,12 @@ terraform {
     }
   }
 }
+
 provider "rhcs" {
-  url   = var.url
+  url = var.url
 }
-data "rhcs_info" "info" {}
+
+resource "rhcs_kubeletconfig" "kubeletconfig" {
+  cluster = var.cluster
+  pod_pids_limit = var.pod_pids_limit
+}

--- a/tests/tf-manifests/rhcs/kubelet-config/output.tf
+++ b/tests/tf-manifests/rhcs/kubelet-config/output.tf
@@ -1,0 +1,4 @@
+
+output "pod_pids_limit" {
+  value = rhcs_kubeletconfig.kubeletconfig.pod_pids_limit
+}

--- a/tests/tf-manifests/rhcs/kubelet-config/variable.tf
+++ b/tests/tf-manifests/rhcs/kubelet-config/variable.tf
@@ -1,0 +1,14 @@
+variable "url" {
+  type    = string
+  default = "https://api.stage.openshift.com"
+}
+
+variable "cluster" {
+  type    = string
+  default = null
+}
+variable "pod_pids_limit" {
+  type    = number
+  default = null
+}
+

--- a/tests/tf-manifests/rhcs/machine-pools/main.tf
+++ b/tests/tf-manifests/rhcs/machine-pools/main.tf
@@ -8,7 +8,6 @@ terraform {
 }
 
 provider "rhcs" {
-  token = var.token
   url   = var.url
 }
 

--- a/tests/tf-manifests/rhcs/machine-pools/variable.tf
+++ b/tests/tf-manifests/rhcs/machine-pools/variable.tf
@@ -44,10 +44,6 @@ variable "use_spot_instances" {
   type    = bool
   default = false
 }
-
-variable "token" {
-  type = string
-}
 variable "url" {
   type    = string
   default = "https://api.stage.openshift.com"

--- a/tests/tf-manifests/rhcs/rhcs-info/variable.tf
+++ b/tests/tf-manifests/rhcs/rhcs-info/variable.tf
@@ -1,6 +1,3 @@
-variable "token" {
-  type = string
-}
 variable "url" {
   type    = string
   default = "https://api.stage.openshift.com"

--- a/tests/utils/cms/cms.go
+++ b/tests/utils/cms/cms.go
@@ -261,3 +261,9 @@ func RetrieveCurrentAccount(connection *client.Connection, params ...map[string]
 	resp, err = connection.AccountsMgmt().V1().CurrentAccount().Get().Send()
 	return resp, err
 }
+
+// RetrieveKubeletConfig returns the kubeletconfig
+func RetrieveKubeletConfig(connection *client.Connection, clusterID string) (*cmv1.KubeletConfig, error) {
+	resp, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).KubeletConfig().Get().Send()
+	return resp.Body(), err
+}

--- a/tests/utils/constants/constants.go
+++ b/tests/utils/constants/constants.go
@@ -81,6 +81,7 @@ var (
 	DNSDir                = path.Join(configrationDir, RHCSProviderDIR, "dns")
 	RhcsInfoDir           = path.Join(configrationDir, RHCSProviderDIR, "rhcs-info")
 	DefaultMachinePoolDir = path.Join(configrationDir, RHCSProviderDIR, "default-machine-pool")
+	KubeletConfigDir      = path.Join(configrationDir, RHCSProviderDIR, "kubelet-config")
 )
 
 // Dirs of different types of clusters

--- a/tests/utils/exec/account-roles.go
+++ b/tests/utils/exec/account-roles.go
@@ -12,7 +12,6 @@ type AccountRolesArgs struct {
 	AccountRolePrefix   string `json:"account_role_prefix,omitempty"`
 	OCMENV              string `json:"rhcs_environment,omitempty"`
 	OpenshiftVersion    string `json:"openshift_version,omitempty"`
-	Token               string `json:"token,omitempty"`
 	URL                 string `json:"url,omitempty"`
 	ChannelGroup        string `json:"channel_group,omitempty"`
 	UnifiedAccRolesPath string `json:"path,omitempty"`

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -13,7 +13,6 @@ type ClusterCreationArgs struct {
 	ClusterName                          string            `json:"cluster_name,omitempty"`
 	OperatorRolePrefix                   string            `json:"operator_role_prefix,omitempty"`
 	OpenshiftVersion                     string            `json:"openshift_version,omitempty"`
-	Token                                string            `json:"token,omitempty"`
 	URL                                  string            `json:"url,omitempty"`
 	AWSRegion                            string            `json:"aws_region,omitempty"`
 	AWSAvailabilityZones                 []string          `json:"aws_availability_zones,omitempty"`

--- a/tests/utils/exec/dns-domain.go
+++ b/tests/utils/exec/dns-domain.go
@@ -8,8 +8,7 @@ import (
 )
 
 type DnsDomainArgs struct {
-	ID    string `json:"id,omitempty"`
-	Token string `json:"token,omitempty"`
+	ID string `json:"id,omitempty"`
 }
 
 type DnsService struct {

--- a/tests/utils/exec/idps.go
+++ b/tests/utils/exec/idps.go
@@ -12,7 +12,6 @@ type IDPArgs struct {
 	ClusterID     string        `json:"cluster_id,omitempty"`
 	Name          string        `json:"name,omitempty"`
 	ID            string        `json:"id,omitempty"`
-	Token         string        `json:"token,omitempty"`
 	OCMENV        string        `json:"ocm_environment,omitempty"`
 	URL           string        `json:"url,omitempty"`
 	CA            string        `json:"ca,omitempty"`

--- a/tests/utils/exec/import.go
+++ b/tests/utils/exec/import.go
@@ -9,7 +9,6 @@ import (
 
 type ImportArgs struct {
 	URL          string `json:"url,omitempty"`
-	Token        string `json:"token,omitempty"`
 	ResourceKind string `json:"resource_kind,omitempty"`
 	ResourceName string `json:"resource_name,omitempty"`
 	ClusterID    string `json:"cluster_id,omitempty"`

--- a/tests/utils/exec/kubelet-config.go
+++ b/tests/utils/exec/kubelet-config.go
@@ -1,0 +1,94 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+)
+
+type KubeletConfigArgs struct {
+	URL          string `json:"url,omitempty"`
+	Cluster      string `json:"cluster,omitempty"`
+	PodPidsLimit int    `json:"pod_pids_limit,omitempty"`
+}
+
+type KubeletConfigOutput struct {
+	Cluster      string `json:"cluster,omitempty"`
+	PodPidsLimit int    `json:"pod_pids_limit,omitempty"`
+}
+
+type KubeletConfigService struct {
+	CreationArgs *KubeletConfigArgs
+	ManifestDir  string
+	Context      context.Context
+}
+
+func (kc *KubeletConfigService) Init(manifestDirs ...string) error {
+	kc.ManifestDir = CON.KubeletConfigDir
+	if len(manifestDirs) != 0 {
+		kc.ManifestDir = manifestDirs[0]
+	}
+	ctx := context.TODO()
+	kc.Context = ctx
+	err := runTerraformInit(ctx, kc.ManifestDir)
+	if err != nil {
+		return err
+	}
+	return nil
+
+}
+
+func (kc *KubeletConfigService) Apply(createArgs *KubeletConfigArgs, recordtfvars bool, extraArgs ...string) (*KubeletConfigOutput, error) {
+	createArgs.URL = CON.GateWayURL
+	kc.CreationArgs = createArgs
+	args, tfvars := combineStructArgs(createArgs, extraArgs...)
+	_, err := runTerraformApplyWithArgs(kc.Context, kc.ManifestDir, args)
+	if err != nil {
+		return nil, err
+	}
+	if recordtfvars {
+		recordTFvarsFile(kc.ManifestDir, tfvars)
+	}
+	output, err := kc.Output()
+	return output, err
+}
+func (kc *KubeletConfigService) Plan(createArgs *KubeletConfigArgs, extraArgs ...string) (string, error) {
+	createArgs.URL = CON.GateWayURL
+	kc.CreationArgs = createArgs
+	args, _ := combineStructArgs(createArgs, extraArgs...)
+	output, err := runTerraformPlanWithArgs(kc.Context, kc.ManifestDir, args)
+
+	return output, err
+}
+func (kc *KubeletConfigService) Output() (*KubeletConfigOutput, error) {
+	out, err := runTerraformOutput(kc.Context, kc.ManifestDir)
+	if err != nil {
+		return nil, err
+	}
+	var accOutput = &KubeletConfigOutput{
+		PodPidsLimit: h.DigInt(out["pod_pids_limit"], "value"),
+	}
+	return accOutput, nil
+}
+
+func (kc *KubeletConfigService) Destroy(createArgs ...*KubeletConfigArgs) (string, error) {
+	if kc.CreationArgs == nil && len(createArgs) == 0 {
+		return "", fmt.Errorf("got unset destroy args, set it in object or pass as a parameter")
+	}
+	destroyArgs := kc.CreationArgs
+	if len(createArgs) != 0 {
+		destroyArgs = createArgs[0]
+	}
+	destroyArgs.URL = CON.GateWayURL
+	args, _ := combineStructArgs(destroyArgs)
+	output, err := runTerraformDestroyWithArgs(kc.Context, kc.ManifestDir, args)
+	return output, err
+}
+
+func NewKubeletConfigService(manifestDir ...string) (*KubeletConfigService, error) {
+	kc := &KubeletConfigService{}
+	err := kc.Init(manifestDir...)
+	return kc, err
+}

--- a/tests/utils/exec/machine-pools.go
+++ b/tests/utils/exec/machine-pools.go
@@ -12,7 +12,6 @@ type MachinePoolArgs struct {
 	Cluster                  string              `json:"cluster,omitempty"`
 	OCMENV                   string              `json:"ocm_environment,omitempty"`
 	Name                     string              `json:"name,omitempty"`
-	Token                    string              `json:"token,omitempty"`
 	URL                      string              `json:"url,omitempty"`
 	MachineType              string              `json:"machine_type,omitempty"`
 	Replicas                 *int                `json:"replicas,omitempty"`

--- a/tests/utils/exec/oidc-provider-operator-roles.go
+++ b/tests/utils/exec/oidc-provider-operator-roles.go
@@ -11,7 +11,6 @@ import (
 type OIDCProviderOperatorRolesArgs struct {
 	AccountRolePrefix   string `json:"account_role_prefix,omitempty"`
 	OperatorRolePrefix  string `json:"operator_role_prefix,omitempty"`
-	Token               string `json:"token,omitempty"`
 	URL                 string `json:"url,omitempty"`
 	OIDCConfig          string `json:"oidc_config,omitempty"`
 	AWSRegion           string `json:"aws_region,omitempty"`

--- a/tests/utils/exec/rhcs-info.go
+++ b/tests/utils/exec/rhcs-info.go
@@ -9,7 +9,6 @@ import (
 
 type RhcsInfoArgs struct {
 	ID           string `json:"id,omitempty"`
-	Token        string `json:"token,omitempty"`
 	ResourceName string `json:"resource_name,omitempty"`
 	ResourceKind string `json:"resource_kind,omitempty"`
 }

--- a/tests/utils/exec/tf-exec.go
+++ b/tests/utils/exec/tf-exec.go
@@ -38,8 +38,7 @@ func runTerraformInit(ctx context.Context, dir string) error {
 
 func runTerraformApplyWithArgs(ctx context.Context, dir string, terraformArgs []string) (output string, err error) {
 	applyArgs := append([]string{"apply", "-auto-approve", "-no-color"}, terraformArgs...)
-	Logger.Infof("Running terraform apply against the dir: %s", dir)
-	Logger.Debugf("Running terraform apply against the dir: %s with args %v", dir, terraformArgs)
+	Logger.Infof("Running terraform apply against the dir: %s with args %v", dir, terraformArgs)
 	terraformApply := exec.Command("terraform", applyArgs...)
 	terraformApply.Dir = dir
 	var stdoutput bytes.Buffer
@@ -59,8 +58,7 @@ func runTerraformApplyWithArgs(ctx context.Context, dir string, terraformArgs []
 
 func runTerraformPlanWithArgs(ctx context.Context, dir string, terraformArgs []string) (output string, err error) {
 	planArgs := append([]string{"plan", "-no-color"}, terraformArgs...)
-	Logger.Infof("Running terraform plan against the dir: %s ", dir)
-	Logger.Debugf("Running terraform plan against the dir: %s with args %v", dir, terraformArgs)
+	Logger.Infof("Running terraform plan against the dir: %s with args %v", dir, terraformArgs)
 	terraformPlan := exec.Command("terraform", planArgs...)
 	terraformPlan.Dir = dir
 	var stdoutput bytes.Buffer
@@ -141,8 +139,7 @@ func runTerraformState(dir, subcommand, terraformArgs string) (string, error) {
 }
 
 func runTerraformImportWithArgs(ctx context.Context, dir string, terraformArgs []string) (output string, err error) {
-	Logger.Infof("Running terraform import against the dir: %s", dir)
-	Logger.Debugf("Running terraform import against the dir: %s with args %v", dir, terraformArgs)
+	Logger.Infof("Running terraform import against the dir: %s with args %v", dir, terraformArgs)
 
 	terraformImport := exec.CommandContext(ctx, "terraform", append([]string{"import"}, terraformArgs...)...)
 	terraformImport.Dir = dir


### PR DESCRIPTION
What I did in the PR:
- Removed token from current manifests file to make it read from ENV variable
- Exposed apply variable 
- Finished automation of OCP-70128  and OCP-70129 for kubeletconfig cases

Testing output:
```
lixue@Xue-Lis-MacBook-Pro terraform-provider-rhcs % ginkgo -focus "(OCP-70128|OCP-70129)" tests/e2e
time="2023-12-27T10:56:20+08:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2023-12-27T10:56:20+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version:latest worker_disk_size:200 zones:]"
time="2023-12-27T10:56:20+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version:latest worker_disk_size:200 zones:]"
time="2023-12-27T10:56:20+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/resource-import"
Running Suite: e2e tests suite - /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/e2e
================================================================================================
Random Seed: 1703645774

Will run 2 of 47 specs
time="2023-12-27T10:56:21+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version:latest worker_disk_size:200 zones:]"
time="2023-12-27T10:56:21+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic"
time="2023-12-27T10:56:26+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic"
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden
/Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:243
------------------------------
SStime="2023-12-27T10:56:27+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config"
time="2023-12-27T10:56:28+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config with args [-var cluster=28cg8f2p5cnn6bld7qfk56blhpvp0780 -var pod_pids_limit=12345 -var url=https://api.stage.openshift.com]"
time="2023-12-27T10:56:33+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config"
time="2023-12-27T10:56:35+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config with args [-var url=https://api.stage.openshift.com -var cluster=28cg8f2p5cnn6bld7qfk56blhpvp0780 -var pod_pids_limit=12346]"
time="2023-12-27T10:56:40+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config"
time="2023-12-27T10:56:41+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config"
time="2023-12-27T10:56:46+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config"
time="2023-12-27T10:56:46+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config"
time="2023-12-27T10:56:46+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config"
•time="2023-12-27T10:56:47+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config"
time="2023-12-27T10:56:47+08:00" level=info msg="Running terraform plan against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config with args [-var url=https://api.stage.openshift.com -var cluster=28cg8f2p5cnn6bld7qfk56blhpvp0780 -var pod_pids_limit=1]"
time="2023-12-27T10:56:48+08:00" level=error msg="Planning failed. Terraform encountered an error while generating this plan.\n\n\nError: The requested podPidsLimit is too low\n\n  with rhcs_kubeletconfig.kubeletconfig,\n  on main.tf line 16, in resource \"rhcs_kubeletconfig\" \"kubeletconfig\":\n  16:   pod_pids_limit = var.pod_pids_limit\n\nThe requested podPidsLimit of '1' is below the minimum allowable value of\n'4096'"
time="2023-12-27T10:56:48+08:00" level=info msg="Running terraform plan against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config with args [-var url=https://api.stage.openshift.com -var cluster=28cg8f2p5cnn6bld7qfk56blhpvp0780 -var pod_pids_limit=1.23456789e+09]"
time="2023-12-27T10:56:48+08:00" level=error msg="Planning failed. Terraform encountered an error while generating this plan.\n\n\nError: The requested podPidsLimit is too high\n\n  with rhcs_kubeletconfig.kubeletconfig,\n  on main.tf line 16, in resource \"rhcs_kubeletconfig\" \"kubeletconfig\":\n  16:   pod_pids_limit = var.pod_pids_limit\n\nThe requested podPidsLimit of '1234567890' is above the default maximum value\nof '16384', and above the maximum supported value of '3694303'"
time="2023-12-27T10:56:48+08:00" level=info msg="Running terraform plan against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config with args [-var url=https://api.stage.openshift.com -var cluster=28cg8f2p5cnn6bld7qfk56blhpvp0780 -var pod_pids_limit=1.234567e+06]"
time="2023-12-27T10:56:49+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/kubelet-config"
•SS

Ran 2 of 47 Specs in 28.068 seconds
SUCCESS! -- 2 Passed | 0 Failed | 1 Pending | 44 Skipped
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.13.2

PASS

Ginkgo ran 1 suite in 34.616663306s
Test Suite Passed
```