### PR TITLE
exclude OCP-65684 from CI until fixed

### DIFF
--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -146,7 +146,7 @@ var _ = Describe("TF Test", func() {
 
 		Context("Author:smiron-Medium-OCP-65684 @OCP-65684 @smiron", func() {
 			It("OCP-65684 - cluster_rosa_classic resource can be import by the terraform import command",
-				ci.Day2, ci.Medium, ci.FeatureImport, func() {
+				ci.Day2, ci.Medium, ci.FeatureImport, ci.Exclude, func() {
 
 					By("Run the command to import rosa_classic resource")
 					importParam := &exe.ImportArgs{


### PR DESCRIPTION
Following this thread: https://redhat-internal.slack.com/archives/C063JMV5SEP/p1704776239261739
