### PR TITLE
OCM-6148 | feat: allow longer cluster names

### DIFF
--- a/docs/data-sources/cluster_rosa_classic.md
+++ b/docs/data-sources/cluster_rosa_classic.md
@@ -27,6 +27,7 @@ data "rhcs_cluster_rosa_classic" "cluster" {
 
 ### Optional
 
+- `domain_prefix` (String) The domain prefix is optionally assigned by the user.It will appear in the Cluster's domain when the cluster is provisionedIf not supplied, it will be auto generated.After the creation of the resource, it is not possible to update the attribute value.
 - `kms_key_arn` (String) Used to encrypt root volume of compute node pools. The key ARN is the Amazon Resource Name (ARN) of a AWS Key Management Service (KMS) Key. It is a unique, fully qualified identifier for the AWS KMS Key. A key ARN includes the AWS account, Region, and the key ID(optional). After the creation of the resource, it is not possible to update the attribute value.
 
 ### Read-Only
@@ -65,7 +66,7 @@ data "rhcs_cluster_rosa_classic" "cluster" {
 - `max_replicas` (Number) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 - `min_replicas` (Number) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 - `multi_az` (Boolean) Indicates if the cluster should be deployed to multiple availability zones. Default value is 'false'. This attribute is specifically applies for the Worker Machine Pool and becomes irrelevant once the resource is created. Any modifications to the default Machine Pool should be made through the Terraform imported Machine Pool resource. For more details, refer to [Worker Machine Pool in ROSA Cluster](../guides/worker-machine-pool.md)
-- `name` (String) Name of the cluster. Cannot exceed 15 characters in length. After the creation of the resource, it is not possible to update the attribute value.
+- `name` (String) Name of the cluster. Cannot exceed 54 characters in length. After the creation of the resource, it is not possible to update the attribute value.
 - `ocm_properties` (Map of String) Merged properties defined by OCM and the user defined 'properties'.
 - `pod_cidr` (String) Block of IP addresses for pods. After the creation of the resource, it is not possible to update the attribute value.
 - `private` (Boolean) Restrict cluster API endpoint and application routes to, private connectivity. This requires that PrivateLink be enabled and by extension, your own VPC. After the creation of the resource, it is not possible to update the attribute value.

--- a/docs/data-sources/cluster_rosa_hcp.md
+++ b/docs/data-sources/cluster_rosa_hcp.md
@@ -21,6 +21,7 @@ OpenShift managed cluster using rosa sts.
 
 ### Optional
 
+- `domain_prefix` (String) The domain prefix is optionally assigned by the user.It will appear in the Cluster's domain when the cluster is provisionedIf not supplied, it will be auto generated.After the creation of the resource, it is not possible to update the attribute value.
 - `kms_key_arn` (String) Used to encrypt root volume of compute node pools. The key ARN is the Amazon Resource Name (ARN) of a AWS Key Management Service (KMS) Key. It is a unique, fully qualified identifier for the AWS KMS Key. A key ARN includes the AWS account, Region, and the key ID(optional). After the creation of the resource, it is not possible to update the attribute value.
 
 ### Read-Only
@@ -43,7 +44,7 @@ OpenShift managed cluster using rosa sts.
 - `external_id` (String) Unique external identifier of the cluster. After the creation of the resource, it is not possible to update the attribute value.
 - `host_prefix` (Number) Length of the prefix of the subnet assigned to each node. After the creation of the resource, it is not possible to update the attribute value.
 - `machine_cidr` (String) Block of IP addresses for nodes. After the creation of the resource, it is not possible to update the attribute value.
-- `name` (String) Name of the cluster. Cannot exceed 15 characters in length. After the creation of the resource, it is not possible to update the attribute value.
+- `name` (String) Name of the cluster. Cannot exceed 54 characters in length. After the creation of the resource, it is not possible to update the attribute value.
 - `ocm_properties` (Map of String) Merged properties defined by OCM and the user defined 'properties'.
 - `pod_cidr` (String) Block of IP addresses for pods. After the creation of the resource, it is not possible to update the attribute value.
 - `private` (Boolean) Provides private connectivity from your cluster's VPC to Red Hat SRE, without exposing traffic to the public internet. After the creation of the resource, it is not possible to update the attribute value.

--- a/docs/resources/cluster_rosa_classic.md
+++ b/docs/resources/cluster_rosa_classic.md
@@ -49,7 +49,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
 
 - `aws_account_id` (String) Identifier of the AWS account. After the creation of the resource, it is not possible to update the attribute value.
 - `cloud_region` (String) Cloud region identifier, for example 'us-east-1'.
-- `name` (String) Name of the cluster. Cannot exceed 15 characters in length. After the creation of the resource, it is not possible to update the attribute value.
+- `name` (String) Name of the cluster. Cannot exceed 54 characters in length. After the creation of the resource, it is not possible to update the attribute value.
 
 ### Optional
 
@@ -70,6 +70,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
 - `disable_scp_checks` (Boolean) Indicates if cloud permission checks are disabled when attempting installation of the cluster. After the creation of the resource, it is not possible to update the attribute value.
 - `disable_waiting_in_destroy` (Boolean) Disable addressing cluster state in the destroy resource. Default value is false, and so a `destroy` will wait for the cluster to be deleted.
 - `disable_workload_monitoring` (Boolean) Enables you to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics.
+- `domain_prefix` (String) The domain prefix is optionally assigned by the user.It will appear in the Cluster's domain when the cluster is provisioned. If not supplied, it will be auto generated. It cannot exceed 15 characters in length. After the creation of the resource, it is not possible to update the attribute value.
 - `ec2_metadata_http_tokens` (String) This value determines which EC2 Instance Metadata Service mode to use for EC2 instances in the cluster.This can be set as `optional` (IMDS v1 or v2) or `required` (IMDSv2 only). This feature is available from OpenShift version 4.11.0 and newer. After the creation of the resource, it is not possible to update the attribute value.
 - `etcd_encryption` (Boolean) Encrypt etcd data. Note that all AWS storage is already encrypted. After the creation of the resource, it is not possible to update the attribute value.
 - `fips` (Boolean) Create cluster that uses FIPS Validated / Modules in Process cryptographic libraries. After the creation of the resource, it is not possible to update the attribute value.

--- a/docs/resources/cluster_rosa_hcp.md
+++ b/docs/resources/cluster_rosa_hcp.md
@@ -22,7 +22,7 @@ OpenShift managed cluster using ROSA HCP.
 - `aws_billing_account_id` (String) Identifier of the AWS account for billing. After the creation of the resource, it is not possible to update the attribute value.
 - `aws_subnet_ids` (List of String) AWS subnet IDs. After the creation of the resource, it is not possible to update the attribute value.
 - `cloud_region` (String) AWS region identifier, for example 'us-east-1'.
-- `name` (String) Name of the cluster. Cannot exceed 15 characters in length. After the creation of the resource, it is not possible to update the attribute value.
+- `name` (String) Name of the cluster. Cannot exceed 54 characters in length. After the creation of the resource, it is not possible to update the attribute value.
 - `sts` (Attributes) STS configuration. (see [below for nested schema](#nestedatt--sts))
 
 ### Optional
@@ -31,6 +31,7 @@ OpenShift managed cluster using ROSA HCP.
 - `compute_machine_type` (String) Identifies the machine type used by the initial worker nodes, for example `m5.xlarge`. Use the `rhcs_machine_types` data source to find the possible values. This attribute is specifically applies for the Worker Node Pool and becomes irrelevant once the resource is created. Any modifications to the default Machine Pool should be made through the Terraform imported Machine Pool resource. For more details, refer to [Worker Node Pool in ROSA Cluster](../guides/worker-machine-pool.md)
 - `destroy_timeout` (Number) This value sets the maximum duration in minutes to allow for destroying resources. Default value is 60 minutes.
 - `disable_waiting_in_destroy` (Boolean) Disable addressing cluster state in the destroy resource. Default value is false, and so a `destroy` will wait for the cluster to be deleted.
+- `domain_prefix` (String) The domain prefix is optionally assigned by the user.It will appear in the Cluster's domain when the cluster is provisioned. If not supplied, it will be auto generated. It cannot exceed 15 characters in length. After the creation of the resource, it is not possible to update the attribute value.
 - `etcd_encryption` (Boolean) Encrypt etcd data. Note that all AWS storage is already encrypted. After the creation of the resource, it is not possible to update the attribute value.
 - `etcd_kms_key_arn` (String) Used for etcd encryption. The key ARN is the Amazon Resource Name (ARN) of a AWS Key Management Service (KMS) Key. It is a unique, fully qualified identifier for the AWS KMS Key. A key ARN includes the AWS account, Region, and the key ID(optional). After the creation of the resource, it is not possible to update the attribute value.
 - `host_prefix` (Number) Length of the prefix of the subnet assigned to each node. After the creation of the resource, it is not possible to update the attribute value.

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,9 @@ require (
 
 require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
+	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
+	golang.org/x/sys v0.17.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 )
 
@@ -112,8 +114,6 @@ require (
 	golang.org/x/crypto v0.20.0 // indirect
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df // indirect
 	golang.org/x/mod v0.13.0 // indirect
-	golang.org/x/net v0.21.0 // indirect
-	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97 // indirect

--- a/provider/cluster/cluster_resource.go
+++ b/provider/cluster/cluster_resource.go
@@ -74,6 +74,13 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Description: "Name of the cluster.",
 				Required:    true,
 			},
+			"domain_prefix": schema.StringAttribute{
+				Description: "The domain prefix is optionally assigned by the user." +
+					"It will appear in the Cluster's domain when the cluster is provisioned. " +
+					"If not supplied, it will be auto generated",
+				Optional: true,
+				Computed: true,
+			},
 			"cloud_provider": schema.StringAttribute{
 				Description: "Cloud provider identifier, for example 'aws'.",
 				Required:    true,
@@ -255,6 +262,9 @@ func createClusterObject(ctx context.Context,
 	// Create the cluster:
 	builder := cmv1.NewCluster()
 	builder.Name(state.Name.ValueString())
+	if common.HasValue(state.DomainPrefix) {
+		builder.DomainPrefix(state.DomainPrefix.ValueString())
+	}
 	builder.CloudProvider(cmv1.NewCloudProvider().ID(state.CloudProvider.ValueString()))
 	builder.Product(cmv1.NewProduct().ID(state.Product.ValueString()))
 	builder.Region(cmv1.NewCloudRegion().ID(state.CloudRegion.ValueString()))
@@ -635,6 +645,7 @@ func populateClusterState(object *cmv1.Cluster, state *ClusterState) error {
 	object.API()
 	state.Product = types.StringValue(object.Product().ID())
 	state.Name = types.StringValue(object.Name())
+	state.DomainPrefix = types.StringValue(object.DomainPrefix())
 	state.CloudProvider = types.StringValue(object.CloudProvider().ID())
 	state.CloudRegion = types.StringValue(object.Region().ID())
 	state.MultiAZ = types.BoolValue(object.MultiAZ())

--- a/provider/cluster/cluster_resource_test.go
+++ b/provider/cluster/cluster_resource_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Cluster creation", func() {
 	clusterName := "my-cluster"
 	clusterVersion := "openshift-v4.11.12"
 	productId := "rosa"
+	domainPrefix := "my-cluster-dns-prefix"
 	cloudProviderId := "aws"
 	regionId := "us-east-1"
 	multiAz := true
@@ -59,8 +60,9 @@ var _ = Describe("Cluster creation", func() {
 		properties, _ := common.ConvertStringMapToMapType(map[string]string{"rosa_creator_arn": rosaCreatorArn})
 
 		clusterState := &ClusterState{
-			Name:    types.StringValue(clusterName),
-			Version: types.StringValue(clusterVersion),
+			Name:         types.StringValue(clusterName),
+			Version:      types.StringValue(clusterVersion),
+			DomainPrefix: types.StringValue(domainPrefix),
 
 			CloudRegion:       types.StringValue(regionId),
 			AWSAccountID:      types.StringValue(awsAccountID),
@@ -74,6 +76,7 @@ var _ = Describe("Cluster creation", func() {
 
 		Expect(clusterObject.Name()).To(Equal(clusterName))
 		Expect(clusterObject.Version().ID()).To(Equal(clusterVersion))
+		Expect(clusterObject.DomainPrefix()).To(Equal(domainPrefix))
 
 		id, ok := clusterObject.Region().GetID()
 		Expect(ok).To(BeTrue())
@@ -93,7 +96,8 @@ var _ = Describe("Cluster creation", func() {
 	It("populateClusterState converts correctly a Cluster object into a ClusterState", func() {
 		// We builder a Cluster object by creating a json and using cmv1.UnmarshalCluster on it
 		clusterJson := map[string]interface{}{
-			"id": clusterId,
+			"id":            clusterId,
+			"domain_prefix": domainPrefix,
 			"product": map[string]interface{}{
 				"id": productId,
 			},
@@ -148,6 +152,7 @@ var _ = Describe("Cluster creation", func() {
 		Expect(clusterState.ID.ValueString()).To(Equal(clusterId))
 		Expect(clusterState.Version.ValueString()).To(Equal(clusterVersion))
 		Expect(clusterState.Product.ValueString()).To(Equal(productId))
+		Expect(clusterState.DomainPrefix.ValueString()).To(Equal(domainPrefix))
 		Expect(clusterState.CloudProvider.ValueString()).To(Equal(cloudProviderId))
 		Expect(clusterState.CloudRegion.ValueString()).To(Equal(regionId))
 		Expect(clusterState.MultiAZ.ValueBool()).To(Equal(multiAz))

--- a/provider/cluster/cluster_state.go
+++ b/provider/cluster/cluster_state.go
@@ -45,6 +45,7 @@ type ClusterState struct {
 	MultiAZ                                   types.Bool   `tfsdk:"multi_az"`
 	AvailabilityZones                         types.List   `tfsdk:"availability_zones"`
 	Name                                      types.String `tfsdk:"name"`
+	DomainPrefix                              types.String `tfsdk:"domain_prefix"`
 	PodCIDR                                   types.String `tfsdk:"pod_cidr"`
 	Properties                                types.Map    `tfsdk:"properties"`
 	ServiceCIDR                               types.String `tfsdk:"service_cidr"`

--- a/provider/clusterrosa/classic/cluster_rosa_classic_datasource.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_datasource.go
@@ -65,8 +65,15 @@ func (r *ClusterRosaClassicDatasource) Schema(ctx context.Context, req datasourc
 				Computed:    true,
 			},
 			"name": schema.StringAttribute{
-				Description: "Name of the cluster. Cannot exceed 15 characters in length. " + common.ValueCannotBeChangedStringDescription,
+				Description: "Name of the cluster. Cannot exceed 54 characters in length. " + common.ValueCannotBeChangedStringDescription,
 				Computed:    true,
+			},
+			"domain_prefix": schema.StringAttribute{
+				Description: "The domain prefix is optionally assigned by the user." +
+					"It will appear in the Cluster's domain when the cluster is provisioned" +
+					"If not supplied, it will be auto generated." + common.ValueCannotBeChangedStringDescription,
+				Optional: true,
+				Computed: true,
 			},
 			"cloud_region": schema.StringAttribute{
 				Description: "Cloud region identifier, for example 'us-east-1'.",

--- a/provider/clusterrosa/classic/cluster_rosa_classic_resource_test.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_resource_test.go
@@ -50,6 +50,7 @@ func (c MockHttpClient) Get(url string) (resp *http.Response, err error) {
 const (
 	clusterId         = "1n2j3k4l5m6n7o8p9q0r"
 	clusterName       = "my-cluster"
+	domainPrefix      = "domain-prefix"
 	regionId          = "us-east-1"
 	multiAz           = true
 	rosaCreatorArn    = "arn:aws:iam::123456789012:dummy/dummy"
@@ -85,8 +86,9 @@ var (
 
 func generateBasicRosaClassicClusterJson() map[string]interface{} {
 	return map[string]interface{}{
-		"id":   clusterId,
-		"name": clusterName,
+		"id":            clusterId,
+		"name":          clusterName,
+		"domain_prefix": domainPrefix,
 		"region": map[string]interface{}{
 			"id": regionId,
 		},
@@ -139,6 +141,7 @@ func generateBasicRosaClassicClusterState() *ClusterRosaClassicState {
 	}
 	return &ClusterRosaClassicState{
 		Name:              types.StringValue(clusterName),
+		DomainPrefix:      types.StringValue(domainPrefix),
 		CloudRegion:       types.StringValue(regionId),
 		AWSAccountID:      types.StringValue(awsAccountID),
 		AvailabilityZones: azs,
@@ -170,6 +173,7 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(rosaClusterObject.Name()).To(Equal(clusterName))
+			Expect(rosaClusterObject.DomainPrefix()).To(Equal(domainPrefix))
 
 			id, ok := rosaClusterObject.Region().GetID()
 			Expect(ok).To(BeTrue())
@@ -250,7 +254,8 @@ var _ = Describe("Rosa Classic Sts cluster", func() {
 
 			Expect(clusterState.APIURL.ValueString()).To(Equal(apiUrl))
 			Expect(clusterState.ConsoleURL.ValueString()).To(Equal(consoleUrl))
-			Expect(clusterState.Domain.ValueString()).To(Equal(fmt.Sprintf("%s.%s", clusterName, baseDomain)))
+			Expect(clusterState.DomainPrefix.ValueString()).To(Equal(domainPrefix))
+			Expect(clusterState.Domain.ValueString()).To(Equal(fmt.Sprintf("%s.%s", domainPrefix, baseDomain)))
 
 			Expect(clusterState.AvailabilityZones.Elements()).To(HaveLen(1))
 			azs, err := common.StringListToArray(context.Background(), clusterState.AvailabilityZones)

--- a/provider/clusterrosa/classic/cluster_rosa_classic_state.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_state.go
@@ -58,6 +58,7 @@ type ClusterRosaClassicState struct {
 	DisableSCPChecks                          types.Bool                   `tfsdk:"disable_scp_checks"`
 	AvailabilityZones                         types.List                   `tfsdk:"availability_zones"`
 	Name                                      types.String                 `tfsdk:"name"`
+	DomainPrefix                              types.String                 `tfsdk:"domain_prefix"`
 	PodCIDR                                   types.String                 `tfsdk:"pod_cidr"`
 	Properties                                types.Map                    `tfsdk:"properties"`
 	OCMProperties                             types.Map                    `tfsdk:"ocm_properties"`

--- a/provider/clusterrosa/common/consts.go
+++ b/provider/clusterrosa/common/consts.go
@@ -17,7 +17,8 @@ const (
 	NonPositiveTimeoutSummary       = "Can't poll cluster state with a non-positive timeout"
 	NonPositiveTimeoutFormat        = "Can't poll state of cluster with identifier '%s', the timeout that was set is not a positive number"
 
-	MaxClusterNameLength = 15
+	MaxClusterNameLength         = 54
+	MaxClusterDomainPrefixLength = 15
 )
 
 var OCMProperties = map[string]string{

--- a/provider/clusterrosa/hcp/datasource.go
+++ b/provider/clusterrosa/hcp/datasource.go
@@ -68,8 +68,15 @@ func (r *ClusterRosaHcpDatasource) Schema(ctx context.Context, req datasource.Sc
 				Computed:    true,
 			},
 			"name": schema.StringAttribute{
-				Description: "Name of the cluster. Cannot exceed 15 characters in length. " + common.ValueCannotBeChangedStringDescription,
+				Description: "Name of the cluster. Cannot exceed 54 characters in length. " + common.ValueCannotBeChangedStringDescription,
 				Computed:    true,
+			},
+			"domain_prefix": schema.StringAttribute{
+				Description: "The domain prefix is optionally assigned by the user." +
+					"It will appear in the Cluster's domain when the cluster is provisioned" +
+					"If not supplied, it will be auto generated." + common.ValueCannotBeChangedStringDescription,
+				Optional: true,
+				Computed: true,
 			},
 			"cloud_region": schema.StringAttribute{
 				Description: "Cloud region identifier, for example 'us-east-1'.",

--- a/provider/clusterrosa/hcp/resource_test.go
+++ b/provider/clusterrosa/hcp/resource_test.go
@@ -49,6 +49,7 @@ const (
 	clusterId           = "1n2j3k4l5m6n7o8p9q0r"
 	clusterName         = "my-cluster"
 	regionId            = "us-east-1"
+	domainPrefix        = "domain-prefix"
 	rosaCreatorArn      = "arn:aws:iam::123456789012:dummy/dummy"
 	apiUrl              = "https://api.my-cluster.com:6443"
 	consoleUrl          = "https://console.my-cluster.com"
@@ -87,8 +88,9 @@ var (
 
 func generateBasicRosaHcpClusterJson() map[string]interface{} {
 	return map[string]interface{}{
-		"id":   clusterId,
-		"name": clusterName,
+		"id":            clusterId,
+		"name":          clusterName,
+		"domain_prefix": domainPrefix,
 		"hypershift": map[string]interface{}{
 			"enabled": true,
 		},
@@ -146,6 +148,7 @@ func generateBasicRosaHcpClusterState() *ClusterRosaHcpState {
 	subnetIdsList, _ := types.ListValueFrom(context.TODO(), types.StringType, subnetIds)
 	return &ClusterRosaHcpState{
 		Name:                types.StringValue(clusterName),
+		DomainPrefix:        types.StringValue(domainPrefix),
 		CloudRegion:         types.StringValue(regionId),
 		AWSAccountID:        types.StringValue(awsAccountID),
 		AWSBillingAccountID: types.StringValue(awsBillingAccountId),
@@ -177,6 +180,7 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(rosaClusterObject.Name()).To(Equal(clusterName))
+			Expect(rosaClusterObject.DomainPrefix()).To(Equal(domainPrefix))
 
 			id, ok := rosaClusterObject.Region().GetID()
 			Expect(ok).To(BeTrue())
@@ -257,7 +261,8 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 
 			Expect(clusterState.APIURL.ValueString()).To(Equal(apiUrl))
 			Expect(clusterState.ConsoleURL.ValueString()).To(Equal(consoleUrl))
-			Expect(clusterState.Domain.ValueString()).To(Equal(fmt.Sprintf("%s.%s", clusterName, baseDomain)))
+			Expect(clusterState.Domain.ValueString()).To(Equal(fmt.Sprintf("%s.%s", domainPrefix, baseDomain)))
+			Expect(clusterState.DomainPrefix.ValueString()).To(Equal(domainPrefix))
 
 			Expect(clusterState.AvailabilityZones.Elements()).To(HaveLen(1))
 			azs, err := common.StringListToArray(context.Background(), clusterState.AvailabilityZones)

--- a/provider/clusterrosa/hcp/state.go
+++ b/provider/clusterrosa/hcp/state.go
@@ -9,6 +9,7 @@ import (
 type ClusterRosaHcpState struct {
 	ID             types.String `tfsdk:"id"`
 	Name           types.String `tfsdk:"name"`
+	DomainPrefix   types.String `tfsdk:"domain_prefix"`
 	ExternalID     types.String `tfsdk:"external_id"`
 	Private        types.Bool   `tfsdk:"private"`
 	APIURL         types.String `tfsdk:"api_url"`

--- a/subsystem/cluster_resource_rosa_create_test.go
+++ b/subsystem/cluster_resource_rosa_create_test.go
@@ -63,6 +63,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 	  "external_id": "123",
 	  "infra_id": "my-cluster-123",
 	  "name": "my-cluster",
+	  "domain_prefix": "mydomainprefix",
 	  "state": "ready",
 	  "region": {
 	    "id": "us-west-1"
@@ -108,6 +109,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 	  "external_id": "123",
 	  "infra_id": "my-cluster-123",
 	  "name": "my-cluster",
+	  "domain_prefix": "mydomainprefix",
 	  "additional_trust_bundle" : "REDUCTED",
 	  "state": "ready",
 	  "region": {
@@ -152,6 +154,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 	const templateReadyState = `{
 	  "id": "123",
 	  "name": "my-cluster",
+	  "domain_prefix": "my-cluster",
 	  "state": "ready",
 	  "region": {
 	    "id": "us-west-1"
@@ -572,6 +575,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 				CombineHandlers(
 					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
 					VerifyJQ(`.name`, "my-cluster"),
+					VerifyJQ(`.domain_prefix`, "mydomainprefix"),
 					VerifyJQ(`.cloud_provider.id`, "aws"),
 					VerifyJQ(`.region.id`, "us-west-1"),
 					VerifyJQ(`.product.id`, "rosa"),
@@ -603,6 +607,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 			terraform.Source(`
 		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
 		    name           = "my-cluster"
+			domain_prefix  = "mydomainprefix"
 		    cloud_region   = "us-west-1"
 			aws_account_id = "123"
 			sts = {
@@ -1797,11 +1802,11 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 			Expect(terraform.Apply()).ToNot(BeZero())
 		})
 
-		It("Should fail cluster creation when cluster name length is more than 15", func() {
+		It("Should fail cluster creation when cluster name length is more than 54", func() {
 			// Run the apply command:
 			terraform.Source(`
 		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
-		    name           = "my-cluster-234567"
+		    name           = "my-cluster-234567-foobarfoobar-foobar-fooobaaar-fooo-baaaar"
 		    cloud_region   = "us-west-1"
 			aws_account_id = "123"
 			properties = {

--- a/subsystem/cluster_resource_rosa_import_test.go
+++ b/subsystem/cluster_resource_rosa_import_test.go
@@ -29,6 +29,7 @@ var _ = Describe("rhcs_cluster_rosa_classic - import", func() {
 	const template = `{
 		"id": "123",
 		"name": "my-cluster",
+		"domain_prefix": "my-cluster",
 		"region": {
 		  "id": "us-west-1"
 		},

--- a/subsystem/cluster_resource_test.go
+++ b/subsystem/cluster_resource_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Cluster creation", func() {
 		"id": "osd"
 	  },
 	  "name": "my-cluster",
+	  "domain_prefix": "my-cluster",
 	  "cloud_provider": {
 	    "id": "aws"
 	  },

--- a/subsystem/cluster_waiter_test.go
+++ b/subsystem/cluster_waiter_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Cluster creation", func() {
 	const templateReadyState = `{
 	  "id": "123",
 	  "name": "my-cluster",
+	  "domain_prefix": "my-cluster",
 	  "state": "ready",
 	  "region": {
 	    "id": "us-west-1"
@@ -57,6 +58,7 @@ var _ = Describe("Cluster creation", func() {
 	const templateWaitingState = `{
 	  "id": "123",
 	  "name": "my-cluster",
+	  "domain_prefix": "my-cluster",
 	  "state": "waiting",
 	  "region": {
 	    "id": "us-west-1"
@@ -82,6 +84,7 @@ var _ = Describe("Cluster creation", func() {
 	const templateErrorState = `{
 	  "id": "123",
 	  "name": "my-cluster",
+	  "domain_prefix": "my-cluster",
 	  "state": "error",
 	  "region": {
 	    "id": "us-west-1"

--- a/subsystem/hcp/cluster_resource_test.go
+++ b/subsystem/hcp/cluster_resource_test.go
@@ -1628,11 +1628,11 @@ var _ = Describe("HCP Cluster", func() {
 			Expect(terraform.Apply()).ToNot(BeZero())
 		})
 
-		It("Should fail cluster creation when cluster name length is more than 15", func() {
+		It("Should fail cluster creation when cluster name length is more than 54", func() {
 			// Run the apply command:
 			terraform.Source(`
 			resource "rhcs_cluster_rosa_hcp" "my_cluster" {
-				name           = "my-cluster-234567"
+				name           = "my-cluster-234567-foobar-foobar-foobar-foobar-fooobaaar-fooobaaz"
 				cloud_region   = "us-west-1"
 				aws_account_id = "123"
 				aws_billing_account_id = "123"

--- a/subsystem/identity_provider_resource_test.go
+++ b/subsystem/identity_provider_resource_test.go
@@ -1152,6 +1152,7 @@ var _ = Describe("Identity provider import", func() {
 	  "external_id": "123",
 	  "infra_id": "my-cluster-123",
 	  "name": "my-cluster",
+	  "domain_prefix": "my-cluster",
 	  "state": "ready",
 	  "region": {
 	    "id": "us-west-1"


### PR DESCRIPTION
**What this PR does / why we need it**:
The changes allow customer to supply a name which can be less than <= 54 characters and a domain_prefix optional field to customise the cluster's domain.

**Which issue(s) this PR fixes**:
Fixes #[OCM-6148](https://issues.redhat.com//browse/OCM-6148)

**Change type**
- [x] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [x] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
