### PR TITLE
OCPQE-18948 | ci: Create cluster autoscaler with ocm terraform provider

### DIFF
--- a/tests/ci/labels.go
+++ b/tests/ci/labels.go
@@ -5,6 +5,7 @@ import (
 )
 
 // Features
+var FeatureClusterautoscaler = Label("feature-clusterautoscaler")
 var FeatureMachinepool = Label("feature-machinepool")
 var FeatureIDP = Label("feature-idp")
 var FeatureImport = Label("feature-import")

--- a/tests/e2e/cluster_autoscaler_day2_test.go
+++ b/tests/e2e/cluster_autoscaler_day2_test.go
@@ -1,0 +1,134 @@
+package e2e
+
+import (
+
+	// nolint
+
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	ci "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/cms"
+	con "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	exe "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/exec"
+)
+
+var _ = Describe("TF Test", func() {
+	Describe("Create cluster autoscaler test cases", func() {
+		var caService *exe.ClusterAutoscalerService
+		var clusterAutoScalerBodyForRecreate *cmv1.ClusterAutoscaler
+		var clusterAutoscalerStatusBefore int
+
+		BeforeEach(func() {
+			caService = exe.NewClusterAutoscalerService(con.ClusterAutoscalerDir)
+			caRetrieveBody, _ := cms.RetrieveClusterAutoscaler(ci.RHCSConnection, clusterID)
+			clusterAutoscalerStatusBefore = caRetrieveBody.Status()
+			if clusterAutoscalerStatusBefore == http.StatusOK {
+				clusterAutoScalerBodyForRecreate = caRetrieveBody.Body()
+			}
+		})
+		AfterEach(func() {
+			By("Recover clusterautoscaler")
+			clusterAutoscalerAfter, _ := cms.RetrieveClusterAutoscaler(ci.RHCSConnection, clusterID)
+			if (clusterAutoscalerAfter.Status() == clusterAutoscalerStatusBefore) && clusterAutoscalerStatusBefore != http.StatusNotFound {
+				recreateAutoscaler, err := cms.PatchClusterAutoscaler(ci.RHCSConnection, clusterID, clusterAutoScalerBodyForRecreate)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(recreateAutoscaler.Status()).To(Equal(http.StatusOK))
+			} else if clusterAutoscalerAfter.Status() == http.StatusOK && clusterAutoscalerStatusBefore == http.StatusNotFound {
+				deleteAutoscaler, err := cms.DeleteClusterAutoscaler(ci.RHCSConnection, clusterID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deleteAutoscaler.Status()).To(Equal(http.StatusNoContent))
+			} else if clusterAutoscalerAfter.Status() == http.StatusNotFound && clusterAutoscalerStatusBefore == http.StatusOK {
+				recreateAutoscaler, err := cms.CreateClusterAutoscaler(ci.RHCSConnection, clusterID, clusterAutoScalerBodyForRecreate)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(recreateAutoscaler.Status()).To(Equal(http.StatusCreated))
+			}
+		})
+		Context("Author:zhsun-High-OCP-69137 @zhsun", func() {
+			It("Author:zhsun-High-OCP-69137 - Create cluster autoscaler with ocm terraform provider", ci.Day2, ci.High, ci.FeatureClusterautoscaler, func() {
+				By("Delete clusterautoscaler when it exists in cluster")
+				if clusterAutoscalerStatusBefore == http.StatusOK {
+					caDeleteBody, err := cms.DeleteClusterAutoscaler(ci.RHCSConnection, clusterID)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(caDeleteBody.Status()).To(Equal(http.StatusNoContent))
+				}
+
+				By("Create clusterautoscaler")
+				max := 1
+				min := 0
+				resourceRange := &exe.ResourceRange{
+					Max: max,
+					Min: min,
+				}
+				maxNodesTotal := 10
+				resourceLimits := &exe.ResourceLimits{
+					Cores:         resourceRange,
+					MaxNodesTotal: maxNodesTotal,
+					Memory:        resourceRange,
+				}
+				delayAfterAdd := "3h"
+				delayAfterDelete := "3h"
+				delayAfterFailure := "3h"
+				unneededTime := "1h"
+				utilizationThreshold := "0.5"
+				enabled := true
+				scaleDown := &exe.ScaleDown{
+					DelayAfterAdd:        delayAfterAdd,
+					DelayAfterDelete:     delayAfterDelete,
+					DelayAfterFailure:    delayAfterFailure,
+					UnneededTime:         unneededTime,
+					UtilizationThreshold: utilizationThreshold,
+					Enabled:              enabled,
+				}
+				balanceSimilarNodeGroups := true
+				skipNodesWithLocalStorage := true
+				logVerbosity := 1
+				maxPodGracePeriod := 10
+				podPriorityThreshold := -10
+				ignoreDaemonsetsUtilization := true
+				maxNodeProvisionTime := "1h"
+				balancingIgnoredLabels := []string{"l1", "l2"}
+				ClusterAutoscalerArgs := &exe.ClusterAutoscalerArgs{
+					Cluster:                     clusterID,
+					BalanceSimilarNodeGroups:    balanceSimilarNodeGroups,
+					SkipNodesWithLocalStorage:   skipNodesWithLocalStorage,
+					LogVerbosity:                logVerbosity,
+					MaxPodGracePeriod:           maxPodGracePeriod,
+					PodPriorityThreshold:        podPriorityThreshold,
+					IgnoreDaemonsetsUtilization: ignoreDaemonsetsUtilization,
+					MaxNodeProvisionTime:        maxNodeProvisionTime,
+					BalancingIgnoredLabels:      balancingIgnoredLabels,
+					ResourceLimits:              resourceLimits,
+					ScaleDown:                   scaleDown,
+				}
+				_, err = caService.Apply(ClusterAutoscalerArgs, false)
+				Expect(err).ToNot(HaveOccurred())
+				_, err = caService.Output()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verify the parameters of the createdautoscaler")
+				caOut, err := caService.Output()
+				Expect(err).ToNot(HaveOccurred())
+				caResponseBody, err := cms.RetrieveClusterAutoscaler(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(caResponseBody.Body().BalanceSimilarNodeGroups()).To(Equal(caOut.BalanceSimilarNodeGroups))
+				Expect(caResponseBody.Body().SkipNodesWithLocalStorage()).To(Equal(caOut.SkipNodesWithLocalStorage))
+				Expect(caResponseBody.Body().LogVerbosity()).To(Equal(caOut.LogVerbosity))
+				Expect(caResponseBody.Body().MaxPodGracePeriod()).To(Equal(caOut.MaxPodGracePeriod))
+				Expect(caResponseBody.Body().PodPriorityThreshold()).To(Equal(caOut.PodPriorityThreshold))
+				Expect(caResponseBody.Body().IgnoreDaemonsetsUtilization()).To(Equal(caOut.IgnoreDaemonsetsUtilization))
+				Expect(caResponseBody.Body().MaxNodeProvisionTime()).To(Equal(caOut.MaxNodeProvisionTime))
+				Expect(caResponseBody.Body().BalancingIgnoredLabels()).To(Equal(caOut.BalancingIgnoredLabels))
+				Expect(caResponseBody.Body().ResourceLimits().MaxNodesTotal()).To(Equal(caOut.MaxNodesTotal))
+				Expect(caResponseBody.Body().ScaleDown().DelayAfterAdd()).To(Equal(caOut.DelayAfterAdd))
+				Expect(caResponseBody.Body().ScaleDown().DelayAfterDelete()).To(Equal(caOut.DelayAfterDelete))
+				Expect(caResponseBody.Body().ScaleDown().DelayAfterFailure()).To(Equal(caOut.DelayAfterFailure))
+				Expect(caResponseBody.Body().ScaleDown().UnneededTime()).To(Equal(caOut.UnneededTime))
+				Expect(caResponseBody.Body().ScaleDown().UtilizationThreshold()).To(Equal(caOut.UtilizationThreshold))
+				Expect(caResponseBody.Body().ScaleDown().Enabled()).To(Equal(caOut.Enabled))
+			})
+		})
+	})
+})

--- a/tests/tf-manifests/rhcs/cluster-autoscaler/main.tf
+++ b/tests/tf-manifests/rhcs/cluster-autoscaler/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    rhcs = {
+      version = ">= 1.1.0"
+      source  = "terraform.local/local/rhcs"
+    }
+  }
+}
+
+provider "rhcs" {
+  url = var.url
+}
+
+resource "rhcs_cluster_autoscaler" "cluster_autoscaler" {
+  cluster                       = var.cluster_id
+  balance_similar_node_groups   = var.balance_similar_node_groups
+  skip_nodes_with_local_storage = var.skip_nodes_with_local_storage
+  log_verbosity                 = var.log_verbosity
+  max_pod_grace_period          = var.max_pod_grace_period
+  pod_priority_threshold        = var.pod_priority_threshold
+  ignore_daemonsets_utilization = var.ignore_daemonsets_utilization
+  max_node_provision_time       = var.max_node_provision_time
+  balancing_ignored_labels      = var.balancing_ignored_labels
+  resource_limits = {
+    max_nodes_total = var.max_nodes_total
+    cores = {
+      min = var.min_cores
+      max = var.max_cores
+    }
+    memory = {
+      min = var.min_memory
+      max = var.max_memory
+    }
+  }
+  scale_down = {
+    enabled               = var.enabled
+    utilization_threshold = var.utilization_threshold
+    unneeded_time         = var.unneeded_time
+    delay_after_add       = var.delay_after_add
+    delay_after_delete    = var.delay_after_delete
+    delay_after_failure   = var.delay_after_failure
+  }
+}

