### PR TITLE
change the place of qe_usage property

### DIFF
--- a/tests/utils/constants/config.go
+++ b/tests/utils/constants/config.go
@@ -26,7 +26,6 @@ type RHCSconfig struct {
 	RHCSEnv           string `env:"RHCS_ENV" default:"staging" yaml:"env"`
 	ClusterProfile    string `env:"CLUSTER_PROFILE" yaml:"clusterProfile,omitempty"`
 	ClusterProfileDir string `env:"CLUSTER_PROFILE_DIR" yaml:"clusterProfileDir,omitempty"`
-	QEUsage           string `env:"QE_USAGE" default:"" yaml:"qeUsage,omitempty"`
 	RhcsOutputDir     string
 	YAMLProfilesDir   string
 	RootDir           string
@@ -48,9 +47,6 @@ func init() {
 	}
 	if os.Getenv("CLUSTER_PROFILE_DIR") != "" {
 		RHCS.ClusterProfileDir = os.Getenv("CLUSTER_PROFILE_DIR")
-	}
-	if os.Getenv("QE_USAGE") != "" {
-		RHCS.QEUsage = os.Getenv("QE_USAGE")
 	}
 
 	RHCS.RhcsOutputDir = GetRHCSOutputDir()

--- a/tests/utils/constants/constants.go
+++ b/tests/utils/constants/constants.go
@@ -23,6 +23,7 @@ const (
 	ClusterIDEnv              = "CLUSTER_ID"
 	RHCSENV                   = "RHCS_ENV"
 	RhcsClusterProfileENV     = "CLUSTER_PROFILE"
+	QEUsage                   = "QE_USAGE"
 	ClusterTypeManifestDirEnv = "CLUSTER_ROSA_TYPE"
 	MajorVersion              = "MAJOR_VERSION_ENV"
 	RHCSVersion               = "RHCS_VERSION"

--- a/tests/utils/constants/profile_defaults.go
+++ b/tests/utils/constants/profile_defaults.go
@@ -11,7 +11,7 @@ var (
 	DefaultMPLabels  = map[string]string{
 		"test1": "testdata1",
 	}
-	CustomProperties = map[string]string{"custom_property": "test", "qe_usage": RHCS.QEUsage}
+	CustomProperties = map[string]string{"custom_property": "test", "qe_usage": GetEnvWithDefault(QEUsage, "")}
 	LdapURL          = "ldap://ldap.forumsys.com/dc=example,dc=com?uid"
 	GitLabURL        = "https://gitlab.cee.redhat.com"
 	Organizations    = []string{"openshift"}


### PR DESCRIPTION
qe_usage was returned empty since it was placed in the wrong files. 
after re-testing, seems to work now:

```
$ ocm get cluster 28mmm599tf8d8vvk1hueprpdpjo4ogp2 | grep qe
    "qe_usage": "rosa-sts-advanced-critical-high-f3-try"
```