### PR TITLE
Fix OCP-65684 :: remove state file to prevent destructive import

### DIFF
--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -146,7 +146,7 @@ var _ = Describe("TF Test", func() {
 
 		Context("Author:smiron-Medium-OCP-65684 @OCP-65684 @smiron", func() {
 			It("OCP-65684 - cluster_rosa_classic resource can be import by the terraform import command",
-				ci.Day2, ci.Medium, ci.FeatureImport, ci.Exclude, func() {
+				ci.Day2, ci.Medium, ci.FeatureImport, func() {
 
 					By("Run the command to import rosa_classic resource")
 					importParam := &exe.ImportArgs{
@@ -176,8 +176,9 @@ var _ = Describe("TF Test", func() {
 					err = importService.Import(importParam)
 					Expect(err.Error()).To(ContainSubstring("Cannot import non-existent remote object"))
 
-					// skip due to bug :: OCM-5246
-					// Expect(output).To(ContainSubstring(profile.ComputeMachineType))
+					By("clean .tfstate file to revert test changes")
+					defer h.CleanManifestsStateFile(con.ImportResourceDir)
+
 				})
 		})
 

--- a/tests/utils/constants/constants.go
+++ b/tests/utils/constants/constants.go
@@ -120,6 +120,10 @@ func GrantTFvarsFile(manifestDir string) string {
 	return path.Join(manifestDir, "terraform.tfvars")
 }
 
+func GrantTFstateFile(manifestDir string) string {
+	return path.Join(manifestDir, "terraform.tfstate")
+}
+
 // Machine pool taints effect
 const (
 	NoExecute        = "NoExecute"

--- a/tests/utils/helper/manifests_handler.go
+++ b/tests/utils/helper/manifests_handler.go
@@ -90,3 +90,11 @@ func AlignRHCSSourceVersion(dir string) error {
 	}
 	return nil
 }
+
+func CleanManifestsStateFile(dir string) error {
+	err := DeleteFile(CON.GrantTFstateFile(dir))
+	if err != nil {
+		return fmt.Errorf("could not remove state file due to error: %s", err.Error())
+	}
+	return nil
+}


### PR DESCRIPTION
`defer h.DeleteFile(con.GrantTFstateFile(con.ImportResourceDir))`

this will delete the state file after importing the rosa sts cluster, and after that we can run other machine-pool/idp import cases without issues.