### PR TITLE
OCM-5551 | ci: Hide the sensitive information in terraform automation log

### DIFF
--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -224,6 +224,9 @@ func PrepareProxy(region string, VPCID string, subnetPublicID string) (*EXE.Prox
 
 func PrepareKMSKey(profile *Profile, kmsName string, accountRolePrefix string, accountRolePath string) (string, error) {
 	kmsService, err := EXE.NewKMSService()
+	if err != nil {
+		return "", err
+	}
 	kmsArgs := &EXE.KMSArgs{
 		KMSName:           kmsName,
 		AWSRegion:         profile.Region,

--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -49,9 +49,9 @@ var _ = Describe("TF Test", func() {
 				}
 				getResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(getResp.Body().Proxy().GetHTTPProxy()).To(ContainSubstring("http://"))
-				Expect(getResp.Body().Proxy().GetHTTPSProxy()).To(ContainSubstring("https://"))
-				Expect(getResp.Body().Proxy().GetNoProxy()).To(Equal("quay.io"))
+				Expect(getResp.Body().Proxy().HTTPProxy()).To(ContainSubstring("http://"))
+				Expect(getResp.Body().Proxy().HTTPSProxy()).To(ContainSubstring("https://"))
+				Expect(getResp.Body().Proxy().NoProxy()).To(Equal("quay.io"))
 				Expect(getResp.Body().AdditionalTrustBundle()).To(Equal("REDACTED"))
 			})
 		})

