### PR TITLE
OCM-5422: Make the commit format more clear

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,15 @@
 <!--
 - Please ensure code changes are split into a series of logically independent commits.
 - Every commit should have a subject/title (What) and a description/body (Why).
+  The commit subject needs to conform to the following format:
+  [JIRA-TICKET] | [TYPE]: <MESSAGE>
+  Where:
+     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
+     TYPE must be one of the options (case sensitive):
+          feat, fix, docs, style, refactor, test, chore, build, ci, perf
+  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
 - Every PR must have a description.
 - As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-- Make sure to follow commit format described in [Commit Messages Format Guide](../CONTRIBUTE.md)
 -->
 
 **What this PR does / why we need it**:

--- a/.github/workflows/check-commit-format.yml
+++ b/.github/workflows/check-commit-format.yml
@@ -28,6 +28,10 @@ jobs:
           echo "validating $message"
           if ! echo "$message" | grep -qE "^[A-Z]+-[0-9]+ \| (feat|fix|docs|style|refactor|test|chore|build|ci|perf): .*$"; then
             echo "Invalid commit message format. Expected format: JIRA_TICKET | TYPE: MESSAGE"
+            echo "Where:"
+            echo "   JIRA_TICKET is jira ticket ID (for example OCM-xxx)"
+            echo "   TYPE must be one of the options (case sensitive):"
+            echo "        feat, fix, docs, style, refactor, test, chore, build, ci, perf"
             exit 1
           fi
           done

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -67,7 +67,7 @@ to follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#
 
 The commit message should follow this template:
 ```shell
-<type>[JIRA-TICKET] | [TYPE]: <MESSAGE>
+[JIRA-TICKET] | [TYPE]: <MESSAGE>
 
 [optional BODY]
 


### PR DESCRIPTION


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Make sure to follow commit format described in [Commit Messages Format Guide](../CONTRIBUTE.md)
-->

**What this PR does / why we need it**:
Add more details about the TYPE options

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #[OCM-5422](https://issues.redhat.com//browse/OCM-5422)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
