### PR TITLE
OCM-7082 | fix: validate cluster id is not empty for subresources

### DIFF
--- a/provider/autoscaler/classic/resource.go
+++ b/provider/autoscaler/classic/resource.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -63,6 +65,9 @@ func (r *ClusterAutoscalerResource) Schema(ctx context.Context, req resource.Sch
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster." + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"balance_similar_node_groups": schema.BoolAttribute{
 				Description: "Automatically identify node groups with " +

--- a/provider/autoscaler/hcp/resource.go
+++ b/provider/autoscaler/hcp/resource.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -61,6 +63,9 @@ func (r *ClusterAutoscalerResource) Schema(ctx context.Context, req resource.Sch
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster." + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"max_pod_grace_period": schema.Int64Attribute{
 				Description: "Gives pods graceful termination time before scaling down.",

--- a/provider/clusterwaiter/cluster_waiter_resource.go
+++ b/provider/clusterwaiter/cluster_waiter_resource.go
@@ -3,8 +3,10 @@ package clusterwaiter
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,6 +42,9 @@ func (r *ClusterWaiterResource) Schema(ctx context.Context, req resource.SchemaR
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster.",
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"timeout": schema.Int64Attribute{
 				Description: "An optional timeout until the cluster is ready. The timeout value is set in minutes." +

--- a/provider/defaultingress/classic/resource.go
+++ b/provider/defaultingress/classic/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -57,6 +58,9 @@ func (r *DefaultIngressResource) Schema(ctx context.Context, req resource.Schema
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster. " + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"id": schema.StringAttribute{
 				Description: "Unique identifier of the ingress.",

--- a/provider/defaultingress/hcp/resource.go
+++ b/provider/defaultingress/hcp/resource.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -47,6 +49,9 @@ func (r *DefaultIngressResource) Schema(ctx context.Context, req resource.Schema
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster. " + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"id": schema.StringAttribute{
 				Description: "Unique identifier of the ingress.",

--- a/provider/group/groups_data_source.go
+++ b/provider/group/groups_data_source.go
@@ -18,9 +18,12 @@ package group
 
 import (
 	"context"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -48,6 +51,9 @@ func (g *GroupsDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster.",
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"items": schema.ListNestedAttribute{
 				Description: "Content of the list.",

--- a/provider/groupmembership/group_membership_resource.go
+++ b/provider/groupmembership/group_membership_resource.go
@@ -19,10 +19,13 @@ package groupmembership
 import (
 	"context"
 	"fmt"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -55,6 +58,9 @@ func (g *GroupMembershipResource) Schema(ctx context.Context, req resource.Schem
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster.",
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"group": schema.StringAttribute{
 				Description: "Identifier of the group.",

--- a/provider/identityprovider/identity_provider_resource.go
+++ b/provider/identityprovider/identity_provider_resource.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -71,6 +72,9 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster.",
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"id": schema.StringAttribute{
 				Description: "Unique identifier of the identity provider.",

--- a/provider/kubeletconfig/kubeletconfig_resource.go
+++ b/provider/kubeletconfig/kubeletconfig_resource.go
@@ -19,7 +19,9 @@ package kubeletconfig
 import (
 	"context"
 	"fmt"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -71,6 +73,9 @@ func (k *KubeletConfigResource) Schema(_ context.Context, _ resource.SchemaReque
 			"cluster": schema.StringAttribute{
 				Required:    true,
 				Description: "Identifier of the cluster." + common.ValueCannotBeChangedStringDescription,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"pod_pids_limit": schema.Int64Attribute{
 				Required: true,

--- a/provider/machinepool/classic/machine_pool_datasource.go
+++ b/provider/machinepool/classic/machine_pool_datasource.go
@@ -19,9 +19,12 @@ package classic
 import (
 	"context"
 	"fmt"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -66,6 +69,9 @@ func (r *MachinePoolDatasource) Schema(ctx context.Context, req datasource.Schem
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster of the machine pool. ",
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"id": schema.StringAttribute{
 				Description: "Unique identifier of the machine pool.",

--- a/provider/machinepool/classic/machine_pool_resource.go
+++ b/provider/machinepool/classic/machine_pool_resource.go
@@ -78,6 +78,9 @@ func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaReq
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster. " + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"id": schema.StringAttribute{
 				Description: "Unique identifier of the machine pool.",

--- a/provider/machinepool/hcp/machine_pool_datasource.go
+++ b/provider/machinepool/hcp/machine_pool_datasource.go
@@ -19,6 +19,7 @@ package hcp
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -78,6 +79,9 @@ func (r *HcpMachinePoolDatasource) Schema(ctx context.Context, req datasource.Sc
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster. " + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"replicas": schema.Int64Attribute{
 				Description: "The number of machines of the pool",

--- a/provider/machinepool/hcp/machine_pool_resource.go
+++ b/provider/machinepool/hcp/machine_pool_resource.go
@@ -94,6 +94,9 @@ func (r *HcpMachinePoolResource) Schema(ctx context.Context, req resource.Schema
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster. " + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"replicas": schema.Int64Attribute{
 				Description: "The number of machines of the pool",

--- a/provider/tuningconfigs/resource.go
+++ b/provider/tuningconfigs/resource.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -44,6 +47,9 @@ func (r *TuningConfigResource) Schema(ctx context.Context, req resource.SchemaRe
 			"cluster": schema.StringAttribute{
 				Description: "Identifier of the cluster. " + common.ValueCannotBeChangedStringDescription,
 				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "cluster ID may not be empty/blank string"),
+				},
 			},
 			"id": schema.StringAttribute{
 				Description: "Unique identifier of the tuning config.",

--- a/subsystem/cluster_autoscaler_resource_test.go
+++ b/subsystem/cluster_autoscaler_resource_test.go
@@ -27,6 +27,16 @@ import (
 
 var _ = Describe("Cluster Autoscaler", func() {
 	Context("creation", func() {
+
+		It("fails if cluster ID is empty", func() {
+			terraform.Source(`
+				resource "rhcs_cluster_autoscaler" "cluster_autoscaler" {
+					cluster = ""
+				}
+			`)
+			Expect(terraform.Apply()).ToNot(BeZero())
+		})
+
 		It("fails if given an out-of-range utilization threshold", func() {
 			terraform.Source(`
 				resource "rhcs_cluster_autoscaler" "cluster_autoscaler" {

--- a/subsystem/cluster_waiter_test.go
+++ b/subsystem/cluster_waiter_test.go
@@ -108,6 +108,15 @@ var _ = Describe("Cluster creation", func() {
 	}`
 
 	Context("Create cluster waiter resource", func() {
+
+		It("fails if cluster ID is empty", func() {
+			terraform.Source(`
+				resource "rhcs_cluster_wait" "rosa_cluster" {
+				  cluster = ""
+				}
+			`)
+			Expect(terraform.Apply()).ToNot(BeZero())
+		})
 		It("Create cluster waiter without a timeout", func() {
 			// Prepare the server:
 			server.AppendHandlers(

--- a/subsystem/default_ingress_resource_test.go
+++ b/subsystem/default_ingress_resource_test.go
@@ -58,6 +58,15 @@ var _ = Describe("default ingress", func() {
 						}
 					`
 
+	It("fails if cluster ID is empty", func() {
+		terraform.Source(`
+			resource "rhcs_default_ingress" "default_ingress" {
+				cluster = ""
+			}
+		`)
+		Expect(terraform.Apply()).ToNot(BeZero())
+	})
+
 	It("Sends updates to attribute individually", func() {
 		// Prepare the server:
 		server.AppendHandlers(

--- a/subsystem/group_membership_resource_test.go
+++ b/subsystem/group_membership_resource_test.go
@@ -42,6 +42,15 @@ var _ = Describe("Group membership creation", func() {
 		)
 	})
 
+	It("fails if cluster ID is empty", func() {
+		terraform.Source(`
+		resource "rhcs_group_membership" "my_membership" {
+				cluster = ""
+			}
+		`)
+		Expect(terraform.Apply()).ToNot(BeZero())
+	})
+
 	It("Can create a group membership", func() {
 		// Prepare the server:
 		server.AppendHandlers(

--- a/subsystem/groups_data_source_test.go
+++ b/subsystem/groups_data_source_test.go
@@ -26,6 +26,14 @@ import (
 )
 
 var _ = Describe("Groups data source", func() {
+	It("fails if cluster ID is empty", func() {
+		terraform.Source(`
+		data "rhcs_groups" "my_groups" {
+				cluster = ""
+			}
+		`)
+		Expect(terraform.Apply()).ToNot(BeZero())
+	})
 	It("Can list groups", func() {
 		// Prepare the server:
 		server.AppendHandlers(

--- a/subsystem/hcp/cluster_autoscaler_resource_test.go
+++ b/subsystem/hcp/cluster_autoscaler_resource_test.go
@@ -27,6 +27,14 @@ import (
 
 var _ = Describe("Hcp Cluster Autoscaler", func() {
 	Context("creation", func() {
+		It("fails if cluster ID is empty", func() {
+			terraform.Source(`
+				resource "rhcs_hcp_cluster_autoscaler" "cluster_autoscaler" {
+					cluster = ""
+				}
+			`)
+			Expect(terraform.Apply()).ToNot(BeZero())
+		})
 		It("fails if given an invalid duration string", func() {
 			terraform.Source(`
 				resource "rhcs_hcp_cluster_autoscaler" "cluster_autoscaler" {

--- a/subsystem/hcp/default_ingress_resource_test.go
+++ b/subsystem/hcp/default_ingress_resource_test.go
@@ -55,6 +55,15 @@ var _ = Describe("rhcs_cluster_rosa_hcp - default ingress", func() {
 						}
 					`
 
+	It("fails if cluster ID is empty", func() {
+		terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = ""
+			}
+		`)
+		Expect(terraform.Apply()).ToNot(BeZero())
+	})
+
 	It("Updates ListeningMethod", func() {
 		// Prepare the server:
 		server.AppendHandlers(

--- a/subsystem/hcp/machine_pool_resource_test.go
+++ b/subsystem/hcp/machine_pool_resource_test.go
@@ -34,6 +34,14 @@ const (
 
 var _ = Describe("Hcp Machine pool", func() {
 	Context("static validation", func() {
+		It("fails if cluster ID is empty", func() {
+			terraform.Source(`
+			resource "rhcs_hcp_machine_pool" "my_pool" {
+					cluster = ""
+				}
+			`)
+			Expect(terraform.Apply()).ToNot(BeZero())
+		})
 		It("is invalid to specify both availability_zone and subnet_id", func() {
 			terraform.Source(`
 			resource "rhcs_hcp_machine_pool" "my_pool" {

--- a/subsystem/hcp/tuningconfigs_test.go
+++ b/subsystem/hcp/tuningconfigs_test.go
@@ -72,6 +72,14 @@ var _ = Describe("Tuning Configs", func() {
 	tuningConfigSpecTemplate := b.String()
 
 	Context("tuning configs creation", func() {
+		It("fails if cluster ID is empty", func() {
+			terraform.Source(`
+			resource "rhcs_tuning_config" "tuning_config" {
+					cluster = ""
+				}
+			`)
+			Expect(terraform.Apply()).ToNot(BeZero())
+		})
 		It("fails to find a matching cluster object", func() {
 			server.AppendHandlers(
 				CombineHandlers(

--- a/subsystem/identity_provider_resource_test.go
+++ b/subsystem/identity_provider_resource_test.go
@@ -73,6 +73,14 @@ var _ = Describe("Identity provider creation", func() {
 	const template3 = templatePt1 + users3 + templatePt2
 
 	Context("Identity Provider Failure", func() {
+		It("fails if cluster ID is empty", func() {
+			terraform.Source(`
+			data "rhcs_identity_provider" "my_idp" {
+					cluster = ""
+				}
+			`)
+			Expect(terraform.Apply()).ToNot(BeZero())
+		})
 		It("cluster_id not found", func() {
 			// Prepare the server:
 			server.AppendHandlers(
@@ -88,7 +96,7 @@ var _ = Describe("Identity provider creation", func() {
 
 			// Run the apply command:
 			terraform.Source(`
-	    	  resource "rhcs_identity_provider" "my_ip" {
+	    	  resource "rhcs_identity_provider" "my_idp" {
 	    	    cluster = "123"
 	    	    name    = "my-ip"
 	    	    htpasswd = {
@@ -129,7 +137,7 @@ var _ = Describe("Identity provider creation", func() {
 			It("Can't create a 'htpasswd' identity provider. No users provided", func() {
 				// Run the apply command:
 				terraform.Source(`
-	    	      resource "rhcs_identity_provider" "my_ip" {
+	    	      resource "rhcs_identity_provider" "my_idp" {
 	    	        cluster = "123"
 	    	        name    = "my-ip"
 	    	        htpasswd = {
@@ -142,7 +150,7 @@ var _ = Describe("Identity provider creation", func() {
 			It("Can't create a 'htpasswd' identity provider. duplication of username", func() {
 				// Run the apply command:
 				terraform.Source(`
-	    	      resource "rhcs_identity_provider" "my_ip" {
+	    	      resource "rhcs_identity_provider" "my_idp" {
 	    	        cluster = "123"
 	    	        name    = "my-ip"
 	    	        htpasswd = {
@@ -164,7 +172,7 @@ var _ = Describe("Identity provider creation", func() {
 			It("Can't create a 'htpasswd' identity provider. invalid username", func() {
 				// Run the apply command:
 				terraform.Source(`
-	    	      resource "rhcs_identity_provider" "my_ip" {
+	    	      resource "rhcs_identity_provider" "my_idp" {
 	    	        cluster = "123"
 	    	        name    = "my-ip"
 	    	        htpasswd = {
@@ -180,7 +188,7 @@ var _ = Describe("Identity provider creation", func() {
 			It("Can't create a 'htpasswd' identity provider. invalid password", func() {
 				// Run the apply command:
 				terraform.Source(`
-	    	      resource "rhcs_identity_provider" "my_ip" {
+	    	      resource "rhcs_identity_provider" "my_idp" {
 	    	        cluster = "123"
 	    	        name    = "my-ip"
 	    	        htpasswd = {
@@ -251,7 +259,7 @@ var _ = Describe("Identity provider creation", func() {
 
 			// Run the apply command:
 			terraform.Source(`
-	    	  resource "rhcs_identity_provider" "my_ip" {
+	    	  resource "rhcs_identity_provider" "my_idp" {
 	    	    cluster = "123"
 	    	    name    = "my-ip"
 	    	    htpasswd = {
@@ -264,7 +272,7 @@ var _ = Describe("Identity provider creation", func() {
 	    	`)
 			Expect(terraform.Apply()).To(BeZero())
 		})
-		
+
 		It("Reconcile an 'htpasswd' identity provider, when state exists but 404 from server", func() {
 			// Prepare the server:
 			server.AppendHandlers(
@@ -295,7 +303,7 @@ var _ = Describe("Identity provider creation", func() {
 
 			// Run the apply command:
 			terraform.Source(`
-	    	  resource "rhcs_identity_provider" "my_ip" {
+	    	  resource "rhcs_identity_provider" "my_idp" {
 	    	    cluster = "123"
 	    	    name    = "my-ip"
 	    	    htpasswd = {
@@ -361,7 +369,7 @@ var _ = Describe("Identity provider creation", func() {
 
 			// Run the apply command:
 			terraform.Source(`
-	    	  resource "rhcs_identity_provider" "my_ip" {
+	    	  resource "rhcs_identity_provider" "my_idp" {
 	    	    cluster = "123"
 	    	    name    = "my-ip"
 	    	    htpasswd = {
@@ -373,7 +381,7 @@ var _ = Describe("Identity provider creation", func() {
 	    	  }
 	    	`)
 			Expect(terraform.Apply()).To(BeZero())
-			resource := terraform.Resource("rhcs_identity_provider", "my_ip")
+			resource := terraform.Resource("rhcs_identity_provider", "my_idp")
 			Expect(resource).To(MatchJQ(".attributes.id", "457"))
 		})
 
@@ -413,7 +421,7 @@ var _ = Describe("Identity provider creation", func() {
 
 			// Run the apply command:
 			terraform.Source(`
-	    	  resource "rhcs_identity_provider" "my_ip" {
+	    	  resource "rhcs_identity_provider" "my_idp" {
 	    	    cluster = "123"
 	    	    name    = "my-ip"
 	    	    gitlab = {
@@ -431,7 +439,7 @@ var _ = Describe("Identity provider creation", func() {
 			Context("Invalid 'github' identity provider config", func() {
 				It("Should fail with both 'teams' and 'organizations'", func() {
 					terraform.Source(`
-	    	          resource "rhcs_identity_provider" "my_ip" {
+	    	          resource "rhcs_identity_provider" "my_idp" {
 	    	            cluster = "123"
 	    	            name    = "my-ip"
 	    	            github = {
@@ -448,7 +456,7 @@ var _ = Describe("Identity provider creation", func() {
 
 				It("Should fail without 'teams' or 'organizations'", func() {
 					terraform.Source(`
-	    	          resource "rhcs_identity_provider" "my_ip" {
+	    	          resource "rhcs_identity_provider" "my_idp" {
 	    	            cluster = "123"
 	    	            name    = "my-ip"
 	    	            github = {
@@ -463,7 +471,7 @@ var _ = Describe("Identity provider creation", func() {
 
 				It("Should fail if teams contain an invalid format", func() {
 					terraform.Source(`
-	    	          resource "rhcs_identity_provider" "my_ip" {
+	    	          resource "rhcs_identity_provider" "my_idp" {
 	    	            cluster = "123"
 	    	            name    = "my-ip"
 	    	            github = {
@@ -476,7 +484,7 @@ var _ = Describe("Identity provider creation", func() {
 	    	        `)
 					Expect(terraform.Apply()).ToNot(BeZero())
 					terraform.Source(`
-	    	          resource "rhcs_identity_provider" "my_ip" {
+	    	          resource "rhcs_identity_provider" "my_idp" {
 	    	            cluster = "123"
 	    	            name    = "my-ip"
 	    	            github = {
@@ -492,7 +500,7 @@ var _ = Describe("Identity provider creation", func() {
 
 				It("Should fail with an invalid hostname", func() {
 					terraform.Source(`
-	    	          resource "rhcs_identity_provider" "my_ip" {
+	    	          resource "rhcs_identity_provider" "my_idp" {
 	    	            cluster = "123"
 	    	            name    = "my-ip"
 	    	            github = {
@@ -544,7 +552,7 @@ var _ = Describe("Identity provider creation", func() {
 
 				// Run the apply command:
 				terraform.Source(`
-    		      resource "rhcs_identity_provider" "my_ip" {
+    		      resource "rhcs_identity_provider" "my_idp" {
     		        cluster = "123"
     		        name    = "my-ip"
     		        github = {
@@ -595,7 +603,7 @@ var _ = Describe("Identity provider creation", func() {
 
 				// Run the apply command:
 				terraform.Source(`
-		          resource "rhcs_identity_provider" "my_ip" {
+		          resource "rhcs_identity_provider" "my_idp" {
 		            cluster = "123"
 		            name    = "my-ip"
 		            github = {
@@ -615,7 +623,7 @@ var _ = Describe("Identity provider creation", func() {
 				It("Should fail if not both bind properties are set", func() {
 					// Run the apply command:
 					terraform.Source(`
-        		      resource "rhcs_identity_provider" "my_ip" {
+        		      resource "rhcs_identity_provider" "my_idp" {
         		        cluster    = "123"
         		        name       = "my-ip"
         		        ldap = {
@@ -682,7 +690,7 @@ var _ = Describe("Identity provider creation", func() {
 
 				// Run the apply command:
 				terraform.Source(`
-        		  resource "rhcs_identity_provider" "my_ip" {
+        		  resource "rhcs_identity_provider" "my_idp" {
         		    cluster    = "123"
         		    name       = "my-ip"
         		    ldap = {
@@ -745,7 +753,7 @@ var _ = Describe("Identity provider creation", func() {
 
 				// Run the apply command:
 				terraform.Source(`
-        		  resource "rhcs_identity_provider" "my_ip" {
+        		  resource "rhcs_identity_provider" "my_idp" {
         		    cluster    = "123"
         		    name       = "my-ip"
         		    ldap = {
@@ -812,7 +820,7 @@ var _ = Describe("Identity provider creation", func() {
 
 				// Run the apply command:
 				terraform.Source(`
-        		  resource "rhcs_identity_provider" "my_ip" {
+        		  resource "rhcs_identity_provider" "my_idp" {
         		    cluster    = "123"
         		    name       = "my-ip"
         		    ldap = {
@@ -837,7 +845,7 @@ var _ = Describe("Identity provider creation", func() {
 				It("Should fail with invalid hosted_domain", func() {
 					// Run the apply command:
 					terraform.Source(`
-    		          resource "rhcs_identity_provider" "my_ip" {
+    		          resource "rhcs_identity_provider" "my_idp" {
     		            cluster = "123"
     		            name    = "my-ip"
     		            google = {
@@ -853,7 +861,7 @@ var _ = Describe("Identity provider creation", func() {
 				It("Should fail when mapping_method is not lookup and no hosted_domain", func() {
 					// Run the apply command:
 					terraform.Source(`
-    		          resource "rhcs_identity_provider" "my_ip" {
+    		          resource "rhcs_identity_provider" "my_idp" {
     		            cluster = "123"
     		            name    = "my-ip"
     		            google = {
@@ -902,7 +910,7 @@ var _ = Describe("Identity provider creation", func() {
 
 					// Run the apply command:
 					terraform.Source(`
-    		          resource "rhcs_identity_provider" "my_ip" {
+    		          resource "rhcs_identity_provider" "my_idp" {
     		            cluster = "123"
     		            name    = "my-ip"
     		            google = {
@@ -958,7 +966,7 @@ var _ = Describe("Identity provider creation", func() {
 
 						// Run the apply command:
 						terraform.Source(`
-	    	  				resource "rhcs_identity_provider" "my_ip" {
+	    	  				resource "rhcs_identity_provider" "my_idp" {
 	    	    				cluster = "123"
 					    	    name    = "my-ip"
 	    					    htpasswd = {
@@ -999,7 +1007,7 @@ var _ = Describe("Identity provider creation", func() {
 
 						// Run the apply command:
 						terraform.Source(`
-	    	  				resource "rhcs_identity_provider" "my_ip" {
+	    	  				resource "rhcs_identity_provider" "my_idp" {
 	    	    				cluster = "123"
 					    	    name    = "my-ip"
 	    					    htpasswd = {
@@ -1036,7 +1044,7 @@ var _ = Describe("Identity provider creation", func() {
 
 						// Run the apply command:
 						terraform.Source(`
-	    	  				resource "rhcs_identity_provider" "my_ip" {
+	    	  				resource "rhcs_identity_provider" "my_idp" {
 	    	    				cluster = "123"
 					    	    name    = "my-ip"
 	    					    htpasswd = {
@@ -1079,7 +1087,7 @@ var _ = Describe("Identity provider creation", func() {
 
 						// Run the apply command:
 						terraform.Source(`
-	    	  				resource "rhcs_identity_provider" "my_ip" {
+	    	  				resource "rhcs_identity_provider" "my_idp" {
 	    	    				cluster = "123"
 					    	    name    = "my-ip"
 	    					    htpasswd = {
@@ -1131,7 +1139,7 @@ var _ = Describe("Identity provider creation", func() {
 
 					// Run the apply command:
 					terraform.Source(`
-    		          resource "rhcs_identity_provider" "my_ip" {
+    		          resource "rhcs_identity_provider" "my_idp" {
     		            cluster = "123"
     		            name    = "my-ip"
                         mapping_method = "lookup"
@@ -1229,7 +1237,7 @@ var _ = Describe("Identity provider creation", func() {
 
 			// Run the apply command:
 			terraform.Source(`
-    		  resource "rhcs_identity_provider" "my_ip" {
+    		  resource "rhcs_identity_provider" "my_idp" {
     		    cluster    				= "123"
     		    name       				= "my-ip"
     		    openid = {
@@ -1251,14 +1259,14 @@ var _ = Describe("Identity provider creation", func() {
     		  }
     		`)
 			Expect(terraform.Apply()).To(BeZero())
-			resource := terraform.Resource("rhcs_identity_provider", "my_ip")
+			resource := terraform.Resource("rhcs_identity_provider", "my_idp")
 			Expect(resource).To(MatchJQ(`.attributes.openid.extra_authorize_parameters.test_key`, "test_value"))
 		})
 
 		It("Should fail with invalid mapping_method", func() {
 			// Run the apply command:
 			terraform.Source(`
-    		  resource "rhcs_identity_provider" "my_ip" {
+    		  resource "rhcs_identity_provider" "my_idp" {
     		    cluster = "123"
     		    name    = "my-ip"
                 mapping_method = "invalid"
@@ -1275,7 +1283,7 @@ var _ = Describe("Identity provider creation", func() {
 		It("Should fail with invalid htpasswd password", func() {
 			// Run the apply command:
 			terraform.Source(`
-    		  resource "rhcs_identity_provider" "my_ip" {
+    		  resource "rhcs_identity_provider" "my_idp" {
     		    cluster = "123"
     		    name    = "my-ip"
                 mapping_method = "invalid"

--- a/subsystem/kubeletconfig_resource_test.go
+++ b/subsystem/kubeletconfig_resource_test.go
@@ -27,6 +27,14 @@ import (
 
 var _ = Describe("Cluster KubeletConfig", func() {
 	Context("Create KubeletConfig", func() {
+		It("fails if cluster ID is empty", func() {
+			terraform.Source(`
+			resource "rhcs_kubeletconfig" "cluster_kubeletconfig" {
+					cluster = ""
+				}
+			`)
+			Expect(terraform.Apply()).ToNot(BeZero())
+		})
 		It("It fails if the requested podPidsLimit is below the minimum", func() {
 			terraform.Source(`
 				resource "rhcs_kubeletconfig" "cluster_kubeletconfig" {

--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -26,6 +26,14 @@ import (
 )
 
 var _ = Describe("Machine pool (static) validation", func() {
+	It("fails if cluster ID is empty", func() {
+		terraform.Source(`
+		resource "rhcs_machine_pool" "my_pool" {
+				cluster = ""
+			}
+		`)
+		Expect(terraform.Apply()).ToNot(BeZero())
+	})
 	It("is invalid to specify both availability_zone and subnet_id", func() {
 		terraform.Source(`
 		  resource "rhcs_machine_pool" "my_pool" {


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

[OCM-7082](https://issues.redhat.com//browse/OCM-7082)

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [x] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
