### PR TITLE
OCM-5285: MP labels can't be an empty map

### DIFF
--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -151,6 +152,9 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 					" This list will overwrite any modifications made to node labels on an ongoing basis.",
 				ElementType: types.StringType,
 				Optional:    true,
+				Validators: []validator.Map{
+					mapvalidator.SizeAtLeast(1),
+				},
 			},
 			"multi_availability_zone": schema.BoolAttribute{
 				Description: "Create a multi-AZ machine pool for a multi-AZ cluster (default is `true`)." + common.ValueCannotBeChangedStringDescription,

--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -662,11 +662,23 @@ var _ = Describe("Machine pool creation", func() {
 					}
 				  },
 				  "replicas": 12,
-                  "labels": {}
+                  "labels": null
 				}`),
 			),
 		)
 
+		// Invalid deletion - labels map can't be empty
+		terraform.Source(`
+		  resource "rhcs_machine_pool" "my_pool" {
+		    cluster      = "123"
+		    name         = "my-pool"
+		    machine_type = "r5.xlarge"
+		    replicas     = 12
+            labels       = {}
+		  }
+		`)
+		Expect(terraform.Apply()).ToNot(BeZero())
+		// Valid deletion
 		terraform.Source(`
 		  resource "rhcs_machine_pool" "my_pool" {
 		    cluster      = "123"


### PR DESCRIPTION
If users wish to delete all labels, they should simply remove the `labels` attribute from the tf statement.