### PR TITLE
OCM-902: Verify imdsv2 value is set post cluster creation

### DIFF
--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -50,7 +50,7 @@ type Profile struct {
 	Proxy                 bool   `ini:"proxy,omitempty" json:"proxy,omitempty"`
 	OIDCConfig            string `ini:"oidc_config,omitempty" json:"oidc_config,omitempty"`
 	ProvisionShard        string `ini:"provisionShard,omitempty" json:"provisionShard,omitempty"`
-	Ec2MetadataHttpTokens string `ini:"imdsv2,omitempty" json:"imdsv2,omitempty"`
+	Ec2MetadataHttpTokens string `ini:"ec2_metadata_http_tokens,omitempty" json:"ec2_metadata_http_tokens,omitempty"`
 	ComputeMachineType    string `ini:"compute_machine_type,omitempty" json:"compute_machine_type,omitempty"`
 	AuditLogForward       bool   `ini:"auditlog_forward,omitempty" json:"auditlog_forward,omitempty"`
 	AdminEnabled          bool   `ini:"admin_enabled,omitempty" json:"admin_enabled,omitempty"`
@@ -352,6 +352,10 @@ func GenerateClusterCreationArgsByProfile(token string, profile *Profile) (clust
 
 	if profile.ChannelGroup != "" {
 		clusterArgs.ChannelGroup = profile.ChannelGroup
+	}
+
+	if profile.Ec2MetadataHttpTokens != "" {
+		clusterArgs.Ec2MetadataHttpTokens = profile.Ec2MetadataHttpTokens
 	}
 
 	if profile.Region == "" {

--- a/tests/ci/profiles/tf_classic_cluster_profiles.yml
+++ b/tests/ci/profiles/tf_classic_cluster_profiles.yml
@@ -26,7 +26,7 @@ profiles:
     tagging: false
     channel_group: stable
     zones: ""
-    imdsv2: "optional"
+    ec2_metadata_http_tokens: "optional"
     oidc_config: "managed"
     admin_enabled: false
     unified_acc_role_path: ""
@@ -57,7 +57,7 @@ profiles:
     tagging: true
     channel_group: stable
     zones: ""
-    imdsv2: "required"
+    ec2_metadata_http_tokens: "required"
     oidc_config: "un-managed"
     admin_enabled: true
     additional_sg_number: 4
@@ -124,7 +124,7 @@ profiles:
     tagging: true
     channel_group: stable
     zones: ""
-    imdsv2: ""
+    ec2_metadata_http_tokens: ""
     oidc_config: "managed"
     admin_enabled: true
     unified_acc_role_path: "/uni-fied/"
@@ -155,7 +155,7 @@ profiles:
     tagging: false
     channel_group: stable
     zones: ""
-    imdsv2: ""
+    ec2_metadata_http_tokens: ""
     oidc_config: "managed"
     admin_enabled: true
     unified_acc_role_path: ""

--- a/tests/ci/profiles/tf_hcp_cluster_profiles.yml
+++ b/tests/ci/profiles/tf_hcp_cluster_profiles.yml
@@ -26,7 +26,7 @@ profiles:
     tagging: true
     channel_group: candidate
     zones: "a,b,c"
-    imdsv2: ""
+    ec2_metadata_http_tokens: ""
     oidc_config: "managed"
     admin_enabled: false # Not yet supported
 # rosa-hcp-sts-pl :: creating a managed oidc config cluster 
@@ -56,7 +56,7 @@ profiles:
 #     tagging: false
 #     channel_group: candidate
 #     zones: ""
-#     imdsv2: "optional"
+#     ec2_metadata_http_tokens: "optional"
 #     oidc_config: "managed"
 #     admin_enabled: false # Not yet supported
 #     unified_acc_role_path: ""
@@ -87,7 +87,7 @@ profiles:
 #     tagging: true
 #     channel_group: stable
 #     zones: ""
-#     imdsv2: ""
+#     ec2_metadata_http_tokens: ""
 #     oidc_config: "managed"
 #     admin_enabled: false # Not yet supported
 #     unified_acc_role_path: "/uni-fied/"
@@ -118,7 +118,7 @@ profiles:
 #     tagging: false
 #     channel_group: stable
 #     zones: ""
-#     imdsv2: ""
+#     ec2_metadata_http_tokens: ""
 #     oidc_config: "managed"
 #     admin_enabled: false # Not yet supported
 #     unified_acc_role_path: ""

--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -336,5 +336,14 @@ var _ = Describe("TF Test", func() {
 				}
 			})
 		})
