### PR TITLE
add qe_usage var env to track leakages

### DIFF
--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -198,7 +198,6 @@ func GenerateClusterCreationArgsByProfile(token string, profile *Profile) (clust
 	profile.Version = PrepareVersion(RHCSConnection, profile.Version, profile.ChannelGroup, profile)
 
 	clusterArgs = &EXE.ClusterCreationArgs{
-		// Token:            token,
 		OpenshiftVersion: profile.Version,
 	}
 

--- a/tests/utils/constants/config.go
+++ b/tests/utils/constants/config.go
@@ -26,6 +26,7 @@ type RHCSconfig struct {
 	RHCSEnv           string `env:"RHCS_ENV" default:"staging" yaml:"env"`
 	ClusterProfile    string `env:"CLUSTER_PROFILE" yaml:"clusterProfile,omitempty"`
 	ClusterProfileDir string `env:"CLUSTER_PROFILE_DIR" yaml:"clusterProfileDir,omitempty"`
+	QEUsage           string `env:"QE_USAGE" default:"" yaml:"qeUsage,omitempty"`
 	RhcsOutputDir     string
 	YAMLProfilesDir   string
 	RootDir           string
@@ -47,6 +48,9 @@ func init() {
 	}
 	if os.Getenv("CLUSTER_PROFILE_DIR") != "" {
 		RHCS.ClusterProfileDir = os.Getenv("CLUSTER_PROFILE_DIR")
+	}
+	if os.Getenv("QE_USAGE") != "" {
+		RHCS.QEUsage = os.Getenv("QE_USAGE")
 	}
 
 	RHCS.RhcsOutputDir = GetRHCSOutputDir()

--- a/tests/utils/constants/profile_defaults.go
+++ b/tests/utils/constants/profile_defaults.go
@@ -11,7 +11,7 @@ var (
 	DefaultMPLabels  = map[string]string{
 		"test1": "testdata1",
 	}
-	CustomProperties = map[string]string{"custom_property": "test"}
+	CustomProperties = map[string]string{"custom_property": "test", "qe_usage": RHCS.QEUsage}
 	LdapURL          = "ldap://ldap.forumsys.com/dc=example,dc=com?uid"
 	GitLabURL        = "https://gitlab.cee.redhat.com"
 	Organizations    = []string{"openshift"}


### PR DESCRIPTION
The new custom property - QE_USAGE, will help us to track after leakages by indicating the name of
the profile from which the cluster was created and did not teardown.

Depends on this [PR](https://github.com/openshift/release/pull/47237)