--- a/tests/tf-manifests/rhcs/cluster-autoscaler/output.tf
+++ b/tests/tf-manifests/rhcs/cluster-autoscaler/output.tf
@@ -1,0 +1,61 @@
+output "cluster_id" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.cluster
+}
+output "balance_similar_node_groups" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.balance_similar_node_groups
+}
+output "skip_nodes_with_local_storage" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.skip_nodes_with_local_storage
+}
+output "log_verbosity" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.log_verbosity
+}
+output "max_pod_grace_period" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.max_pod_grace_period
+}
+output "pod_priority_threshold" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.pod_priority_threshold
+}
+output "ignore_daemonsets_utilization" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.ignore_daemonsets_utilization
+}
+output "max_node_provision_time" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.max_node_provision_time
+}
+output "balancing_ignored_labels" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.balancing_ignored_labels
+}
+output "max_nodes_total" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.resource_limits.max_nodes_total
+}
+output "min_cores" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.resource_limits.cores.min
+}
+output "max_cores" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.resource_limits.cores.max
+}
+output "min_memory" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.resource_limits.memory.min
+}
+output "max_memory" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.resource_limits.memory.max
+}
+output "delay_after_add" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.scale_down.delay_after_add
+}
+output "delay_after_delete" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.scale_down.delay_after_delete
+}
+output "delay_after_failure" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.scale_down.delay_after_failure
+}
+output "unneeded_time" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.scale_down.unneeded_time
+}
+output "utilization_threshold" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.scale_down.utilization_threshold
+}
+output "enabled" {
+  value = rhcs_cluster_autoscaler.cluster_autoscaler.scale_down.enabled
+}
+

