### PR TITLE
fix OCP-65981 :: change expected error syntax when no clusterID exists 

### DIFF
--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -853,7 +853,7 @@ var _ = Describe("TF Test", func() {
 						}
 
 						err = importService.Import(importParam)
-						Expect(err.Error()).To(ContainSubstring("'%s' not found", unknownClusterID))
+						Expect(err.Error()).To(ContainSubstring("Cluster %s not found", unknownClusterID))
 
 					})
 			})


### PR DESCRIPTION
<img width="748" alt="image" src="https://github.com/terraform-redhat/terraform-provider-rhcs/assets/54883783/726a66d3-0630-4ed6-841b-9aa97552a56c">
