### PR TITLE
OCM-5853: exclude commits validations for PRs created by specific authors

### DIFF
--- a/.github/workflows/check-commit-format.yml
+++ b/.github/workflows/check-commit-format.yml
@@ -20,18 +20,35 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+
         run: |
           IFS=$'\n' commit_messages=($(git log --pretty=format:"%s" $BASE_SHA...$HEAD_SHA))          
           
+          # Lists of GitHub users for whom the commit validation should be skipped:
+          # * red-hat-konflux - automatic bot responsible for any change related to
+          #   RHTAP integration (changes in https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/.tekton/terraform-provider-rhcs-push.yaml)
+          declare -a skip_pr_authors=(
+            "red-hat-konflux"
+          )
+          echo "The PR Author is \"${PR_AUTHOR}\""
+          for skip_pr_author in "${skip_pr_authors[@]}"
+          do
+            if [ "${PR_AUTHOR}" = "${skip_pr_author}" ]; then
+              echo "The commits created by this PR author (probably bot) should be skipped!!!"
+              exit 0
+            fi
+          done
+
           for message in "${commit_messages[@]}"
           do
-          echo "validating $message"
-          if ! echo "$message" | grep -qE "^[A-Z]+-[0-9]+ \| (feat|fix|docs|style|refactor|test|chore|build|ci|perf): .*$"; then
-            echo "Invalid commit message format. Expected format: JIRA_TICKET | TYPE: MESSAGE"
-            echo "Where:"
-            echo "   JIRA_TICKET is jira ticket ID (for example OCM-xxx)"
-            echo "   TYPE must be one of the options (case sensitive):"
-            echo "        feat, fix, docs, style, refactor, test, chore, build, ci, perf"
-            exit 1
-          fi
+            echo "validating commit message:\"$message\""
+            if ! echo "$message" | grep -qE "^[A-Z]+-[0-9]+ \| (feat|fix|docs|style|refactor|test|chore|build|ci|perf): .*$"; then
+              echo "Invalid commit message format. Expected format: JIRA_TICKET | TYPE: MESSAGE"
+              echo "Where:"
+              echo "   JIRA_TICKET is jira ticket ID (for example OCM-xxx)"
+              echo "   TYPE must be one of the options (case sensitive):"
+              echo "        feat, fix, docs, style, refactor, test, chore, build, ci, perf"
+              exit 1
+            fi
           done


### PR DESCRIPTION


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:
This is done for exclude commits in auto generated PRs Now added commit message from red-hat-konflux

**Which issue(s) this PR fixes**:
Fixes #[OCM-5853](https://issues.redhat.com//browse/OCM-5853)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