--- a/tests/tf-manifests/rhcs/cluster-autoscaler/variable.tf
+++ b/tests/tf-manifests/rhcs/cluster-autoscaler/variable.tf
@@ -1,0 +1,109 @@
+variable "cluster_id" {
+  type = string
+}
+variable "balance_similar_node_groups" {
+  default = true
+  type    = bool
+}
+variable "skip_nodes_with_local_storage" {
+  default = true
+  type    = bool
+}
+variable "log_verbosity" {
+  type    = number
+  default = 1
+}
+variable "max_pod_grace_period" {
+  type    = number
+  default = 10
+}
+variable "pod_priority_threshold" {
+  type    = number
+  default = -10
+}
+variable "ignore_daemonsets_utilization" {
+  default = true
+  type    = bool
+}
+variable "max_node_provision_time" {
+  type    = string
+  default = "1h"
+}
+variable "balancing_ignored_labels" {
+  default = null
+  type    = list(string)
+}
+variable "url" {
+  type    = string
+  default = "https://api.stage.openshift.com"
+}
+
+variable "max_nodes_total" {
+  type    = number
+  default = 10
+}
+variable "min_cores" {
+  type    = number
+  default = 0
+}
+variable "max_cores" {
+  type    = number
+  default = 1
+}
+variable "min_memory" {
+  type    = number
+  default = 0
+}
+variable "max_memory" {
+  type    = number
+  default = 1
+}
+variable "enabled" {
+  default = true
+  type    = bool
+}
+variable "utilization_threshold" {
+  type    = string
+  default = "0.5"
+}
+variable "unneeded_time" {
+  type    = string
+  default = "1h"
+}
+variable "delay_after_add" {
+  type    = string
+  default = "1h"
+}
+variable "delay_after_delete" {
+  type    = string
+  default = "1h"
+}
+variable "delay_after_failure" {
+  type    = string
+  default = "1h"
+}
+variable "resource_limits" {
+  type = object({
+    max_nodes_total = optional(number)
+    cores = object({
+      min_cores = optional(number)
+      max_cores = optional(number)
+    })
+    memory = object({
+      min_memory = optional(number)
+      max_memory = optional(number)
+    })
+  })
+  default = null
+}
+variable "scale_down" {
+  type = object({
+    enabled               = bool
+    utilization_threshold = optional(string)
+    unneeded_time         = optional(string)
+    delay_after_add       = optional(string)
+    delay_after_delete    = optional(string)
+    delay_after_failure   = optional(string)
+  })
+  default = null
+}

