### PR TITLE
OCM-3021: MP taints can't be an empty array

### DIFF
--- a/provider/machinepool/machine_pool_resource.go
+++ b/provider/machinepool/machine_pool_resource.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -144,6 +145,9 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 							},
 						},
 					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
 				},
 				Optional: true,
 			},

--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -1082,6 +1082,20 @@ var _ = Describe("Machine pool creation", func() {
 			),
 		)
 
+		// invalid removal of taints
+		terraform.Source(`
+		  resource "rhcs_machine_pool" "my_pool" {
+		    cluster      = "123"
+		    name         = "my-pool"
+		    machine_type = "r5.xlarge"
+		    replicas     = 12
+            taints       = []
+		  }
+		`)
+
+		Expect(terraform.Apply()).ToNot(BeZero())
+
+		// valid removal of taints
 		terraform.Source(`
 		  resource "rhcs_machine_pool" "my_pool" {
 		    cluster      = "123"


### PR DESCRIPTION
This fixes an inconsistent result from the provider when attempting to delete taints by passing an empty array.