### PR TITLE
Add an option to prevent terraform.tfvars deletion

### DIFF
--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -406,7 +406,7 @@ func CreateRHCSClusterByProfile(token string, profile *Profile) (string, error) 
 		defer DestroyRHCSClusterByProfile(token, profile)
 	}
 	Expect(err).ToNot(HaveOccurred())
-	err = clusterService.Apply(creationArgs, true)
+	err = clusterService.Apply(creationArgs, true, true)
 	if err != nil {
 		clusterService.Destroy(creationArgs)
 		return "", err

--- a/tests/e2e/negative_day_one_test.go
+++ b/tests/e2e/negative_day_one_test.go
@@ -52,13 +52,13 @@ var _ = Describe("RHCS Provider Negative Test", func() {
 
 					By("Edit cluster admin user name to not valid")
 					creationArgs.AdminCredentials["username"] = "one:two"
-					err = clusterService.Apply(creationArgs, true)
+					err = clusterService.Apply(creationArgs, true, true)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("Attribute admin_credentials.username username may not contain the characters:\n'/:%'"))
 
 					By("Edit cluster admin user name to empty")
 					creationArgs.AdminCredentials["username"] = ""
-					err = clusterService.Apply(creationArgs, true)
+					err = clusterService.Apply(creationArgs, true, true)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("Attribute 'username' is mandatory"))
 				})
@@ -67,31 +67,31 @@ var _ = Describe("RHCS Provider Negative Test", func() {
 			It("Cluster admin during deployment - validate password policy", ci.Day1Negative, func() {
 				By("Edit cluster admin password  to the short one")
 				creationArgs.AdminCredentials["password"] = helper.GenerateRandomStringWithSymbols(13)
-				err = clusterService.Apply(creationArgs, true)
+				err = clusterService.Apply(creationArgs, true, true)
 				Expect(err).To(HaveOccurred())
 
 				Expect(err.Error()).To(ContainSubstring("Attribute admin_credentials.password string length must be at least 14"))
 				By("Edit cluster admin password to empty")
 				creationArgs.AdminCredentials["password"] = ""
-				err = clusterService.Apply(creationArgs, true)
+				err = clusterService.Apply(creationArgs, true, true)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Attribute admin_credentials.password password should use ASCII-standard"))
 
 				By("Edit cluster admin password that lacks a capital letter")
 				creationArgs.AdminCredentials["password"] = strings.ToLower(helper.GenerateRandomStringWithSymbols(14))
-				err = clusterService.Apply(creationArgs, true)
+				err = clusterService.Apply(creationArgs, true, true)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Attribute admin_credentials.password password must contain uppercase\ncharacters"))
 
 				By("Edit cluster admin password that lacks symbol but has digits")
 				creationArgs.AdminCredentials["password"] = "QwertyPasswordNoDigitsSymbols"
-				err = clusterService.Apply(creationArgs, true)
+				err = clusterService.Apply(creationArgs, true, true)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Attribute admin_credentials.password password must contain numbers or\nsymbols"))
 
 				By("Edit cluster admin password that includes Non English chars")
 				creationArgs.AdminCredentials["password"] = "Qwert12345345@ש"
-				err = clusterService.Apply(creationArgs, true)
+				err = clusterService.Apply(creationArgs, true, true)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Attribute admin_credentials.password password should use ASCII-standard\ncharacters only"))
 

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -99,7 +99,7 @@ func (creator *ClusterService) Init(manifestDir string) error {
 
 }
 
-func (creator *ClusterService) Apply(createArgs *ClusterCreationArgs, recordtfvars bool, extraArgs ...string) error {
+func (creator *ClusterService) Apply(createArgs *ClusterCreationArgs, recordtfvars bool, tfvarsDeletion bool, extraArgs ...string) error {
 	createArgs.URL = CON.GateWayURL
 	args, tfvars := combineStructArgs(createArgs, extraArgs...)
 	if recordtfvars {
@@ -108,7 +108,9 @@ func (creator *ClusterService) Apply(createArgs *ClusterCreationArgs, recordtfva
 
 	_, err := runTerraformApplyWithArgs(creator.Context, creator.ManifestDir, args)
 	if err != nil {
-		deleteTFvarsFile(creator.ManifestDir)
+		if tfvarsDeletion {
+			deleteTFvarsFile(creator.ManifestDir)
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
There are cases where deleting terraform.tfvars when facing an error in the cluster is something we would like to prevent -
for example, when we have negative scenarios, we would like the original vars to exists and not get deleted by the test.

The PR opened as a solution for one of the tests described in this [PR](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/476)