--- a/tests/utils/cms/cms.go
+++ b/tests/utils/cms/cms.go
@@ -255,6 +255,26 @@ func RetrieveClusterMachinePool(connection *client.Connection, clusterID string,
 	return resp.Body(), nil
 }
 
+func CreateClusterAutoscaler(connection *client.Connection, clusterID string, body *cmv1.ClusterAutoscaler) (*cmv1.AutoscalerPostResponse, error) {
+	resp, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Autoscaler().Post().Request(body).Send()
+	return resp, err
+}
+
+func PatchClusterAutoscaler(connection *client.Connection, clusterID string, body *cmv1.ClusterAutoscaler) (*cmv1.AutoscalerUpdateResponse, error) {
+	resp, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Autoscaler().Update().Body(body).Send()
+	return resp, err
+}
+
+func DeleteClusterAutoscaler(connection *client.Connection, clusterID string) (*cmv1.AutoscalerDeleteResponse, error) {
+	resp, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Autoscaler().Delete().Send()
+	return resp, err
+}
+
+func RetrieveClusterAutoscaler(connection *client.Connection, clusterID string) (*cmv1.AutoscalerGetResponse, error) {
+	resp, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Autoscaler().Get().Send()
+	return resp, err
+}
+
 // Upgrade policies related
 func ListUpgradePolicies(connection *client.Connection, clusterID string, params ...map[string]interface{}) (*cmv1.UpgradePoliciesListResponse, error) {
 	request := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).UpgradePolicies().List()

