### PR TITLE
OCM-7020 | fix: tuning config id should be computed only

### DIFF
--- a/docs/resources/tuning_config.md
+++ b/docs/resources/tuning_config.md
@@ -21,6 +21,6 @@ Edit a cluster tuning config
 - `name` (String) Name of the tuning configuration. After the creation of the resource, it is not possible to update the attribute value.
 - `spec` (String) Definition of the spec
 
-### Optional
+### Read-Only
 
 - `id` (String) Unique identifier of the tuning config.

--- a/provider/tuningconfigs/resource.go
+++ b/provider/tuningconfigs/resource.go
@@ -48,7 +48,6 @@ func (r *TuningConfigResource) Schema(ctx context.Context, req resource.SchemaRe
 			"id": schema.StringAttribute{
 				Description: "Unique identifier of the tuning config.",
 				Computed:    true,
-				Optional:    true,
 				PlanModifiers: []planmodifier.String{
 					// This passes the state through to the plan, preventing
 					// "known after apply" since we know it won't change.


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

[OCM-7020](https://issues.redhat.com//browse/OCM-7020)

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [x] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
