### PR TITLE
OCM-4331 | ci: fix OCP-63141 to prevent CI failure

### DIFF
--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -110,18 +110,18 @@ var _ = Describe("TF Test", func() {
 			})
 		})
 		Context("Author:smiron-Medium-OCP-63141 @OCP-63141 @smiron", func() {
-			It("Verify availability zones and multi-az is set post cluster creation", ci.Day1Post, ci.Medium, func() {
-				vpcService := exe.NewVPCService()
+			It("Verify availability zones and multi-az are set post cluster creation", ci.Day1Post, ci.Medium, func() {
+				getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
 				zonesArray := strings.Split(profile.Zones, ",")
-				clusterAvailZones := cluster.Nodes().AvailabilityZones()
+				clusterAvailZones := getResp.Body().Nodes().AvailabilityZones()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.MultiAZ()).To(Equal(profile.MultiAZ))
+				Expect(getResp.Body().MultiAZ()).To(Equal(profile.MultiAZ))
+
 				if profile.Zones != "" {
-					Expect(clusterAvailZones).
-						To(Equal(H.JoinStringWithArray(profile.Region, zonesArray)))
+					Expect(clusterAvailZones).To(Equal(H.JoinStringWithArray(profile.Region, zonesArray)))
 				} else {
-					vpcOut, _ := vpcService.Output()
-					Expect(clusterAvailZones).To(Equal(vpcOut.AZs))
+					// the default zone for each region
+					Expect(clusterAvailZones[0]).To(Equal(fmt.Sprintf("%sa", profile.Region)))
 				}
 			})
 		})


### PR DESCRIPTION
We had issues with the optional job for rhcs-sts-pl clusters - since the machine_pool_test.go is running before the verification post day1 tests, test case OCP-65071 changes the number of subnets the cluster's vpc have.
hence, the post day1 test case OCP-63141, which validates availability zones and multi-az are set post cluster creation fails, as it reads the current state which was not cleaned after the first test.
In this PR, I have changed OCP-63141 test to not be depended on the results of OCP-65071.