### PR TITLE
fix typo in ingress error message

### DIFF
--- a/provider/defaultingress/ingress.go
+++ b/provider/defaultingress/ingress.go
@@ -230,7 +230,7 @@ func (r *DefaultIngressResource) Update(ctx context.Context, req resource.Update
 		diags.AddError(
 			"Failed to update default ingress",
 			fmt.Sprintf(
-				"Cannont upate default ingress for"+
+				"Cannot update default ingress for "+
 					"cluster '%s': %v", state.Cluster.ValueString(), err,
 			),
 		)


### PR DESCRIPTION
Currently the actual output looks like 
```
│ Cannont upate default ingress forcluster '28gjcif4b7fluce0uksce104492bjk0h': status is 400 ...
``` 

Expected:
```
Cannot update default ingress for cluster ...
```