--- a/tests/utils/constants/manifests.go
+++ b/tests/utils/constants/manifests.go
@@ -77,6 +77,7 @@ var (
 	RhcsInfoDir           = path.Join(ManifestsConfigurationDir, RHCSProviderDir, "rhcs-info")
 	DefaultMachinePoolDir = path.Join(ManifestsConfigurationDir, RHCSProviderDir, "default-machine-pool")
 	KubeletConfigDir      = path.Join(ManifestsConfigurationDir, RHCSProviderDir, "kubelet-config")
+	ClusterAutoscalerDir  = path.Join(ManifestsConfigurationDir, RHCSProviderDir, "cluster-autoscaler")
 )
 
 func GetClusterManifestsDir(clusterType ClusterType) string {

--- a/tests/utils/exec/cluster-autoscaler.go
+++ b/tests/utils/exec/cluster-autoscaler.go
@@ -1,0 +1,154 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+)
+
+type ClusterAutoscalerArgs struct {
+	Cluster                     string          `json:"cluster_id,omitempty"`
+	OCMENV                      string          `json:"ocm_environment,omitempty"`
+	BalanceSimilarNodeGroups    bool            `json:"balance_similar_node_groups,omitempty"`
+	SkipNodesWithLocalStorage   bool            `json:"skip_nodes_with_local_storage,omitempty"`
+	LogVerbosity                int             `json:"log_verbosity,omitempty"`
+	MaxPodGracePeriod           int             `json:"max_pod_grace_period,omitempty"`
+	PodPriorityThreshold        int             `json:"pod_priority_threshold,omitempty"`
+	IgnoreDaemonsetsUtilization bool            `json:"ignore_daemonsets_utilization,omitempty"`
+	MaxNodeProvisionTime        string          `json:"max_node_provision_time,omitempty"`
+	BalancingIgnoredLabels      []string        `json:"balancing_ignored_labels,omitempty"`
+	ResourceLimits              *ResourceLimits `json:"resource_limits,omitempty"`
+	ScaleDown                   *ScaleDown      `json:"scale_down,omitempty"`
+}
+type ResourceLimits struct {
+	Cores         *ResourceRange `json:"cores,omitempty"`
+	MaxNodesTotal int            `json:"max_nodes_total,omitempty"`
+	Memory        *ResourceRange `json:"memory,omitempty"`
+}
+type ScaleDown struct {
+	DelayAfterAdd        string `json:"delay_after_add,omitempty"`
+	DelayAfterDelete     string `json:"delay_after_delete,omitempty"`
+	DelayAfterFailure    string `json:"delay_after_failure,omitempty"`
+	UnneededTime         string `json:"unneeded_time,omitempty"`
+	UtilizationThreshold string `json:"utilization_threshold,omitempty"`
+	Enabled              bool   `json:"enabled,omitempty"`
+}
+type ResourceRange struct {
+	Max int `json:"max,omitempty"`
+	Min int `json:"min,omitempty"`
+}
+type ClusterAutoscalerService struct {
+	CreationArgs *ClusterAutoscalerArgs
+	ManifestDir  string
+	Context      context.Context
+}
+type ClusterAutoscalerOutput struct {
+	Cluster                     string   `json:"cluster_id,omitempty"`
+	BalanceSimilarNodeGroups    bool     `json:"balance_similar_node_groups,omitempty"`
+	SkipNodesWithLocalStorage   bool     `json:"skip_nodes_with_local_storage,omitempty"`
+	LogVerbosity                int      `json:"log_verbosity,omitempty"`
+	MaxPodGracePeriod           int      `json:"max_pod_grace_period,omitempty"`
+	PodPriorityThreshold        int      `json:"pod_priority_threshold,omitempty"`
+	IgnoreDaemonsetsUtilization bool     `json:"ignore_daemonsets_utilization,omitempty"`
+	MaxNodeProvisionTime        string   `json:"max_node_provision_time,omitempty"`
+	BalancingIgnoredLabels      []string `json:"balancing_ignored_labels,omitempty"`
+	MaxNodesTotal               int      `json:"max_nodes_total,omitempty"`
+	MinCores                    int      `json:"min_cores,omitempty"`
+	MaxCores                    int      `json:"max_cores,omitempty"`
+	MinMemory                   int      `json:"min_memory,omitempty"`
+	MaxMemory                   int      `json:"max_memory,omitempty"`
+	DelayAfterAdd               string   `json:"delay_after_add,omitempty"`
+	DelayAfterDelete            string   `json:"delay_after_delete,omitempty"`
+	DelayAfterFailure           string   `json:"delay_after_failure,omitempty"`
+	UnneededTime                string   `json:"unneeded_time,omitempty"`
+	UtilizationThreshold        string   `json:"utilization_threshold,omitempty"`
+	Enabled                     bool     `json:"enabled,omitempty"`
+}
+
+func (ca *ClusterAutoscalerService) Init(manifestDirs ...string) error {
+	ca.ManifestDir = CON.ClusterAutoscalerDir
+	if len(manifestDirs) != 0 {
+		ca.ManifestDir = manifestDirs[0]
+	}
+	ctx := context.TODO()
+	ca.Context = ctx
+	err := runTerraformInit(ctx, ca.ManifestDir)
+	if err != nil {
+		return err
+	}
+	return nil
+
+}
+
+func (ca *ClusterAutoscalerService) Apply(createArgs *ClusterAutoscalerArgs, recordtfargs bool, extraArgs ...string) (string, error) {
+	ca.CreationArgs = createArgs
+	args, tfvars := combineStructArgs(createArgs, extraArgs...)
+	output, err := runTerraformApplyWithArgs(ca.Context, ca.ManifestDir, args)
+	if err == nil && recordtfargs {
+		recordTFvarsFile(ca.ManifestDir, tfvars)
+	}
+	return output, err
+}
+
+func (ca *ClusterAutoscalerService) Plan(createArgs *ClusterAutoscalerArgs, extraArgs ...string) (string, error) {
+	ca.CreationArgs = createArgs
+	args, _ := combineStructArgs(createArgs, extraArgs...)
+	output, err := runTerraformPlanWithArgs(ca.Context, ca.ManifestDir, args)
+	return output, err
+}
+
+func (ca *ClusterAutoscalerService) Output() (ClusterAutoscalerOutput, error) {
+	caDir := CON.ClusterAutoscalerDir
+	if ca.ManifestDir != "" {
+		caDir = ca.ManifestDir
+	}
+	var output ClusterAutoscalerOutput
+	out, err := runTerraformOutput(context.TODO(), caDir)
+	if err != nil {
+		return output, err
+	}
+	output = ClusterAutoscalerOutput{
+		Cluster:                     h.DigString(out["cluster_id"], "value"),
+		LogVerbosity:                h.DigInt(out["log_verbosity"], "value"),
+		BalanceSimilarNodeGroups:    h.DigBool(out["balance_similar_node_groups"], "value"),
+		SkipNodesWithLocalStorage:   h.DigBool(out["skip_nodes_with_local_storage"], "value"),
+		MaxPodGracePeriod:           h.DigInt(out["max_pod_grace_period"], "value"),
+		PodPriorityThreshold:        h.DigInt(out["pod_priority_threshold"], "value"),
+		IgnoreDaemonsetsUtilization: h.DigBool(out["ignore_daemonsets_utilization"], "value"),
+		MaxNodeProvisionTime:        h.DigString(out["max_node_provision_time"], "value"),
+		BalancingIgnoredLabels:      h.DigArrayToString(out["balancing_ignored_labels"], "value"),
+		MaxNodesTotal:               h.DigInt(out["max_nodes_total"], "value"),
+		MinCores:                    h.DigInt(out["min_cores"], "value"),
+		MaxCores:                    h.DigInt(out["max_cores"], "value"),
+		MinMemory:                   h.DigInt(out["min_memory"], "value"),
+		MaxMemory:                   h.DigInt(out["max_memory"], "value"),
+		DelayAfterAdd:               h.DigString(out["delay_after_add"], "value"),
+		DelayAfterDelete:            h.DigString(out["delay_after_delete"], "value"),
+		DelayAfterFailure:           h.DigString(out["delay_after_failure"], "value"),
+		UnneededTime:                h.DigString(out["unneeded_time"], "value"),
+		UtilizationThreshold:        h.DigString(out["utilization_threshold"], "value"),
+		Enabled:                     h.DigBool(out["enabled"], "value"),
+	}
+	return output, nil
+}
+
+func (ca *ClusterAutoscalerService) Destroy(createArgs ...*ClusterAutoscalerArgs) (output string, err error) {
+	if ca.CreationArgs == nil && len(createArgs) == 0 {
+		return "", fmt.Errorf("got unset destroy args, set it in object or pass as a parameter")
+	}
+	destroyArgs := ca.CreationArgs
+	if len(createArgs) != 0 {
+		destroyArgs = createArgs[0]
+	}
+	args, _ := combineStructArgs(destroyArgs)
+
+	return runTerraformDestroyWithArgs(ca.Context, ca.ManifestDir, args)
+}
+
+func NewClusterAutoscalerService(manifestDir ...string) *ClusterAutoscalerService {
+	ca := &ClusterAutoscalerService{}
+	ca.Init(manifestDir...)
+	return ca
+}


