### PR TITLE
automate ocp-64907 :: validate custom property operations on cluster 

### DIFF
--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -353,6 +353,7 @@ func GenerateClusterCreationArgsByProfile(token string, profile *Profile) (clust
 		clusterArgs.WorkerDiskSize = profile.WorkerDiskSize
 	}
 	clusterArgs.UnifiedAccRolesPath = profile.UnifiedAccRolesPath
+	clusterArgs.CustomProperties = CON.CustomProperties
 
 	return clusterArgs, profile.ManifestsDIR, err
 }

--- a/tests/e2e/general_day_two_test.go
+++ b/tests/e2e/general_day_two_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ci "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
@@ -11,6 +13,7 @@ import (
 )
 
 var _ = Describe("TF day2 scenrios", func() {
+
 	Context("Author:smiron-Medium-OCP-67570 @OCP-67570 @smiron", func() {
 		var dnsService *exe.DnsService
 		BeforeEach(func() {
@@ -66,6 +69,80 @@ var _ = Describe("TF day2 scenrios", func() {
 				Expect(resourceStateMap["organization_id"]).To(Equal(currentAccountInfo.Body().Organization().ID()))
 				Expect(resourceStateMap["organization_external_id"]).To(Equal(currentAccountInfo.Body().Organization().ExternalID()))
 				Expect(resourceStateMap["organization_name"]).To(Equal(currentAccountInfo.Body().Organization().Name()))
+			})
+	})
+	Context("Author: smiron-Medium-OCP-64907 @OCP-64907 @smiron", func() {
+		var (
+			clusterService           *exe.ClusterService
+			err                      error
+			profile                  *ci.Profile
+			originalCustomProperties map[string]string
+		)
+
+		BeforeEach(func() {
+			// Load profile from YAML file based on environment
+			profile = ci.LoadProfileYamlFileByENV()
+
+			// Initialize the cluster service
+			clusterService, err = exe.NewClusterService(profile.ManifestsDIR)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Read terraform.tfvars file and get its content as a map
+			terraformTFVarsPath := filepath.Join(profile.ManifestsDIR, "terraform.tfvars")
+			terraformTFVarsContent := exe.ReadTerraformTFVars(terraformTFVarsPath)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Capture the original custom properties
+			originalCustomProperties, err = h.ParseStringToMap(terraformTFVarsContent["custom_properties"])
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			// Cleanup
+			clusterArgs := &exe.ClusterCreationArgs{
+				AWSRegion:        profile.Region,
+				CustomProperties: originalCustomProperties,
+			}
+
+			// Restore cluster state
+			err = clusterService.Apply(clusterArgs, false, true)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should validate custom property operations on cluster - day 2",
+			ci.Day2, ci.Medium, ci.FeatureIDP, func() {
+
+				By("Adding additional custom property to the existing cluster")
+				updatedCustomProperties := con.CustomProperties
+				updatedCustomProperties["second_custom_property"] = "test2"
+
+				// Apply updated custom properties to the cluster
+				clusterArgs := &exe.ClusterCreationArgs{
+					AWSRegion:        profile.Region,
+					CustomProperties: updatedCustomProperties,
+				}
+
+				err = clusterService.Apply(clusterArgs, false, true)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Validating cluster's custom property update
+				clusterDetails, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(clusterDetails.Body().Properties()["second_custom_property"]).Should(Equal(updatedCustomProperties["second_custom_property"]))
+
+				By("Applying reserved property to existing cluster should not be allowed")
+				updatedCustomProperties = map[string]string{
+					"rosa_tf_version": "true",
+				}
+
+				clusterArgs = &exe.ClusterCreationArgs{
+					AWSRegion:        profile.Region,
+					CustomProperties: updatedCustomProperties,
+				}
+
+				err = clusterService.Apply(clusterArgs, false, false)
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring("Can not override reserved properties keys"))
 			})
 	})
 })

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -58,10 +58,12 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   aws_account_id     = data.aws_caller_identity.current.account_id
   availability_zones = var.aws_availability_zones
   multi_az           = var.multi_az
-  properties = {
-    rosa_creator_arn = data.aws_caller_identity.current.arn
-    custom_property = "test"
-  }
+  properties = merge(
+        {
+            rosa_creator_arn = data.aws_caller_identity.current.arn
+        },
+        var.custom_properties
+  )
   sts                                             = local.sts_roles
   replicas                                        = var.replicas
   proxy                                           = var.proxy

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -145,6 +145,11 @@ variable "properties" {
   default = null
 }
 
+variable "custom_properties" {
+  type    = map(string)
+  default = null
+}
+
 variable "proxy" {
   type = object({
     http_proxy              = string

--- a/tests/utils/constants/profile_defaults.go
+++ b/tests/utils/constants/profile_defaults.go
@@ -11,8 +11,9 @@ var (
 	DefaultMPLabels  = map[string]string{
 		"test1": "testdata1",
 	}
-	LdapURL       = "ldap://ldap.forumsys.com/dc=example,dc=com?uid"
-	GitLabURL     = "https://gitlab.cee.redhat.com"
-	Organizations = []string{"openshift"}
-	HostedDomain  = "redhat.com"
+	CustomProperties = map[string]string{"custom_property": "test"}
+	LdapURL          = "ldap://ldap.forumsys.com/dc=example,dc=com?uid"
+	GitLabURL        = "https://gitlab.cee.redhat.com"
+	Organizations    = []string{"openshift"}
+	HostedDomain     = "redhat.com"
 )

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -31,6 +31,7 @@ type ClusterCreationArgs struct {
 	DefaultMPLabels                      map[string]string `json:"default_mp_labels,omitempty"`
 	DisableSCPChecks                     bool              `json:"disable_scp_checks,omitempty"`
 	MultiAZ                              bool              `json:"multi_az,omitempty"`
+	CustomProperties                     map[string]string `json:"custom_properties,omitempty"`
 	WorkerDiskSize                       int               `json:"worker_disk_size,omitempty"`
 	AdditionalComputeSecurityGroups      []string          `json:"additional_compute_security_groups,omitempty"`
 	AdditionalInfraSecurityGroups        []string          `json:"additional_infra_security_groups,omitempty"`

--- a/tests/utils/exec/tf-exec.go
+++ b/tests/utils/exec/tf-exec.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path"
 	"strconv"
+	"strings"
 
 	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
 	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
@@ -208,6 +209,34 @@ func recordTFvarsFile(fileDir string, tfvars map[string]string) error {
 
 	}
 	return iniConn.SaveTo(tfvarsFile)
+}
+
+// Function to read terraform.tfvars file and return its content as a map
+func ReadTerraformTFVars(filePath string) map[string]string {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		Logger.Errorf("Can't read file %s - not found or could not be fetched", filePath)
+		return nil
+	}
+
+	lines := strings.Split(string(content), "\n")
+	properties := make(map[string]string)
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "=") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				key := strings.TrimSpace(parts[0])
+				value := strings.TrimSpace(parts[1])
+				// Remove quotes if present
+				value = strings.Trim(value, `"`)
+				properties[key] = value
+			}
+		}
+	}
+
+	return properties
 }
 
 // delete the recorded TFvarsFile named terraform.tfvars