--- a/tests/utils/exec/tf-exec.go
+++ b/tests/utils/exec/tf-exec.go
@@ -85,12 +85,11 @@ func runTerraformDestroyWithArgs(ctx context.Context, dir string, terraformArgs 
 	var stdoutput bytes.Buffer
 	terraformDestroy.Stdout = &stdoutput
 	terraformDestroy.Stderr = os.Stderr
-	fmt.Println("args: ", terraformDestroy)
 	err = terraformDestroy.Run()
 	output = h.Strip(stdoutput.String(), "\n")
 	if err != nil {
-		Logger.Errorf(output)
 		err = fmt.Errorf("%s: %s", err.Error(), output)
+		Logger.Errorf(err.Error())
 		return
 	}
 	deleteTFvarsFile(dir)

--- a/tests/utils/log/constants.go
+++ b/tests/utils/log/constants.go
@@ -1,0 +1,15 @@
+package log
+
+import (
+	"regexp"
+)
+
+const (
+	RedactValue = "XXXXXXXX"
+)
+
+var RedactKeyList = []*regexp.Regexp{
+	regexp.MustCompile(`(\\?"password\\?":\\?")([^"]*)(\\?")`),
+	regexp.MustCompile(`(\\?"additional_trust_bundle\\?":\\?")([^"]*)(\\?")`),
+	regexp.MustCompile(`(-----BEGIN CERTIFICATE-----\n)([^-----]*)(-----END CERTIFICATE-----)`),
+}

--- a/tests/utils/log/logger.go
+++ b/tests/utils/log/logger.go
@@ -1,15 +1,86 @@
 package log
 
 import (
+	"fmt"
+	"regexp"
+
 	logging "github.com/sirupsen/logrus"
 )
 
-func GetLogger() *logging.Logger {
+func GetLogger() *Log {
 	// Create the logger
 	logger := logging.New()
 	// Set logger level for your debug command
 	logger.SetLevel(logging.InfoLevel)
-	return logger
+	return &Log{logger: logger, redActSensitive: true}
 }
 
-var Logger *logging.Logger = GetLogger()
+var Logger *Log = GetLogger()
+
+type Log struct {
+	logger          *logging.Logger
+	redActSensitive bool
+}
+
+func (l *Log) NeedRedact(originalString string, regexP *regexp.Regexp) bool {
+	return regexP.MatchString(originalString)
+}
+func (l *Log) Redact(fmtedString string) string {
+	if !l.redActSensitive {
+		return fmtedString
+	}
+	for _, regexP := range RedactKeyList {
+		if l.NeedRedact(fmtedString, regexP) {
+			l.logger.Debugf("Got need redacted string from log match regex %s", regexP.String())
+			fmtedString = regexP.ReplaceAllString(fmtedString, fmt.Sprintf(`$1"%s$3`, RedactValue))
+		}
+	}
+	return fmtedString
+}
+func (l *Log) Infof(fmtString string, args ...interface{}) {
+	if len(args) != 0 {
+		fmtString = fmt.Sprintf(fmtString, args...)
+	}
+	l.Info(fmtString)
+}
+
+func (l *Log) Info(fmtString string) {
+	fmtString = l.Redact(fmtString)
+	l.logger.Info(fmtString)
+}
+
+func (l *Log) Errorf(fmtString string, args ...interface{}) {
+	if len(args) != 0 {
+		fmtString = fmt.Sprintf(fmtString, args...)
+	}
+	l.Error(fmtString)
+}
+
+func (l *Log) Error(fmtString string) {
+	fmtString = l.Redact(fmtString)
+	l.logger.Error(fmtString)
+}
+
+func (l *Log) Warnf(fmtString string, args ...interface{}) {
+	if len(args) != 0 {
+		fmtString = fmt.Sprintf(fmtString, args...)
+	}
+	l.Warn(fmtString)
+}
+
+func (l *Log) Warn(fmtString string) {
+	fmtString = l.Redact(fmtString)
+	l.logger.Warn(fmtString)
+}
+
+func (l *Log) Debugf(fmtString string, args ...interface{}) {
+	if len(args) != 0 {
+		fmtString = fmt.Sprintf(fmtString, args...)
+	}
+	l.Debug(fmtString)
+}
+
+func (l *Log) Debug(fmtString string) {
+	fmtString = l.Redact(fmtString)
+	l.logger.Debug(fmtString)
+}


### PR DESCRIPTION

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:
The log of CI job contains sensitive information which should be hidden.
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #[OCM-5551](https://issues.redhat.com/browse/OCM-5551) Hide the sensitive information in terraform automation log

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.

**Current output**
```
lixue@Xue-Lis-MacBook-Pro terraform-provider-rhcs % ginkgo run --label-filter day1-prepare tests/e2e --timeout 2h     
time="2024-02-23T22:33:18+08:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2024-02-23T22:33:18+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:false hypershift:false imdsv2:required kms_key_arn:true labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version: version_pattern:latest worker_disk_size:200 zones:]"
Running Suite: e2e tests suite - /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/e2e
================================================================================================
Random Seed: 1708698791

Will run 1 of 59 specs
time="2024-02-23T22:33:18+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:false hypershift:false imdsv2:required kms_key_arn:true labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version: version_pattern:latest worker_disk_size:200 zones:]"
time="2024-02-23T22:33:18+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic"
time="2024-02-23T22:33:26+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic"
time="2024-02-23T22:33:28+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-ad : map[additional_sg_number:4 admin_enabled:true autoscale:true byok:true byovpc:true ccs:true channel_group:candidate cloud_provider:aws compute_machine_type:m5.2xlarge etcd_encryption:true fips:false hypershift:false imdsv2:required kms_key_arn:true labeling:true major_version:4.14 multi_az:true oidc_config:un-managed private:false private_link:false product_id:rosa proxy:true region:ap-northeast-1 sts:true tagging:true unified_acc_role_path:/unified/ version: version_pattern:latest worker_disk_size:200 zones:]"
time="2024-02-23T22:33:30+08:00" level=info msg="Cluster OCP latest version is set to 4.14.14"
time="2024-02-23T22:33:30+08:00" level=info msg="Admin password is written to the output directory"
time="2024-02-23T22:33:30+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/account-roles"
time="2024-02-23T22:33:39+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/account-roles with args [-var account_role_prefix=rhcs-sts-ad-myu -var rhcs_environment=staging -var openshift_version=4.14 -var url=https://api.stage.openshift.com -var channel_group=candidate -var path=/unified/]"
time="2024-02-23T22:33:53+08:00" level=info msg="Recording tfvars file /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/account-roles/terraform.tfvars"
time="2024-02-23T22:33:53+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/account-roles"
time="2024-02-23T22:33:54+08:00" level=info msg="Created account roles with prefix rhcs-sts-ad-myu"
time="2024-02-23T22:33:54+08:00" level=info msg="Sleep for 10 sec to let aws account role async creation finished"
time="2024-02-23T22:34:04+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/oidc-provider-operator-roles"
time="2024-02-23T22:34:15+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/oidc-provider-operator-roles with args [-var account_role_prefix=rhcs-sts-ad-myu -var operator_role_prefix=rhcs-sts-ad-myu -var url=https://api.stage.openshift.com -var oidc_config=un-managed -var aws_region=ap-northeast-1 -var rhcs_environment=staging -var path=/unified/]"
time="2024-02-23T22:34:34+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/oidc-provider-operator-roles"
time="2024-02-23T22:34:36+08:00" level=info msg="Recording tfvars file /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/oidc-provider-operator-roles/terraform.tfvars"
time="2024-02-23T22:34:36+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-02-23T22:34:43+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/vpc with args [-var name=rhcs-sts-ad-myu -var aws_region=ap-northeast-1 -var vpc_cidr=10.0.0.0/16 -var multi_az=true]"
time="2024-02-23T22:36:39+08:00" level=info msg="Recording tfvars file /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/vpc/terraform.tfvars"
time="2024-02-23T22:36:39+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-02-23T22:36:41+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/security-groups"
time="2024-02-23T22:36:45+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/security-groups with args [-var vpc_id=vpc-0a9615d6ce7edcf99 -var aws_region=ap-northeast-1 -var name_prefix=rhcs-ci -var sg_number=9]"
time="2024-02-23T22:36:57+08:00" level=info msg="Recording tfvars file /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/security-groups/terraform.tfvars"
time="2024-02-23T22:36:57+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/security-groups"
time="2024-02-23T22:36:59+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/proxy"
time="2024-02-23T22:37:04+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/proxy with args [-var trust_bundle_path=/Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/rhcs_output/ca.cert -var aws_region=ap-northeast-1 -var vpc_id=vpc-0a9615d6ce7edcf99 -var subnet_public_id=subnet-0a5abb5a4859a1e9d]"
time="2024-02-23T22:38:15+08:00" level=info msg="Recording tfvars file /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/proxy/terraform.tfvars"
time="2024-02-23T22:38:15+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/proxy"
time="2024-02-23T22:38:17+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/kms"
time="2024-02-23T22:38:23+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/kms with args [-var tag_description=BYOK Test Key for API automation -var kms_name=rhcs-sts-ad-myu -var aws_region=ap-northeast-1 -var account_role_prefix=rhcs-sts-ad-myu -var path=/unified/ -var tag_key=Purpose -var tag_value=RHCS automation test]"
time="2024-02-23T22:38:40+08:00" level=info msg="Recording tfvars file /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/kms/terraform.tfvars"
time="2024-02-23T22:38:40+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/aws/kms"
time="2024-02-23T22:38:41+08:00" level=info msg="Running terraform init against the dir /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic"
time="2024-02-23T22:38:47+08:00" level=info msg="Recording tfvars file /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic/terraform.tfvars"
time="2024-02-23T22:38:47+08:00" level=info msg="Running terraform apply against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic with args [-var aws_availability_zones=[\"ap-northeast-1a\",\"ap-northeast-1c\",\"ap-northeast-1d\"] -var kms_key_arn=arn:aws:kms:ap-northeast-1:301721915996:key/4864bc0e-079f-47ec-bb00-3375037b99d3 -var aws_subnet_ids=[\"subnet-00ca2c72c1ffb8439\",\"subnet-099acd5a38b051173\",\"subnet-077526e073584462d\",\"subnet-0a5abb5a4859a1e9d\",\"subnet-042a99a53dbb74eff\",\"subnet-0bee63d290150918b\"] -var worker_disk_size=200 -var additional_compute_security_groups=[\"sg-059d9b30197491c2a\",\"sg-0f1fe149c96387319\",\"sg-08239c0a5b7bbd1cf\",\"sg-0e8067f357ad59368\"] -var additional_control_plane_security_groups=[\"sg-059d9b30197491c2a\",\"sg-0f1fe149c96387319\",\"sg-08239c0a5b7bbd1cf\",\"sg-0e8067f357ad59368\"] -var oidc_config_id=29j5tteljp8o2om3lbsm6ed4srs3h7la -var account_role_prefix=rhcs-sts-ad-myu -var openshift_version=4.14.14 -var url=https://api.stage.openshift.com -var channel_group=candidate -var machine_cidr=10.0.0.0/16 -var path=/unified/ -var cluster_name=rhcs-sts-ad-myu -var operator_role_prefix=rhcs-sts-ad-myu -var aws_region=ap-northeast-1 -var multi_az=true -var proxy={\"additional_trust_bundle\":\"\"XXXXXXXX\",\"http_proxy\":\"http://10.0.101.252:8080\",\"https_proxy\":\"https://10.0.101.252:8080\",\"no_proxy\":\"quay.io\"} -var tags={\"tag1\":\"test_tag1\",\"tag2\":\"test_tag2\"} -var etcd_encryption=true -var compute_machine_type=m5.2xlarge -var default_mp_labels={\"test1\":\"testdata1\"} -var custom_properties={\"custom_property\":\"test\",\"qe_usage\":\"\"} -var additional_infra_security_groups=[\"sg-059d9b30197491c2a\",\"sg-0f1fe149c96387319\",\"sg-08239c0a5b7bbd1cf\",\"sg-0e8067f357ad59368\"] -var admin_credentials={\"password\":\"\"XXXXXXXX\",\"username\":\"rhcs-clusteradmin\"}]"
time="2024-02-23T22:39:14+08:00" level=info msg="Running terraform output against the dir: /Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-classic"
•SSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden
/Users/lixue/Workspace/ocm-tf/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:260
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 59 Specs in 357.176 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 57 Skipped
PASS
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.13.2


Ginkgo ran 1 suite in 6m4.957290007s
Test Suite Passed
```