### PR DESCRIPTION
@xueli181114 PTAL
```
$ ginkgo -focus OCP-69137 tests/e2e                                                                                                         
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.9.1
  Mismatched package versions found:
    2.13.2 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
time="2024-01-12T16:01:24+08:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2024-01-12T16:01:24+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version:latest worker_disk_size:200 zones:]"
Running Suite: e2e tests suite - /Users/sunzhaohua/code/terraform-provider-rhcs/tests/e2e
=========================================================================================
Random Seed: 1705046481

Will run 1 of 53 specs
SSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden
/Users/sunzhaohua/code/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:244
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSStime="2024-01-12T16:01:24+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:true hypershift:false imdsv2:required labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version:latest worker_disk_size:200 zones:]"
time="2024-01-12T16:01:24+08:00" level=info msg="Running terraform init against the dir /Users/sunzhaohua/code/terraform-provider-rhcs/tests/tf-manifests/rhcs/cluster-autoscaler"
time="2024-01-12T16:01:31+08:00" level=info msg="Running terraform apply against the dir: /Users/sunzhaohua/code/terraform-provider-rhcs/tests/tf-manifests/rhcs/cluster-autoscaler with args [-var skip_nodes_with_local_storage=true -var max_pod_grace_period=10 -var balancing_ignored_labels=[\"l1\",\"l2\"] -var scale_down={\"delay_after_add\":\"3h\",\"delay_after_delete\":\"3h\",\"delay_after_failure\":\"3h\",\"enabled\":true,\"unneeded_time\":\"1h\",\"utilization_threshold\":\"0.5\"} -var cluster_id=28n855d5e30qjpp8hglv1j3jl9im4o77 -var balance_similar_node_groups=true -var log_verbosity=1 -var pod_priority_threshold=-10 -var ignore_daemonsets_utilization=true -var max_node_provision_time=1h -var resource_limits={\"cores\":{\"max\":1},\"max_nodes_total\":10,\"memory\":{\"max\":1}}]"
time="2024-01-12T16:01:37+08:00" level=info msg="Running terraform output against the dir: /Users/sunzhaohua/code/terraform-provider-rhcs/tests/tf-manifests/rhcs/cluster-autoscaler"
time="2024-01-12T16:01:37+08:00" level=info msg="Running terraform output against the dir: /Users/sunzhaohua/code/terraform-provider-rhcs/tests/tf-manifests/rhcs/cluster-autoscaler"
time="2024-01-12T16:01:38+08:00" level=info msg="Running terraform destroy against the dir: /Users/sunzhaohua/code/terraform-provider-rhcs/tests/tf-manifests/rhcs/cluster-autoscaler"
args:  /usr/local/bin/terraform destroy -auto-approve -no-color -var cluster_id=28n855d5e30qjpp8hglv1j3jl9im4o77 -var skip_nodes_with_local_storage=true -var max_pod_grace_period=10 -var pod_priority_threshold=-10 -var ignore_daemonsets_utilization=true -var balancing_ignored_labels=["l1","l2"] -var scale_down={"delay_after_add":"3h","delay_after_delete":"3h","delay_after_failure":"3h","enabled":true,"unneeded_time":"1h","utilization_threshold":"0.5"} -var balance_similar_node_groups=true -var log_verbosity=1 -var max_node_provision_time=1h -var resource_limits={"cores":{"max":1},"max_nodes_total":10,"memory":{"max":1}}
•SSSSSSSSSSSSSS

Ran 1 of 53 Specs in 23.317 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 51 Skipped
PASS
```