--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -44,6 +44,24 @@ func Parse(data []byte) map[string]interface{} {
 }
 
 func ParseStringToMap(input string) (map[string]string, error) {
+
+	// Attempt to parse input as JSON
+	var jsonData map[string]interface{}
+	if err := json.Unmarshal([]byte(input), &jsonData); err == nil {
+		// If successful, convert the map to map[string]string
+		result := make(map[string]string)
+		for key, value := range jsonData {
+			// Convert each value to string
+			if strValue, ok := value.(string); ok {
+				result[key] = strValue
+			} else {
+				return nil, fmt.Errorf("non-string value found in JSON for key %s", key)
+			}
+		}
+		return result, nil
+	}
+
+	// Fallback to regex-based parsing if JSON parsing fails
 	dataMap := make(map[string]string)
 
 	// Define regex patterns for key-value pairs
@@ -51,6 +69,11 @@ func ParseStringToMap(input string) (map[string]string, error) {
 
 	// Find all matches in the input string
 	matches := pattern.FindAllStringSubmatch(input, -1)
+
+	// Check if there are any matches
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no key-value pairs found in the input string")
+	}
 
 	// Populate the map with key-value pairs
 	for _, match := range matches {


### PR DESCRIPTION
Automation test case : [OCP-64907](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-64907)

The test purpose is to validate custom property operations on cluster - such as adding, deleting, editing custom property to an existing cluster.

Depends on this [PR](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/477).

<img width="647" alt="image" src="https://github.com/terraform-redhat/terraform-provider-rhcs/assets/54883783/43f351e3-d4dd-4a09-b219-435f5a1abf69">

