### PR TITLE
[WIP] OCM-6835: Fix aws_account_id attribute to be sensitive

### DIFF
--- a/docs/resources/cluster_rosa_classic.md
+++ b/docs/resources/cluster_rosa_classic.md
@@ -47,7 +47,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
 
 ### Required
 
-- `aws_account_id` (String) Identifier of the AWS account. After the creation of the resource, it is not possible to update the attribute value.
+- `aws_account_id` (String, Sensitive) Identifier of the AWS account. After the creation of the resource, it is not possible to update the attribute value.
 - `cloud_region` (String) Cloud region identifier, for example 'us-east-1'.
 - `name` (String) Name of the cluster. Cannot exceed 15 characters in length. After the creation of the resource, it is not possible to update the attribute value.
 

--- a/docs/resources/cluster_rosa_hcp.md
+++ b/docs/resources/cluster_rosa_hcp.md
@@ -18,7 +18,7 @@ OpenShift managed cluster using ROSA HCP.
 ### Required
 
 - `availability_zones` (List of String) Availability zones. This attribute is specifically applies for the Worker Node Pool and becomes irrelevant once the resource is created. Any modifications to the default Machine Pool should be made through the Terraform imported Machine Pool resource. For more details, refer to [Worker Node Pool in ROSA Cluster](../guides/worker-machine-pool.md)
-- `aws_account_id` (String) Identifier of the AWS account. After the creation of the resource, it is not possible to update the attribute value.
+- `aws_account_id` (String, Sensitive) Identifier of the AWS account. After the creation of the resource, it is not possible to update the attribute value.
 - `aws_billing_account_id` (String) Identifier of the AWS account for billing. After the creation of the resource, it is not possible to update the attribute value.
 - `aws_subnet_ids` (List of String) AWS subnet IDs. After the creation of the resource, it is not possible to update the attribute value.
 - `cloud_region` (String) AWS region identifier, for example 'us-east-1'.

--- a/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
@@ -232,6 +232,7 @@ func (r *ClusterRosaClassicResource) Schema(ctx context.Context, req resource.Sc
 			"aws_account_id": schema.StringAttribute{
 				Description: "Identifier of the AWS account. " + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Sensitive:   true,
 			},
 			"aws_subnet_ids": schema.ListAttribute{
 				Description: "AWS subnet IDs. " + common.ValueCannotBeChangedStringDescription,

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -165,6 +165,7 @@ func (r *ClusterRosaHcpResource) Schema(ctx context.Context, req resource.Schema
 			"aws_account_id": schema.StringAttribute{
 				Description: "Identifier of the AWS account. " + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Sensitive:   true,
 			},
 			"aws_billing_account_id": schema.StringAttribute{
 				Description: "Identifier of the AWS account for billing. " + common.ValueCannotBeChangedStringDescription,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix aws_account_id attribute to be sensitive
For more info about the leak detection tool see linked ticket description

**Which issue(s) this PR fixes**:
Fixes #[OCM-6835](https://issues.redhat.com//browse/OCM-6835)

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [x] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
