### PR TITLE
OCM-4953 | fix: remove paths from SHA256SUM releases

### DIFF
--- a/build/build_multiarch
+++ b/build/build_multiarch
@@ -25,7 +25,7 @@ do
     cp terraform-registry-manifest.json releases/terraform-provider-rhcs_${REL_VER}_manifest.json
   done
 done
-sha256sum releases/*zip releases/terraform-provider-rhcs_${REL_VER}_manifest.json > releases/terraform-provider-rhcs_${REL_VER}_SHA256SUMS
+cd releases && sha256sum *zip terraform-provider-rhcs_${REL_VER}_manifest.json > terraform-provider-rhcs_${REL_VER}_SHA256SUMS
 }
 
 prepare_release


### PR DESCRIPTION
SHA256SUM file needs a column with each filename of the release.
We were adding the full path and it breaks the Hashicorp release sync.

