### PR TITLE
Fix random string with symbols function

### DIFF
--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -401,7 +401,15 @@ func GenerateRandomStringWithSymbols(length int) string {
 	if err != nil {
 		panic(err)
 	}
-	return base64.StdEncoding.EncodeToString(b)[:length]
+	randomString := base64.StdEncoding.EncodeToString(b)[:length]
+	f := func(r rune) bool {
+		return r < 'A' || r > 'z'
+	}
+	// Verify that the string contains special character or number
+	if strings.IndexFunc(randomString, f) == -1 {
+		randomString = randomString[:len(randomString)-1] + "!"
+	}
+	return randomString
 }
 
 func Subfix(length int) string {


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/terraform-redhat_terraform-provider-rhcs/467/pull-ci-terraform-redhat-terraform-provider-rhcs-main-rosa-sts-advanced-optional-critical-high-presubmit/1741418998823653376

I found out from the CI results that simetimes the symbols/numbers are missed in the string
nAttribute admin_credentials.password password must contain numbers or\nsymbols, got: lJoEKrgzbcWnJG",