+		Context("Author:zhsun-Critical-OCP-63950 @zhsun", func() {
+			It("Verify imdsv2 value is set post cluster creation", ci.Day1Post, ci.Critical, func() {
+				if profile.Ec2MetadataHttpTokens != "" {
+					Expect(string(cluster.AWS().Ec2MetadataHttpTokens())).To(Equal(profile.Ec2MetadataHttpTokens))
+				} else {
+					Expect(string(cluster.AWS().Ec2MetadataHttpTokens())).To(Equal(cmv1.Ec2MetadataHttpTokensOptional))
+				}
+			})
+		})
 	})
 })

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -70,7 +70,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   autoscaling_enabled                             = var.autoscaling.autoscaling_enabled
   min_replicas                                    = var.autoscaling.min_replicas
   max_replicas                                    = var.autoscaling.max_replicas
-  ec2_metadata_http_tokens                        = var.aws_http_tokens_state
+  ec2_metadata_http_tokens                        = var.ec2_metadata_http_tokens
   aws_private_link                                = var.private_link
   private                                         = var.private
   aws_subnet_ids                                  = local.aws_subnet_ids

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -60,7 +60,7 @@ variable "autoscaling" {
   }
 }
 
-variable "aws_http_tokens_state" {
+variable "ec2_metadata_http_tokens" {
   type    = string
   default = null
 }

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -18,7 +18,7 @@ type ClusterCreationArgs struct {
 	AWSAvailabilityZones                 []string           `json:"aws_availability_zones,omitempty"`
 	Replicas                             int                `json:"replicas,omitempty"`
 	ChannelGroup                         string             `json:"channel_group,omitempty"`
-	AWSHttpTokensState                   string             `json:"aws_http_tokens_state,omitempty"`
+	Ec2MetadataHttpTokens                string             `json:"ec2_metadata_http_tokens,omitempty"`
 	PrivateLink                          bool               `json:"private_link,omitempty"`
 	Private                              bool               `json:"private,omitempty"`
 	Fips                                 bool               `json:"fips,omitempty"`


### PR DESCRIPTION
@xueli181114 PTAL
```
$ ginkgo -focus 63950 tests/e2e                                                              
time="2024-03-15T10:56:25+08:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2024-03-15T10:56:25+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-pl : map[admin_enabled:false autoscale:false byok:false byovpc:true ccs:true channel_group:candidate cloud_provider:aws cluster_type:rosa-classic compute_machine_type:m5.xlarge etcd_encryption:false fips:false imdsv2:optional kms_key_arn:false labeling:false major_version:4.14 multi_az:false oidc_config:managed private:true private_link:true product_id:rosa proxy:false region:us-east-1 sts:true tagging:false unified_acc_role_path: version: version_pattern:latest zones:]"
Running Suite: e2e tests suite - /Users/sunzhaohua/code/terraform-provider-rhcs/tests/e2e
=========================================================================================
Random Seed: 1710471380

Will run 1 of 60 specs
time="2024-03-15T10:56:25+08:00" level=warning msg="Got a global ENV variable RHCS_SOURCE set to terraform-redhat/rhcs. Going to replace all of the manifests files"
time="2024-03-15T10:56:25+08:00" level=warning msg="Got a global ENV variable RHCS_VERSION set to 1.5.1-prerelease.4. Going to replace all of the manifests files"
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden [NonHCPCluster]
/Users/sunzhaohua/code/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:261
------------------------------
SSStime="2024-03-15T10:56:26+08:00" level=info msg="Running terraform init against the dir /Users/sunzhaohua/code/terraform-provider-rhcs/tests/tf-manifests/rhcs/resource-import"
time="2024-03-15T10:56:27+08:00" level=info msg="Loaded cluster profile configuration from profile rosa-sts-pl : map[admin_enabled:false autoscale:false byok:false byovpc:true ccs:true channel_group:candidate cloud_provider:aws cluster_type:rosa-classic compute_machine_type:m5.xlarge etcd_encryption:false fips:false imdsv2:optional kms_key_arn:false labeling:false major_version:4.14 multi_az:false oidc_config:managed private:true private_link:true product_id:rosa proxy:false region:us-east-1 sts:true tagging:false unified_acc_role_path: version: version_pattern:latest zones:]"
•SSSSSSSSSSSSSSSSSSS

Ran 1 of 60 Specs in 3.883 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 58 Skipped
PASS

Ginkgo ran 1 suite in 9.381973489s
Test Suite Passed
```