### PR TITLE
OCM-6720 | feat: Adding example usage for trusted ip data source

### DIFF
--- a/examples/list_trusted_ip_addresses/README.md
+++ b/examples/list_trusted_ip_addresses/README.md
@@ -1,0 +1,5 @@
+# Trusted Ip Addresses list example
+
+This example shows how to use the trusted ip addresses data source to get a list of the
+supported ip addresses. To run it adjust the configuration of the provider in
+the `main.tf` file and then run the `terraform apply` command.

--- a/examples/list_trusted_ip_addresses/main.tf
+++ b/examples/list_trusted_ip_addresses/main.tf
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+terraform {
+  required_providers {
+    rhcs = {
+      version = ">= 1.1.0"
+      source  = "terraform-redhat/rhcs"
+    }
+  }
+}
+
+provider "rhcs" {
+}
+
+data "rhcs_trusted_ip_addresses" "all" {
+}
+
+output "trusted_ip_addresses" {
+  description = "Trusted Ip Addresses"
+  value       = data.rhcs_trusted_ip_addresses.all
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Request from [OCM-6084](https://issues.redhat.com/browse/OCM-6084) , Feature adding example usage for trusted ip addresses data source.

JIRA: [OCM-6720](https://issues.redhat.com/browse/OCM-6720)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [x] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
