### PR TITLE
OCM-6885 | fix: should not allow to edit tags on mp of HCP

### DIFF
--- a/docs/resources/hcp_machine_pool.md
+++ b/docs/resources/hcp_machine_pool.md
@@ -63,7 +63,7 @@ Required:
 Optional:
 
 - `additional_security_group_ids` (List of String) Additional security group ids. After the creation of the resource, it is not possible to update the attribute value.
-- `tags` (Map of String) Apply user defined tags to all machine pool resources created in AWS. After the creation of the resource, it is not possible to update the attribute value.
+- `tags` (Map of String) Apply user defined tags to all machine pool resources created in AWS. If tags have been supplied at cluster level please include those in your management file for the machine. After the creation of the resource, it is not possible to update the attribute value.
 
 Read-Only:
 

--- a/provider/machinepool/hcp/aws_node_pool.go
+++ b/provider/machinepool/hcp/aws_node_pool.go
@@ -36,7 +36,9 @@ func AwsNodePoolResource() map[string]schema.Attribute {
 			},
 		},
 		"tags": schema.MapAttribute{
-			Description: "Apply user defined tags to all machine pool resources created in AWS. " + common.ValueCannotBeChangedStringDescription,
+			Description: "Apply user defined tags to all machine pool resources created in AWS." +
+				" If tags have been supplied at cluster level please include those in your management file for the machine. " +
+				common.ValueCannotBeChangedStringDescription,
 			ElementType: types.StringType,
 			Optional:    true,
 		},


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

[OCM-6885](https://issues.redhat.com//browse/OCM-6885)

Relies on parameter to fetch user tags only, excluding system tags the customer might not know about. This helps in making sure that customer is able to provide all cluster plus new machine tags within the management file

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [x] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [x] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
