### PR TITLE
OCM-5698 | ci: fix key-pair name duplication

### DIFF
--- a/tests/tf-manifests/aws/proxy/main.tf
+++ b/tests/tf-manifests/aws/proxy/main.tf
@@ -45,7 +45,7 @@ resource "tls_private_key" "proxy_ssh_key" {
 }
 
 resource "aws_key_pair" "generated_key" {
-  key_name   = "imported-proxy-key"
+  key_name   = "imported-proxy-key-${timestamp()}"
   public_key = tls_private_key.proxy_ssh_key.public_key_openssh
 }
 


### PR DESCRIPTION
This will prevent error messages "already exists" for imported-key-pair name in case they are not deleted (leftovers).