### PR TITLE
Support RHCS_SOURCE and RHCS_VERSION for CI jobs

### DIFF
--- a/tests/e2e/cluster_creation_test.go
+++ b/tests/e2e/cluster_creation_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	CI "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
+	. "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/log"
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/openshift"
 )
 
@@ -26,6 +27,10 @@ var _ = Describe("RHCS Provider Test", func() {
 					timeout := 60
 					timeoutMin := time.Duration(timeout)
 					console, err := openshift.NewConsole(clusterID, CI.RHCSConnection)
+					if err != nil {
+						Logger.Warnf("Got error %s when config the openshift console. Return without waiting for operators ready", err.Error())
+						return
+					}
 					_, err = openshift.RetryCMDRun(fmt.Sprintf("oc wait clusteroperators --all --for=condition=Progressing=false --kubeconfig %s --timeout %dm", console.KubePath, timeout), timeoutMin)
 					Expect(err).ToNot(HaveOccurred())
 				}

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	CI "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
 	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	H "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
 var ctx context.Context
@@ -23,6 +24,10 @@ func TestRHCSProvider(t *testing.T) {
 var _ = BeforeSuite(func() {
 	token = os.Getenv(CON.TokenENVName)
 	var err error
+
+	err = H.AlignRHCSSourceVersion(CON.ConfigrationDir)
+	Expect(err).ToNot(HaveOccurred())
+
 	clusterID, err = CI.PrepareRHCSClusterByProfileENV()
 	Expect(err).ToNot(HaveOccurred())
 	ctx = context.Background()

--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -34,7 +34,7 @@ var _ = Describe("TF Test", func() {
 		}
 
 		var profile *ci.Profile
-		profile = ci.LoadProfileYamlFileByENV()
+
 		var idpService IDPServices
 		var importService exe.ImportService
 		var htpasswdMap = []interface{}{map[string]string{}}
@@ -43,6 +43,9 @@ var _ = Describe("TF Test", func() {
 			googleIDPClientSecret, googleIDPClientId,
 			gitlabIDPClientSecret, gitlabIDPClientId,
 			githubIDPClientSecret, githubIDPClientId string
+		BeforeEach(func() {
+			profile = ci.LoadProfileYamlFileByENV()
+		})
 
 		Describe("IDP Positive scenario test cases", func() {
 			Context("Htpasswd IDP test cases", func() {

--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -27,9 +27,10 @@ var _ = Describe("TF Test", func() {
 		var err error
 		var profile *ci.Profile
 		var cluster *cmv1.Cluster
-		var importService = *exe.NewImportService(con.ImportResourceDir) // init new import service
+		var importService *exe.ImportService
 
 		BeforeEach(func() {
+			importService = exe.NewImportService(con.ImportResourceDir) // init new import service
 			profile = ci.LoadProfileYamlFileByENV()
 			Expect(err).ToNot(HaveOccurred())
 			getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)

--- a/tests/tf-manifests/rhcs/default-machine-pool/variable.tf
+++ b/tests/tf-manifests/rhcs/default-machine-pool/variable.tf
@@ -8,6 +8,10 @@ variable "machine_type" {
 variable "name" {
   type = string
 }
+variable "disk_size" {
+  type    = number
+  default = null
+}
 variable "autoscaling_enabled" {
   default = false
   type    = bool
@@ -60,5 +64,10 @@ variable "subnet_id" {
 }
 variable "multi_availability_zone" {
   type    = bool
+  default = null
+}
+
+variable "additional_security_groups" {
+  type    = list(string)
   default = null
 }

--- a/tests/utils/constants/config.go
+++ b/tests/utils/constants/config.go
@@ -30,6 +30,8 @@ type RHCSconfig struct {
 	YAMLProfilesDir   string
 	RootDir           string
 	KubeConfigDir     string
+	RHCSSource        string `env:"RHCS_SOURCE" default:"staging" yaml:"env"`
+	RHCSVersion       string `env:"RHCS_VERSION" default:"staging" yaml:"env"`
 }
 
 func init() {

--- a/tests/utils/constants/constants.go
+++ b/tests/utils/constants/constants.go
@@ -17,14 +17,16 @@ const (
 	HyphenConnector     string = "-"
 )
 
-var (
+// Below constants is the env variable name defined to run on different testing requirements
+const (
 	TokenENVName              = "RHCS_TOKEN"
 	ClusterIDEnv              = "CLUSTER_ID"
 	RHCSENV                   = "RHCS_ENV"
 	RhcsClusterProfileENV     = "CLUSTER_PROFILE"
 	ClusterTypeManifestDirEnv = "CLUSTER_ROSA_TYPE"
 	MajorVersion              = "MAJOR_VERSION_ENV"
-	ManifestsDirENV           = os.Getenv("MANIFESTS_FOLDER")
+	RHCSVersion               = "RHCS_VERSION"
+	RHCSSource                = "RHCS_SOURCE"
 )
 
 var (
@@ -35,6 +37,7 @@ var (
 	TFYAMLProfile             = "tf_cluster_profile.yml"
 	ConfigSuffix              = "kubeconfig"
 	DefaultAccountRolesPrefix = "account-role-"
+	ManifestsDirENV           = os.Getenv("MANIFESTS_FOLDER")
 )
 
 const (
@@ -53,7 +56,7 @@ func initDIR() string {
 	return manifestsDir
 }
 
-var configrationDir = initDIR()
+var ConfigrationDir = initDIR()
 
 // Provider dirs' name definition
 const (
@@ -64,24 +67,24 @@ const (
 
 // Dirs of aws provider
 var (
-	AccountRolesDir                      = path.Join(configrationDir, AWSProviderDIR, "account-roles")
-	AddAccountRolesDir                   = path.Join(configrationDir, AWSProviderDIR, "add-account-roles")
-	OIDCProviderOperatorRolesManifestDir = path.Join(configrationDir, AWSProviderDIR, "oidc-provider-operator-roles")
-	AWSVPCDir                            = path.Join(configrationDir, AWSProviderDIR, "vpc")
-	AWSVPCTagDir                         = path.Join(configrationDir, AWSProviderDIR, "vpc-tags")
-	AWSSecurityGroupDir                  = path.Join(configrationDir, AWSProviderDIR, "security-groups")
+	AccountRolesDir                      = path.Join(ConfigrationDir, AWSProviderDIR, "account-roles")
+	AddAccountRolesDir                   = path.Join(ConfigrationDir, AWSProviderDIR, "add-account-roles")
+	OIDCProviderOperatorRolesManifestDir = path.Join(ConfigrationDir, AWSProviderDIR, "oidc-provider-operator-roles")
+	AWSVPCDir                            = path.Join(ConfigrationDir, AWSProviderDIR, "vpc")
+	AWSVPCTagDir                         = path.Join(ConfigrationDir, AWSProviderDIR, "vpc-tags")
+	AWSSecurityGroupDir                  = path.Join(ConfigrationDir, AWSProviderDIR, "security-groups")
 )
 
 // Dirs of rhcs provider
 var (
-	ClusterDir            = path.Join(configrationDir, RHCSProviderDIR, "clusters")
-	ImportResourceDir     = path.Join(configrationDir, RHCSProviderDIR, "resource-import")
-	IDPsDir               = path.Join(configrationDir, RHCSProviderDIR, "idps")
-	MachinePoolDir        = path.Join(configrationDir, RHCSProviderDIR, "machine-pools")
-	DNSDir                = path.Join(configrationDir, RHCSProviderDIR, "dns")
-	RhcsInfoDir           = path.Join(configrationDir, RHCSProviderDIR, "rhcs-info")
-	DefaultMachinePoolDir = path.Join(configrationDir, RHCSProviderDIR, "default-machine-pool")
-	KubeletConfigDir      = path.Join(configrationDir, RHCSProviderDIR, "kubelet-config")
+	ClusterDir            = path.Join(ConfigrationDir, RHCSProviderDIR, "clusters")
+	ImportResourceDir     = path.Join(ConfigrationDir, RHCSProviderDIR, "resource-import")
+	IDPsDir               = path.Join(ConfigrationDir, RHCSProviderDIR, "idps")
+	MachinePoolDir        = path.Join(ConfigrationDir, RHCSProviderDIR, "machine-pools")
+	DNSDir                = path.Join(ConfigrationDir, RHCSProviderDIR, "dns")
+	RhcsInfoDir           = path.Join(ConfigrationDir, RHCSProviderDIR, "rhcs-info")
+	DefaultMachinePoolDir = path.Join(ConfigrationDir, RHCSProviderDIR, "default-machine-pool")
+	KubeletConfigDir      = path.Join(ConfigrationDir, RHCSProviderDIR, "kubelet-config")
 )
 
 // Dirs of different types of clusters

--- a/tests/utils/helper/manifests_handler.go
+++ b/tests/utils/helper/manifests_handler.go
@@ -1,0 +1,92 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"path/filepath"
+
+	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	. "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/log"
+)
+
+func RHCSSourceAlignment(manifestsFilePath string, rhcsSource string, rhcsVersion string) error {
+	sourceRegexrP := regexp.MustCompile(`(rhcs\s*=\s*{(?:\n*[\w\W]*?source\s*=\s*))"([a-z,A-Z,\/,\-,\.]*)("[^}]*})`)
+	versionRegexP := regexp.MustCompile(`(rhcs\s*=\s*{(?:\n*[\w\W]*?version\s*=\s*))"([0-9.,=\-><\sA-Za-z]*)("[^}]*})`)
+	var err error
+	if rhcsSource != "" {
+		err = ReplaceRegex(manifestsFilePath, *sourceRegexrP, rhcsSource)
+		if err != nil {
+			return err
+		}
+
+	}
+	if rhcsVersion != "" {
+		err = ReplaceRegex(manifestsFilePath, *versionRegexP, rhcsVersion)
+	}
+
+	return err
+}
+func ReplaceRegex(filePath string, regexP regexp.Regexp, replaceString string) error {
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	stringContent := string(fileContent)
+	if regexP.MatchString(stringContent) {
+		Logger.Debugf("Find match string in file %s, going to replace", filePath)
+		replacedContent := regexP.ReplaceAllString(stringContent, fmt.Sprintf(`$1"%s$3`, replaceString))
+		file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_TRUNC, 0666)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = file.WriteString(replacedContent)
+		if err != nil {
+			return err
+		}
+		Logger.Debugf("Replaced file %s with %s", filePath, replaceString)
+	}
+	return nil
+}
+
+func ScanManifestsDir(dir string) ([]string, error) {
+	files := []string{}
+	manifestR := regexp.MustCompile(`[\w\W]*\.+tf`)
+	err := filepath.Walk(dir, func(filepath string, info os.FileInfo, err error) error {
+		if info != nil && !info.IsDir() {
+			if manifestR.MatchString(info.Name()) {
+				files = append(files, filepath)
+			}
+		}
+		return err
+	})
+	return files, err
+}
+
+func AlignRHCSSourceVersion(dir string) error {
+	rhcsSource := os.Getenv(CON.RHCSSource)
+	rhcsVersion := os.Getenv(CON.RHCSVersion)
+	if rhcsSource == "" && rhcsVersion == "" {
+		return nil
+	}
+	if rhcsSource != "" {
+		Logger.Warnf("Got a global ENV variable %s set to %s. Going to replace all of the manifests files", CON.RHCSSource, rhcsSource)
+	}
+	if rhcsVersion != "" {
+		Logger.Warnf("Got a global ENV variable %s set to %s. Going to replace all of the manifests files", CON.RHCSVersion, rhcsVersion)
+	}
+	files, err := ScanManifestsDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		err := RHCSSourceAlignment(file, rhcsSource, rhcsVersion)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
What I did in this PR:
- Support RHCS_SOURCE AND RHCS_VERSION env variables to replace all of source/version for the manifests files
-  Fixed @OCP-69144 And @OCP-69146 with latest code change
- Enhanced operator waiting for cluster preparation, once local user has no access to /credentials endpoint will return directly with a warning reported
The fixed log and running case with ENV set to `RHCS_VERSION="1.5.0-prerelease.2"` and `RHCS_SOURCE="terraform-redhat/rhcs"`
```
lixue@Xue-Lis-MacBook-Pro terraform-provider-rhcs % ginkgo -focus "(@OCP-69144|@OCP-69146)" tests/e2e
time="2023-12-29T19:16:44+08:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2023-12-29T19:16:44+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version:latest worker_disk_size:200 zones:]"
Running Suite: e2e tests suite - /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/e2e
================================================================================================
Random Seed: 1703848597

Will run 2 of 49 specs
time="2023-12-29T19:16:44+08:00" level=warning msg="Got a global ENV variable RHCS_SOURCE set to terraform-redhat/rhcs. Going to replace all of the manifests files"
time="2023-12-29T19:16:44+08:00" level=warning msg="Got a global ENV variable RHCS_VERSION set to 1.5.0-prerelease.2. Going to replace all of the manifests files"
time="2023-12-29T19:16:45+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version:latest worker_disk_size:200 zones:]"
time="2023-12-29T19:16:45+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic"
time="2023-12-29T19:16:50+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic"
SSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden
/Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:244
------------------------------
SSSSSSSSSSStime="2023-12-29T19:16:52+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version:latest worker_disk_size:200 zones:]"
time="2023-12-29T19:16:52+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-29T19:16:53+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools with args [-var replicas=3 -var disk_size=249 -var cluster=28dttgrnmorva519am2f1lqo1c47r1vg -var name=ocp-69144 -var url=https://api.stage.openshift.com -var machine_type=r5.xlarge]"
time="2023-12-29T19:17:04+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools with args [-var cluster=28dttgrnmorva519am2f1lqo1c47r1vg -var name=ocp-69144 -var url=https://api.stage.openshift.com -var machine_type=r5.xlarge -var replicas=3 -var disk_size=320]"
time="2023-12-29T19:17:06+08:00" level=error msg="rhcs_machine_pool.mp: Refreshing state... [id=ocp-69144]\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_machine_pool.mp will be updated in-place\n  ~ resource \"rhcs_machine_pool\" \"mp\" {\n      ~ disk_size               = 249 -> 320\n        id                      = \"ocp-69144\"\n        name                    = \"ocp-69144\"\n        # (5 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\nrhcs_machine_pool.mp: Modifying... [id=ocp-69144]\n\nError: Attribute value cannot be changed\n\n  with rhcs_machine_pool.mp,\n  on main.tf line 14, in resource \"rhcs_machine_pool\" \"mp\":\n  14: resource \"rhcs_machine_pool\" \"mp\" {\n\nAttribute disk_size, cannot be changed from 249 to 320"
time="2023-12-29T19:17:06+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-29T19:17:12+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools with args [-var cluster=28dttgrnmorva519am2f1lqo1c47r1vg -var name=ocp-69144 -var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge -var replicas=3]"
time="2023-12-29T19:17:22+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-29T19:17:28+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
•time="2023-12-29T19:17:28+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version:latest worker_disk_size:200 zones:]"
time="2023-12-29T19:17:28+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-29T19:17:30+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/security-groups"
time="2023-12-29T19:17:34+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/security-groups"
time="2023-12-29T19:17:35+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/security-groups"
time="2023-12-29T19:17:37+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools with args [-var replicas=3 -var additional_security_groups=[\"sg-09ce7de9c0b89b79c\",\"sg-01829bc5ff3d8dfd5\",\"sg-0877583284ef31435\",\"sg-06c68dc8c33cb6243\"] -var cluster=28dttgrnmorva519am2f1lqo1c47r1vg -var name=ocp-69146 -var url=https://api.stage.openshift.com -var machine_type=r5.xlarge]"
time="2023-12-29T19:17:46+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools with args [-var cluster=28dttgrnmorva519am2f1lqo1c47r1vg -var name=ocp-69146 -var url=https://api.stage.openshift.com -var machine_type=r5.xlarge -var replicas=3 -var additional_security_groups=[\"sg-09ce7de9c0b89b79c\"]]"
time="2023-12-29T19:17:49+08:00" level=error msg="rhcs_machine_pool.mp: Refreshing state... [id=ocp-69146]\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_machine_pool.mp will be updated in-place\n  ~ resource \"rhcs_machine_pool\" \"mp\" {\n      ~ aws_additional_security_group_ids = [\n            \"sg-09ce7de9c0b89b79c\",\n          - \"sg-01829bc5ff3d8dfd5\",\n          - \"sg-0877583284ef31435\",\n          - \"sg-06c68dc8c33cb6243\",\n        ]\n        id                                = \"ocp-69146\"\n        name                              = \"ocp-69146\"\n        # (6 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\nrhcs_machine_pool.mp: Modifying... [id=ocp-69146]\n\nError: Attribute value cannot be changed\n\n  with rhcs_machine_pool.mp,\n  on main.tf line 14, in resource \"rhcs_machine_pool\" \"mp\":\n  14: resource \"rhcs_machine_pool\" \"mp\" {\n\nAttribute aws_additional_security_group_ids, cannot be changed from\n[\"sg-09ce7de9c0b89b79c\",\"sg-01829bc5ff3d8dfd5\",\"sg-0877583284ef31435\",\"sg-06c68dc8c33cb6243\"]\nto [\"sg-09ce7de9c0b89b79c\"]"
time="2023-12-29T19:17:49+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-29T19:17:55+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools with args [-var cluster=28dttgrnmorva519am2f1lqo1c47r1vg -var name=add-69146 -var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge -var replicas=3]"
time="2023-12-29T19:18:03+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
time="2023-12-29T19:18:12+08:00" level=info msg="Running terraform destroy against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools"
•SSSSSSSSSS

Ran 2 of 49 Specs in 88.439 seconds
SUCCESS! -- 2 Passed | 0 Failed | 1 Pending | 46 Skipped
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.13.2

PASS

Ginkgo ran 1 suite in 1m36.253254399s
Test Suite Passed
```