### PR TITLE
OCM-7141 | ci: Automate 72451/72504/72505/72507/72509/72510

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
+	k8s.io/klog/v2 v2.110.1 // indirect
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -980,6 +980,10 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/apimachinery v0.29.0 h1:+ACVktwyicPz0oc6MTMLwa2Pw3ouLAfAon1wPLtG48o=
 k8s.io/apimachinery v0.29.0/go.mod h1:eVBxQ/cwiJxH58eK/jd/vAk4mrxmVlnpBH5J2GbMeis=
+k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
+k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/tests/ci/labels.go
+++ b/tests/ci/labels.go
@@ -6,6 +6,8 @@ import (
 
 // Features
 var FeatureClusterautoscaler = Label("feature-clusterautoscaler")
+var FeatureClusterMisc = Label("feature-cluster-misc")
+var FeatureClusterProxy = Label("feature-cluster-proxy")
 var FeatureMachinepool = Label("feature-machinepool")
 var FeatureIDP = Label("feature-idp")
 var FeatureImport = Label("feature-import")

--- a/tests/e2e/account_roles_test.go
+++ b/tests/e2e/account_roles_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 var _ = Describe("Edit Account roles", func() {
+	defer GinkgoRecover()
+
 	var err error
 	var profile *CI.Profile
 	var accService *EXE.AccountRoleService

--- a/tests/e2e/classic_machine_pool_test.go
+++ b/tests/e2e/classic_machine_pool_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 var _ = Describe("Create MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureMachinepool, func() {
+	defer GinkgoRecover()
+
 	var mpService *exe.MachinePoolService
 	var profile *ci.Profile
 

--- a/tests/e2e/cluster_autoscaler_day2_test.go
+++ b/tests/e2e/cluster_autoscaler_day2_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 var _ = Describe("Create cluster autoscaler", func() {
+	defer GinkgoRecover()
+
 	var caService *exe.ClusterAutoscalerService
 	var clusterAutoScalerBodyForRecreate *cmv1.ClusterAutoscaler
 	var clusterAutoscalerStatusBefore int

--- a/tests/e2e/cluster_upgrade_test.go
+++ b/tests/e2e/cluster_upgrade_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 var _ = Describe("Upgrade", func() {
+	defer GinkgoRecover()
 
 	var targetV string
 	var clusterID string

--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -4,170 +4,527 @@ import (
 
 	// nolint
 
+	"context"
 	"fmt"
+	"time"
 
+	"github.com/Masterminds/semver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	ci "github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
-	cms "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/cms"
-	con "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/cms"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/exec"
 	exe "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/exec"
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+	. "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/log"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var _ = Describe("TF Test", func() {
-	Describe("Create HCP Machine Pool test",
-		ci.NonClassicCluster,
-		ci.Day2,
-		func() {
+var _ = Describe("HCP MachinePool", ci.Day2, ci.NonClassicCluster, ci.FeatureMachinepool, func() {
+	defer GinkgoRecover()
+	var (
+		mpService *exec.MachinePoolService
+		mpArgs    *exec.MachinePoolArgs
+		vpcOutput *exec.VPCOutput
+	)
 
-			var HCPMachinePoolService *exe.MachinePoolService
-			var vpcOutput *exe.VPCOutput
-			BeforeEach(func() {
-				HCPMachinePoolService = exe.NewMachinePoolService(con.HCPMachinePoolDir)
+	BeforeEach(func() {
+		mpService = exec.NewMachinePoolService(constants.HCPMachinePoolDir)
 
-				By("Get vpc output")
-				vpcService := exe.NewVPCService()
-				vpcOutput, err = vpcService.Output()
-				Expect(err).ToNot(HaveOccurred())
+		By("Get vpc output")
+		vpcService := exec.NewVPCService()
+		vpcOutput, err = vpcService.Output()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		mpService.Destroy()
+
+	})
+
+	It("can be created with only required attributes - [id:72504]",
+		ci.Critical, func() {
+			By("Retrieve current cluster information")
+			clusterRespBody, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+			Expect(err).ToNot(HaveOccurred())
+
+			var initialMinReplicas int
+			var initialMaxReplicas int
+			var initialReplicas int
+			if profile.Autoscale {
+				initialMinReplicas = clusterRespBody.Body().Nodes().AutoscaleCompute().MinReplicas()
+				initialMaxReplicas = clusterRespBody.Body().Nodes().AutoscaleCompute().MinReplicas()
+			} else {
+				initialReplicas = clusterRespBody.Body().Nodes().Compute()
+			}
+
+			By("Create machinepool")
+			replicas := 3
+			machineType := "m5.2xlarge"
+			name := helper.GenerateRandomName("np-72504", 2)
+			subnetId := vpcOutput.ClusterPrivateSubnets[0]
+			mpArgs = &exec.MachinePoolArgs{
+				Cluster:            clusterID,
+				AutoscalingEnabled: helper.BoolPointer(false),
+				Replicas:           &replicas,
+				Name:               &name,
+				SubnetID:           &subnetId,
+				MachineType:        &machineType,
+				AutoRepair:         helper.BoolPointer(true),
+			}
+			_, err = mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify attributes are correctly set")
+			mpResponseBody, err := cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.ID()).To(Equal(name))
+			Expect(mpResponseBody.Autoscaling()).To(BeNil())
+			Expect(mpResponseBody.Replicas()).To(Equal(replicas))
+			Expect(mpResponseBody.Subnet()).To(Equal(subnetId))
+			Expect(mpResponseBody.AWSNodePool().InstanceType()).To(Equal(machineType))
+			Expect(mpResponseBody.AutoRepair()).To(BeTrue())
+
+			By("Wait for machinepool replicas available")
+			err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 20*time.Minute, false, func(context.Context) (bool, error) {
+				clusterRespBody, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+				if err != nil {
+					return false, err
+				}
+				if profile.Autoscale {
+					return clusterRespBody.Body().Nodes().AutoscaleCompute().MaxReplicas() == (initialMaxReplicas+replicas) &&
+						clusterRespBody.Body().Nodes().AutoscaleCompute().MinReplicas() == (initialMinReplicas+replicas), nil
+				} else {
+					return clusterRespBody.Body().Nodes().Compute() == (initialReplicas + replicas), nil
+				}
 			})
-			AfterEach(func() {
-				HCPMachinePoolService.Destroy()
+			helper.AssertWaitPollNoErr(err, "Replicas are not ready after 600")
 
-			})
-			It("Author:xueli-High-OCP-73068 @OCP-73068 @xueli Create nodepool with security groups via RHCS will work well", ci.High,
-				func() {
-
-					By("Prepare additional security groups")
-					sgService := exe.NewSecurityGroupService()
-					output, err := sgService.Output()
-					Expect(err).ToNot(HaveOccurred())
-					if output.SGIDs == nil {
-
-						sgArgs := &exe.SecurityGroupArgs{
-							AWSRegion: profile.Region,
-							VPCID:     vpcOutput.VPCID,
-							SGNumber:  4,
-						}
-						err = sgService.Apply(sgArgs, true)
-						Expect(err).ToNot(HaveOccurred())
-						// defer sgService.Destroy()
-					}
-
-					output, err = sgService.Output()
-					Expect(err).ToNot(HaveOccurred())
-
-					replicas := 0
-					machineType := "r5.xlarge"
-					name := "ocp-73068-2"
-					sgIDs := output.SGIDs
-					if len(sgIDs) >= 4 {
-						sgIDs = sgIDs[0:4]
-					}
-					MachinePoolArgs := &exe.MachinePoolArgs{
-						Cluster:                  clusterID,
-						Replicas:                 &replicas,
-						MachineType:              &machineType,
-						Name:                     &name,
-						AdditionalSecurityGroups: &output.SGIDs,
-						AutoscalingEnabled:       helper.BoolPointer(false),
-						AutoRepair:               helper.BoolPointer(false),
-						SubnetID:                 &vpcOutput.ClusterPrivateSubnets[0],
-					}
-					_, err = HCPMachinePoolService.Apply(MachinePoolArgs, true)
-					Expect(err).ToNot(HaveOccurred())
-					defer func() {
-						_, err = HCPMachinePoolService.Destroy()
-						Expect(err).ToNot(HaveOccurred())
-					}()
-
-					By("Verify the parameters of the created machinepool")
-					mpResponseBody, err := cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(len(mpResponseBody.AWSNodePool().AdditionalSecurityGroupIds())).To(Equal(len(sgIDs)))
-					for _, sg := range mpResponseBody.AWSNodePool().AdditionalSecurityGroupIds() {
-						Expect(sg).To(BeElementOf(sgIDs))
-					}
-
-					By("Update security groups is not allowed to a machinepool")
-					testAdditionalSecurityGroups := output.SGIDs[0:1]
-					MachinePoolArgs = &exe.MachinePoolArgs{
-						AdditionalSecurityGroups: &testAdditionalSecurityGroups,
-					}
-
-					applyOutput, err := HCPMachinePoolService.Apply(MachinePoolArgs, false)
-					Expect(err).To(HaveOccurred())
-					Expect(applyOutput).Should(ContainSubstring("Attribute aws_additional_security_group_ids, cannot be changed"))
-
-					By("Destroy the machinepool")
-					_, err = HCPMachinePoolService.Destroy()
-					Expect(err).ToNot(HaveOccurred())
-
-					By("Create another machinepool without additional sg ")
-					name = "add-73068"
-					MachinePoolArgs = &exe.MachinePoolArgs{
-						Cluster:     clusterID,
-						Replicas:    &replicas,
-						MachineType: helper.StringPointer("m5.2xlarge"),
-						Name:        &name,
-					}
-
-					_, err = HCPMachinePoolService.Apply(MachinePoolArgs, false)
-					Expect(err).ToNot(HaveOccurred())
-
-					By("Verify the parameters of the created machinepool")
-					mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(mpResponseBody.AWSNodePool().AdditionalSecurityGroupIds()).To(BeNil())
-					Expect(mpResponseBody.AWSNodePool().InstanceType()).To(Equal("m5.2xlarge"))
-				})
-
-			It("Author:xueli-High-OCP-73069 @OCP-73069 @xueli Create nodepool with security groups via RHCS will work well", ci.Low,
-				func() {
-
-					By("Prepare additional security groups")
-					replicas := 0
-					machineType := "r5.xlarge"
-					name := "ocp-73069"
-					fakeSgIDs := []string{"sg-fake"}
-
-					By("Run terraform apply cannot work with invalid sg IDs")
-					MachinePoolArgs := &exe.MachinePoolArgs{
-						Cluster:                  clusterID,
-						Replicas:                 &replicas,
-						MachineType:              &machineType,
-						Name:                     &name,
-						AdditionalSecurityGroups: &fakeSgIDs,
-						AutoscalingEnabled:       helper.BoolPointer(false),
-						AutoRepair:               helper.BoolPointer(false),
-						SubnetID:                 &vpcOutput.ClusterPrivateSubnets[0],
-					}
-					output, err := HCPMachinePoolService.Apply(MachinePoolArgs, false)
-					Expect(err).To(HaveOccurred())
-					Expect(output).Should(ContainSubstring("is not attached to VPC"))
-
-					By("Terraform plan with too many sg IDs cannot work")
-					i := 0
-					for i < 11 {
-						fakeSgIDs = append(fakeSgIDs, fmt.Sprintf("sg-fakeid%d", i))
-						i++
-					}
-					MachinePoolArgs = &exe.MachinePoolArgs{
-						Cluster:                  clusterID,
-						Replicas:                 &replicas,
-						MachineType:              &machineType,
-						Name:                     &name,
-						AdditionalSecurityGroups: &fakeSgIDs,
-						AutoscalingEnabled:       helper.BoolPointer(false),
-						AutoRepair:               helper.BoolPointer(false),
-						SubnetID:                 &vpcOutput.ClusterPrivateSubnets[0],
-					}
-					output, err = HCPMachinePoolService.Plan(MachinePoolArgs)
-					Expect(err).To(HaveOccurred())
-					Expect(output).Should(
-						MatchRegexp(`Attribute aws_node_pool.additional_security_group_ids list must contain at[\s\S]?most 10 elements, got: %d`, len(fakeSgIDs)))
-
-				})
+			By("Delete machinepool")
+			_, err = mpService.Destroy()
+			Expect(err).ToNot(HaveOccurred())
+			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).To(HaveOccurred())
 		})
 
+	It("can create/edit autoscaling - [id:72505]",
+		ci.Critical, func() {
+			minReplicas := 2
+			maxReplicas := 4
+			replicas := 3
+			machineType := "m5.xlarge"
+			name := helper.GenerateRandomName("np-72505", 2)
+			subnetId := vpcOutput.ClusterPrivateSubnets[0]
+
+			By("Create machinepool")
+			mpArgs = &exec.MachinePoolArgs{
+				Cluster:            clusterID,
+				AutoscalingEnabled: helper.BoolPointer(true),
+				MinReplicas:        &minReplicas,
+				MaxReplicas:        &maxReplicas,
+				Name:               &name,
+				SubnetID:           &subnetId,
+				MachineType:        &machineType,
+				AutoRepair:         helper.BoolPointer(true),
+			}
+			_, err := mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify
+			mpResponseBody, err := cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.Autoscaling()).ToNot(BeNil())
+			Expect(mpResponseBody.Autoscaling().MaxReplica()).To(Equal(maxReplicas))
+			Expect(mpResponseBody.Autoscaling().MinReplica()).To(Equal(minReplicas))
+
+			By("Update autoscaling")
+			minReplicas = 1
+			maxReplicas = 3
+			_, err = mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify
+			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.Autoscaling()).ToNot(BeNil())
+			Expect(mpResponseBody.Autoscaling().MaxReplica()).To(Equal(maxReplicas))
+			Expect(mpResponseBody.Autoscaling().MinReplica()).To(Equal(minReplicas))
+
+			By("Disable autoscaling")
+			mpArgs.AutoscalingEnabled = helper.BoolPointer(false)
+			mpArgs.MinReplicas = nil
+			mpArgs.MaxReplicas = nil
+			mpArgs.Replicas = &replicas
+			_, err = mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify
+			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.Autoscaling()).To(BeNil())
+			Expect(mpResponseBody.Replicas()).To(Equal(replicas))
+
+			By("Scale up")
+			replicas = 4
+			_, err = mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify
+			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.Autoscaling()).To(BeNil())
+			Expect(mpResponseBody.Replicas()).To(Equal(replicas))
+
+			By("Scale to zero")
+			replicas = 0
+			_, err = mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify
+			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.Autoscaling()).To(BeNil())
+			Expect(mpResponseBody.Replicas()).To(Equal(replicas))
+
+			By("Enable back autoscaling")
+			minReplicas = 1
+			maxReplicas = 2
+			mpArgs.Replicas = nil
+			mpArgs.AutoscalingEnabled = helper.BoolPointer(true)
+			mpArgs.MinReplicas = &minReplicas
+			mpArgs.MaxReplicas = &maxReplicas
+			_, err = mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify
+			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.Autoscaling()).ToNot(BeNil())
+			Expect(mpResponseBody.Autoscaling().MaxReplica()).To(Equal(maxReplicas))
+			Expect(mpResponseBody.Autoscaling().MinReplica()).To(Equal(minReplicas))
+		})
+
+	It("can be created with security groups - [id:73068]", ci.High,
+		func() {
+			By("Prepare additional security groups")
+			sgService := exe.NewSecurityGroupService()
+			output, err := sgService.Output()
+			Expect(err).ToNot(HaveOccurred())
+			if output.SGIDs == nil {
+
+				sgArgs := &exe.SecurityGroupArgs{
+					AWSRegion: profile.Region,
+					VPCID:     vpcOutput.VPCID,
+					SGNumber:  4,
+				}
+				err = sgService.Apply(sgArgs, true)
+				Expect(err).ToNot(HaveOccurred())
+				// defer sgService.Destroy()
+			}
+
+			output, err = sgService.Output()
+			Expect(err).ToNot(HaveOccurred())
+
+			replicas := 0
+			machineType := "r5.xlarge"
+			name := "ocp-73068-2"
+			sgIDs := output.SGIDs
+			if len(sgIDs) >= 4 {
+				sgIDs = sgIDs[0:4]
+			}
+			MachinePoolArgs := &exe.MachinePoolArgs{
+				Cluster:                  clusterID,
+				Replicas:                 &replicas,
+				MachineType:              &machineType,
+				Name:                     &name,
+				AdditionalSecurityGroups: &output.SGIDs,
+				AutoscalingEnabled:       helper.BoolPointer(false),
+				AutoRepair:               helper.BoolPointer(false),
+				SubnetID:                 &vpcOutput.ClusterPrivateSubnets[0],
+			}
+			_, err = mpService.Apply(MachinePoolArgs, true)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				_, err = mpService.Destroy()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			By("Verify the parameters of the created machinepool")
+			mpResponseBody, err := cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(mpResponseBody.AWSNodePool().AdditionalSecurityGroupIds())).To(Equal(len(sgIDs)))
+			for _, sg := range mpResponseBody.AWSNodePool().AdditionalSecurityGroupIds() {
+				Expect(sg).To(BeElementOf(sgIDs))
+			}
+
+			By("Update security groups is not allowed to a machinepool")
+			testAdditionalSecurityGroups := output.SGIDs[0:1]
+			MachinePoolArgs = &exe.MachinePoolArgs{
+				AdditionalSecurityGroups: &testAdditionalSecurityGroups,
+			}
+
+			applyOutput, err := mpService.Apply(MachinePoolArgs, false)
+			Expect(err).To(HaveOccurred())
+			Expect(applyOutput).Should(ContainSubstring("Attribute aws_additional_security_group_ids, cannot be changed"))
+
+			By("Destroy the machinepool")
+			_, err = mpService.Destroy()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Create another machinepool without additional sg ")
+			name = "add-73068"
+			MachinePoolArgs = &exe.MachinePoolArgs{
+				Cluster:     clusterID,
+				Replicas:    &replicas,
+				MachineType: helper.StringPointer("m5.2xlarge"),
+				Name:        &name,
+			}
+
+			_, err = mpService.Apply(MachinePoolArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify the parameters of the created machinepool")
+			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.AWSNodePool().AdditionalSecurityGroupIds()).To(BeNil())
+			Expect(mpResponseBody.AWSNodePool().InstanceType()).To(Equal("m5.2xlarge"))
+		})
+
+	It("can validate nodepool creation with security groups - [id:73069]", ci.Low,
+		func() {
+
+			By("Prepare additional security groups")
+			replicas := 0
+			machineType := "r5.xlarge"
+			name := "ocp-73069"
+			fakeSgIDs := []string{"sg-fake"}
+
+			By("Run terraform apply cannot work with invalid sg IDs")
+			MachinePoolArgs := &exe.MachinePoolArgs{
+				Cluster:                  clusterID,
+				Replicas:                 &replicas,
+				MachineType:              &machineType,
+				Name:                     &name,
+				AdditionalSecurityGroups: &fakeSgIDs,
+				AutoscalingEnabled:       helper.BoolPointer(false),
+				AutoRepair:               helper.BoolPointer(false),
+				SubnetID:                 &vpcOutput.ClusterPrivateSubnets[0],
+			}
+			output, err := mpService.Apply(MachinePoolArgs, false)
+			Expect(err).To(HaveOccurred())
+			Expect(output).Should(ContainSubstring("is not attached to VPC"))
+
+			By("Terraform plan with too many sg IDs cannot work")
+			i := 0
+			for i < 11 {
+				fakeSgIDs = append(fakeSgIDs, fmt.Sprintf("sg-fakeid%d", i))
+				i++
+			}
+			MachinePoolArgs = &exe.MachinePoolArgs{
+				Cluster:                  clusterID,
+				Replicas:                 &replicas,
+				MachineType:              &machineType,
+				Name:                     &name,
+				AdditionalSecurityGroups: &fakeSgIDs,
+				AutoscalingEnabled:       helper.BoolPointer(false),
+				AutoRepair:               helper.BoolPointer(false),
+				SubnetID:                 &vpcOutput.ClusterPrivateSubnets[0],
+			}
+			output, err = mpService.Plan(MachinePoolArgs)
+			Expect(err).To(HaveOccurred())
+			Expect(output).Should(
+				MatchRegexp(`Attribute aws_node_pool.additional_security_group_ids list must contain at[\s\S]?most 10 elements, got: %d`, len(fakeSgIDs)))
+
+		})
+
+	It("can create/edit/delete labels/taints/autorepair - [id:72507]",
+		ci.High, func() {
+			By("Create machinepool")
+			replicas := 3
+			machineType := "m5.xlarge"
+			name := helper.GenerateRandomName("np-72507", 2)
+			subnetId := vpcOutput.ClusterPrivateSubnets[0]
+			labels := map[string]string{
+				"l1": "v1",
+				"l2": "v2",
+			}
+			taint1 := map[string]string{"key": "t1", "value": "v1", "schedule_type": constants.NoSchedule}
+			taints := []map[string]string{taint1}
+			mpArgs = &exec.MachinePoolArgs{
+				Cluster:            clusterID,
+				AutoscalingEnabled: helper.BoolPointer(false),
+				Replicas:           &replicas,
+				Name:               &name,
+				SubnetID:           &subnetId,
+				MachineType:        &machineType,
+				AutoRepair:         helper.BoolPointer(false),
+				Labels:             &labels,
+				Taints:             &taints,
+			}
+			_, err := mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify
+			mpResponseBody, err := cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			respTaints := mpResponseBody.Taints()
+			for index, taint := range respTaints {
+				Expect(taint.Effect()).To(Equal(taints[index]["schedule_type"]))
+				Expect(taint.Key()).To(Equal(taints[index]["key"]))
+				Expect(taint.Value()).To(Equal(taints[index]["value"]))
+			}
+			Expect(mpResponseBody.AutoRepair()).To(BeFalse())
+			Expect(mpResponseBody.Labels()).To(Equal(labels))
+
+			By("Update labels/taints/autorepair")
+			mpArgs.AutoRepair = helper.BoolPointer(true)
+			taint2 := map[string]string{"key": "t2", "value": "", "schedule_type": constants.NoExecute}
+			taints = append(taints, taint2)
+			labels = map[string]string{
+				"l3": "v3",
+			}
+			mpArgs.Labels = &labels
+			_, err = mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify
+			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			respTaints = mpResponseBody.Taints()
+			for index, taint := range respTaints {
+				Expect(taint.Effect()).To(Equal(taints[index]["schedule_type"]))
+				Expect(taint.Key()).To(Equal(taints[index]["key"]))
+				Expect(taint.Value()).To(Equal(taints[index]["value"]))
+			}
+			Expect(mpResponseBody.AutoRepair()).To(BeTrue())
+			Expect(mpResponseBody.Labels()).To(Equal(labels))
+
+			By("Remove labels/taints")
+			mpArgs.Labels = nil
+			mpArgs.Taints = nil
+			_, err = mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Verify
+			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.Taints()).To(BeEmpty())
+			Expect(mpResponseBody.AutoRepair()).To(BeTrue())
+			Expect(mpResponseBody.Labels()).To(BeEmpty())
+		})
+
+	It("can be created with specific version - [id:72509]",
+		ci.High, func() {
+			if profile.ChannelGroup != "" && profile.ChannelGroup != "stable" {
+				Skip("Skip test due channel group not `stable` and https://issues.redhat.com/browse/OCM-7083")
+			}
+
+			replicas := 3
+			machineType := "m5.2xlarge"
+			name := helper.GenerateRandomName("np-72509", 2)
+			subnetId := vpcOutput.ClusterPrivateSubnets[0]
+			mpArgs = &exec.MachinePoolArgs{
+				Cluster:            clusterID,
+				AutoscalingEnabled: helper.BoolPointer(false),
+				Replicas:           &replicas,
+				Name:               &name,
+				SubnetID:           &subnetId,
+				MachineType:        &machineType,
+				AutoRepair:         helper.BoolPointer(true),
+			}
+
+			By("Retrieve cluster version")
+			clusterService, err = exec.NewClusterService(constants.GetClusterManifestsDir(profile.GetClusterType()))
+			Expect(err).ToNot(HaveOccurred())
+			clusterOutput, err := clusterService.Output()
+			Expect(err).ToNot(HaveOccurred())
+			clusterVersion := clusterOutput.ClusterVersion
+			clusterSemVer, err := semver.NewVersion(clusterVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Retrieve z-1 version")
+			zLowerVersions := cms.SortRawVersions(cms.GetHcpLowerVersions(ci.RHCSConnection, clusterVersion, exec.StableChannel)) // Should be changed once https://issues.redhat.com/browse/OCM-7083 is solved
+			if len(zLowerVersions) > 0 {
+				zversion := zLowerVersions[len(zLowerVersions)-1]
+				zSemVer, err := semver.NewVersion(zversion)
+				Expect(err).ToNot(HaveOccurred())
+
+				if zSemVer.Major() == clusterSemVer.Major() && zSemVer.Minor() == clusterSemVer.Minor() {
+					By("Create machinepool with z-1")
+					mpArgs.OpenshiftVersion = &zversion
+					_, err = mpService.Apply(mpArgs, true)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Verify machinepool with z-1")
+					mpResponseBody, err := cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mpResponseBody.Version()).To(Equal(zversion))
+
+					By("Destroy machinepool with z-1")
+					_, err = mpService.Destroy()
+					Expect(err).ToNot(HaveOccurred())
+				} else {
+					Logger.Infof("Cannot test `z-1` creation as the greatest lower `z-1` is: %s", zversion)
+				}
+			} else {
+				Logger.Infof("Cannot test `z-1` creation as there is no version available")
+			}
+
+			By("Retrieve y-1 version")
+			throttleVersion := fmt.Sprintf("%v.%v.0", clusterSemVer.Major(), clusterSemVer.Minor())
+			yLowerVersions := cms.SortRawVersions(cms.GetHcpLowerVersions(ci.RHCSConnection, throttleVersion, exec.StableChannel)) // Channel should be changed once https://issues.redhat.com/browse/OCM-7083 is solved
+			if len(yLowerVersions) > 0 {
+				yVersion := yLowerVersions[len(zLowerVersions)-1]
+
+				By("Create machinepool with y-1")
+				mpArgs.OpenshiftVersion = &yVersion
+				_, err = mpService.Apply(mpArgs, true)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verify machinepool with z-1")
+				mpResponseBody, err := cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mpResponseBody.Version()).To(Equal(yVersion))
+
+				By("Destroy machinepool with z-1")
+				_, err = mpService.Destroy()
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+	It("can be created with tags - [id:72510]",
+		ci.Critical, func() {
+			By("Create machinepool")
+			replicas := 3
+			machineType := "m5.2xlarge"
+			name := helper.GenerateRandomName("np-72510", 2)
+			subnetId := vpcOutput.ClusterPrivateSubnets[0]
+			tags := map[string]string{
+				"aaa": "bbb",
+				"ccc": "ddd",
+			}
+			mpArgs = &exec.MachinePoolArgs{
+				Cluster:            clusterID,
+				AutoscalingEnabled: helper.BoolPointer(false),
+				Replicas:           &replicas,
+				Name:               &name,
+				SubnetID:           &subnetId,
+				MachineType:        &machineType,
+				AutoRepair:         helper.BoolPointer(true),
+				Tags:               &tags,
+			}
+			_, err = mpService.Apply(mpArgs, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify tags are correctly set")
+			mpResponseBody, err := cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mpResponseBody.AWSNodePool().Tags()).To(HaveKeyWithValue("aaa", "bbb"))
+			Expect(mpResponseBody.AWSNodePool().Tags()).To(HaveKeyWithValue("ccc", "ddd"))
+
+			// Blocked by https://issues.redhat.com/browse/OCM-6885
+			// By("Edit machinepool tags")
+			// delete(tags, "aaa")
+			// tags["ccc"] = "fff"
+			// _, err = mpService.Apply(mpArgs, false)
+			// Expect(err).ToNot(HaveOccurred())
+
+			// By("Verify tags are correctly updated")
+			// mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
+			// Expect(err).ToNot(HaveOccurred())
+			// Expect(mpResponseBody.AWSNodePool().Tags()).ToNot(HaveKey("aaa"))
+			// Expect(mpResponseBody.AWSNodePool().Tags()).To(HaveKeyWithValue("ccc", "fff"))
+		})
 })

--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 var _ = Describe("Identity Providers", ci.Day2, ci.FeatureIDP, func() {
+	defer GinkgoRecover()
 
 	// all identity providers - declared for future cases
 	type IDPServices struct {

--- a/tests/e2e/kubelet_config_test.go
+++ b/tests/e2e/kubelet_config_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var _ = Describe("Kubelet config", ci.NonHCPCluster, func() {
+	defer GinkgoRecover()
 
 	var kcService *exe.KubeletConfigService
 	BeforeEach(func() {

--- a/tests/e2e/negative_day_one_test.go
+++ b/tests/e2e/negative_day_one_test.go
@@ -18,6 +18,8 @@ var err error
 var profile *ci.Profile
 
 var _ = Describe("Negative Tests", func() {
+	defer GinkgoRecover()
+
 	profile = ci.LoadProfileYamlFileByENV()
 
 	Describe("cluster admin", ci.NonHCPCluster, Ordered, func() {

--- a/tests/e2e/verfication_post_day1_test.go
+++ b/tests/e2e/verfication_post_day1_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 var _ = Describe("Verify cluster", func() {
+	defer GinkgoRecover()
 
 	var err error
 	var profile *ci.Profile

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/output.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/output.tf
@@ -6,6 +6,10 @@ output "cluster_name" {
   value = rhcs_cluster_rosa_classic.rosa_sts_cluster.name
 }
 
+output "cluster_version" {
+  value = rhcs_cluster_rosa_classic.rosa_sts_cluster.current_version
+}
+
 output "additional_compute_security_groups" {
   value = rhcs_cluster_rosa_classic.rosa_sts_cluster.aws_additional_compute_security_group_ids
 }

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/output.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/output.tf
@@ -5,3 +5,7 @@ output "cluster_id" {
 output "cluster_name" {
   value = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.name
 }
+
+output "cluster_version" {
+  value = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.current_version
+}

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -62,7 +62,8 @@ type PrivateHostedZone struct {
 // Just a placeholder, not research what to output yet.
 type ClusterOutput struct {
 	ClusterID                            string   `json:"cluster_id,omitempty"`
-	ClusterName                          string   `json:"name,omitempty"`
+	ClusterName                          string   `json:"cluster_name,omitempty"`
+	ClusterVersion                       string   `json:"cluster_version,omitempty"`
 	AdditionalComputeSecurityGroups      []string `json:"additional_compute_security_groups,omitempty"`
 	AdditionalInfraSecurityGroups        []string `json:"additional_infra_security_groups,omitempty"`
 	AdditionalControlPlaneSecurityGroups []string `json:"additional_control_plane_security_groups,omitempty"`
@@ -134,7 +135,8 @@ func (creator *ClusterService) Output() (*ClusterOutput, error) {
 	}
 	clusterOutput := &ClusterOutput{
 		ClusterID:                            h.DigString(out["cluster_id"], "value"),
-		ClusterName:                          h.DigString(out["name"], "value"),
+		ClusterName:                          h.DigString(out["cluster_name"], "value"),
+		ClusterVersion:                       h.DigString(out["cluster_version"], "value"),
 		AdditionalComputeSecurityGroups:      h.DigArrayToString(out["additional_compute_security_groups"], "value"),
 		AdditionalInfraSecurityGroups:        h.DigArrayToString(out["additional_infra_security_groups"], "value"),
 		AdditionalControlPlaneSecurityGroups: h.DigArrayToString(out["additional_control_plane_security_groups"], "value"),

--- a/tests/utils/exec/machine-pools.go
+++ b/tests/utils/exec/machine-pools.go
@@ -31,10 +31,11 @@ type MachinePoolArgs struct {
 	AdditionalSecurityGroups *[]string            `json:"additional_security_groups,omitempty"`
 
 	// HCP supported
-	TuningConfigs              *[]string `json:"tuning_configs,omitempty"`
-	UpgradeAcknowledgementsFor *string   `json:"upgrade_acknowledgements_for,omitempty"`
-	OpenshiftVersion           *string   `json:"openshift_version,omitempty"`
-	AutoRepair                 *bool     `json:"auto_repair,omitempty"`
+	TuningConfigs              *[]string          `json:"tuning_configs,omitempty"`
+	UpgradeAcknowledgementsFor *string            `json:"upgrade_acknowledgements_for,omitempty"`
+	OpenshiftVersion           *string            `json:"openshift_version,omitempty"`
+	AutoRepair                 *bool              `json:"auto_repair,omitempty"`
+	Tags                       *map[string]string `json:"tags,omitempty"`
 }
 
 type MachinePoolService struct {

--- a/tests/utils/exec/tf-exec.go
+++ b/tests/utils/exec/tf-exec.go
@@ -221,7 +221,6 @@ func recordTFvarsFile(fileDir string, tfvars map[string]string) error {
 	}
 	for k, v := range tfvars {
 		section.Key(k).SetValue(v)
-
 	}
 	return iniConn.SaveTo(tfvarsFile)
 }

--- a/tests/utils/exec/vpc.go
+++ b/tests/utils/exec/vpc.go
@@ -68,6 +68,9 @@ func (vpc *VPCService) Output() (*VPCOutput, error) {
 		vpcDir = vpc.ManifestDir
 	}
 	out, err := runTerraformOutput(context.TODO(), vpcDir)
+	if err != nil {
+		return nil, err
+	}
 	vpcOutput := &VPCOutput{
 		VPCCIDR:               h.DigString(out["vpc-cidr"], "value"),
 		ClusterPrivateSubnets: h.DigArrayToString(out["cluster-private-subnet"], "value"),

--- a/tests/utils/helper/assert.go
+++ b/tests/utils/helper/assert.go
@@ -1,0 +1,50 @@
+package helper
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/log"
+)
+
+// e is return value of Wait.Poll
+// msg is the reason why time out
+// the function assert return value of Wait.Poll, and expect NO error
+// if e is Nil, just pass and nothing happen.
+// if e is not Nil, will not print the default error message "timed out waiting for the condition" because it causes RP AA not to analysis result exactly.
+// if e is "timed out waiting for the condition" or "context deadline exceeded", it is replaced by msg.
+// if e is not "timed out waiting for the condition", it print e and then case fails.
+
+func AssertWaitPollNoErr(e error, msg string) {
+	if e == nil {
+		return
+	}
+	var err error
+	if strings.Compare(e.Error(), "timed out waiting for the condition") == 0 || strings.Compare(e.Error(), "context deadline exceeded") == 0 {
+		err = fmt.Errorf("case: %v\nerror: %s", CurrentSpecReport().FullText(), msg)
+	} else {
+		err = fmt.Errorf("case: %v\nerror: %s", CurrentSpecReport().FullText(), e.Error())
+	}
+	Expect(err).NotTo(HaveOccurred())
+
+}
+
+// e is return value of Wait.Poll
+// msg is the reason why not get
+// the function assert return value of Wait.Poll, and expect error raised.
+// if e is not Nil, just pass and nothing happen.
+// if e is  Nil, will print expected error info and then case fails.
+
+func AssertWaitPollWithErr(e error, msg string) {
+	if e != nil {
+		Logger.Infof("the error: %v", e)
+		return
+	}
+
+	err := fmt.Errorf("case: %v\nexpected error not got because of %v", CurrentSpecReport().FullText(), msg)
+	Expect(err).NotTo(HaveOccurred())
+
+}

--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -430,6 +430,22 @@ func GenerateRandomStringWithSymbols(length int) string {
 	return randomString
 }
 
+// Generate random string
+func GenerateRandomString(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	rand.Seed(time.Now().UnixNano())
+
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(s)
+}
+
+func GenerateRandomName(prefix string, n int) string {
+	return fmt.Sprintf("%s-%s", prefix, strings.ToLower(GenerateRandomString(n)))
+}
+
 func Subfix(length int) string {
 	subfix := make([]byte, length)
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/tests/utils/helper/map.go
+++ b/tests/utils/helper/map.go
@@ -1,0 +1,10 @@
+package helper
+
+// Create a file for usage
+func CopyStringMap(originalMap map[string]string) map[string]string {
+	newMap := make(map[string]string)
+	for k, v := range originalMap {
+		newMap[k] = v
+	}
+	return newMap
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement day2 test cases

<details>
<summary>72504</summary>
$ ginkgo -focus 72504 tests/e2e/
time="2024-04-04T16:44:09+02:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2024-04-04T16:44:09+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
Running Suite: e2e tests suite - /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e
====================================================================================================
Random Seed: 1712241848

Will run 1 of 67 specs
time="2024-04-04T16:44:09+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
time="2024-04-04T16:44:09+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-04T16:44:12+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-04T16:44:14+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
time="2024-04-04T16:44:14+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-04T16:44:17+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-04T16:44:19+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var name=np-72504-ge -var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge -var replicas=3 -var autoscaling_enabled=false -var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true]"
time="2024-04-04T16:44:53+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var replicas=3 -var autoscaling_enabled=false -var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var name=np-72504-ge -var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge
time="2024-04-04T16:44:56+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var name=np-72504-ge -var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge -var replicas=3 -var autoscaling_enabled=false -var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em
•SSSSSSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden [NonHCPCluster]
/home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:262
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 67 Specs in 47.970 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 65 Skipped
PASS
</details>

<details>
<summary>72505</summary>
$  ginkgo -focus 72505 tests/e2e/
time="2024-04-05T09:02:26+02:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2024-04-05T09:02:26+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
Running Suite: e2e tests suite - /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e
====================================================================================================
Random Seed: 1712300544

Will run 1 of 67 specs
time="2024-04-05T09:02:26+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
time="2024-04-05T09:02:26+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-05T09:02:29+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSStime="2024-04-05T09:02:31+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
time="2024-04-05T09:02:31+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-05T09:02:34+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-05T09:02:36+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var url=https://api.stage.openshift.com -var autoscaling_enabled=true -var min_replicas=2 -var subnet_id=subnet-04d27a3aa93f76c91 -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var name=np-72505-b2 -var machine_type=m5.xlarge -var max_replicas=4 -var auto_repair=true]"
time="2024-04-05T09:02:41+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var min_replicas=1 -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var autoscaling_enabled=true -var machine_type=m5.xlarge -var max_replicas=3 -var subnet_id=subnet-04d27a3aa93f76c91 -var name=np-72505-b2 -var url=https://api.stage.openshift.com]"
time="2024-04-05T09:02:45+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var autoscaling_enabled=false -var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var name=np-72505-b2 -var url=https://api.stage.openshift.com -var machine_type=m5.xlarge -var replicas=3]"
time="2024-04-05T09:02:48+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var name=np-72505-b2 -var url=https://api.stage.openshift.com -var machine_type=m5.xlarge -var replicas=4 -var autoscaling_enabled=false -var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em]"
time="2024-04-05T09:02:52+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var machine_type=m5.xlarge -var replicas=0 -var autoscaling_enabled=false -var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var name=np-72505-b2 -var url=https://api.stage.openshift.com]"
time="2024-04-05T09:02:55+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var auto_repair=true -var name=np-72505-b2 -var machine_type=m5.xlarge -var autoscaling_enabled=true -var max_replicas=2 -var subnet_id=subnet-04d27a3aa93f76c91 -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var url=https://api.stage.openshift.com -var min_replicas=1]"
time="2024-04-05T09:03:00+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var name=np-72505-b2 -var min_replicas=1 -var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var url=https://api.stage.openshift.com -var machine_type=m5.xlarge -var autoscaling_enabled=true -var max_replicas=2
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden [NonHCPCluster]
/home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:262
------------------------------
SSSSSSSSSSSSSSSSSSSSS

Ran 1 of 67 Specs in 36.634 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 65 Skipped
PASS

</details>

<details>
<summary>72451</summary>
$ ginkgo -focus 72451 tests/e2e/
time="2024-04-05T11:07:06+02:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2024-04-05T11:07:06+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
Running Suite: e2e tests suite - /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e
====================================================================================================
Random Seed: 1712308025

Will run 1 of 69 specs
time="2024-04-05T11:07:06+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
time="2024-04-05T11:07:06+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-05T11:07:10+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
Stime="2024-04-05T11:07:11+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
time="2024-04-05T11:07:11+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-05T11:07:15+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var aws_region=us-west-2 -var custom_properties={\"custom_property\":\"test\",\"nothing\":\"\",\"qe_usage\":\"\",\"some\":\"thing\"}]"
time="2024-04-05T11:07:23+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var aws_region=us-west-2 -var custom_properties={\"custom_property\":\"test\",\"nothing\":\"\",\"qe_usage\":\"\",\"some\":\"thing2\"}]"
time="2024-04-05T11:07:30+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var aws_region=us-west-2 -var custom_properties={\"custom_property\":\"test\",\"qe_usage\":\"\"}]"
time="2024-04-05T11:07:37+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var aws_region=us-west-2 -var custom_properties={\"custom_property\":\"test\",\"qe_usage\":\"\"}]"
•SSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden [NonHCPCluster]
/home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:262
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 69 Specs in 35.712 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 67 Skipped
PASS

</details>

<details>
<summary>72507</summary>
$ ginkgo -focus 72507 tests/e2e/
time="2024-04-05T10:56:20+02:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2024-04-05T10:56:20+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
Running Suite: e2e tests suite - /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e
====================================================================================================
Random Seed: 1712307379

Will run 1 of 69 specs
time="2024-04-05T10:56:20+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
time="2024-04-05T10:56:20+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-05T10:56:23+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden [NonHCPCluster]
/home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:262
------------------------------
SSSSSSSStime="2024-04-05T10:56:25+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
time="2024-04-05T10:56:25+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-05T10:56:28+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-05T10:56:29+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var url=https://api.stage.openshift.com -var machine_type=m5.xlarge -var autoscaling_enabled=false -var auto_repair=false -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var name=np-72507-te -var replicas=3 -var labels={\"l1\":\"v1\",\"l2\":\"v2\"} -var taints=[{\"key\":\"t1\",\"schedule_type\":\"NoSchedule\",\"value\":\"v1\"}] -var subnet_id=subnet-04d27a3aa93f76c91]"
time="2024-04-05T10:56:34+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var name=np-72507-te -var url=https://api.stage.openshift.com -var machine_type=m5.xlarge -var replicas=3 -var labels={\"l3\":\"v3\"} -var taints=[{\"key\":\"t1\",\"schedule_type\":\"NoSchedule\",\"value\":\"v1\"},{\"key\":\"t2\",\"schedule_type\":\"NoExecute\",\"value\":\"\"}] -var subnet_id=subnet-04d27a3aa93f76c91 -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var autoscaling_enabled=false -var auto_repair=true]"
time="2024-04-05T10:56:38+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var machine_type=m5.xlarge -var replicas=3 -var autoscaling_enabled=false -var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var name=np-72507-te -var url=https://api.stage.openshift.com]"
time="2024-04-05T10:56:41+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var autoscaling_enabled=false -var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var name=np-72507-te -var url=https://api.stage.openshift.com -var machine_type=m5.xlarge -var replicas=3
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 69 Specs in 23.776 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 67 Skipped
PASS

</details>

<details>
<summary>72509</summary>
$ ginkgo -focus 72509 tests/e2e/
time="2024-04-05T09:41:17+02:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2024-04-05T09:41:17+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
Running Suite: e2e tests suite - /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e
====================================================================================================
Random Seed: 1712302875

Will run 1 of 69 specs
time="2024-04-05T09:41:17+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
time="2024-04-05T09:41:17+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-05T09:41:20+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden [NonHCPCluster]
/home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:262
------------------------------
SSSSSSSSSSSSSSSSSSStime="2024-04-05T09:41:22+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
time="2024-04-05T09:41:22+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-05T09:41:25+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 0 of 69 Specs in 9.513 seconds
SUCCESS! -- 0 Passed | 0 Failed | 1 Pending | 68 Skipped
PASS


</details>

<details>
<summary>72510</summary>
$ ginkgo -focus 72510 tests/e2e/
time="2024-04-05T09:24:17+02:00" level=info msg="Running against env staging with gateway url https://api.stage.openshift.com"
time="2024-04-05T09:24:17+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
Running Suite: e2e tests suite - /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e
====================================================================================================
Random Seed: 1712301856

Will run 1 of 69 specs
time="2024-04-05T09:24:17+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path: version: version_pattern:latest zones:a,b,c]"
time="2024-04-05T09:24:17+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-05T09:24:21+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
P [PENDING]
TF Test Verfication/Post day 1 tests Author:xueli-Critical-OCP-69145 @OCP-69145 @xueli Apply to change security group will be forbidden [NonHCPCluster]
/home/tradisso/projects/openshift/terraform-provider-rhcs/tests/e2e/verfication_post_day1_test.go:262
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSStime="2024-04-05T09:24:22+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
time="2024-04-05T09:24:22+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-05T09:24:25+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-05T09:24:27+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var subnet_id=subnet-04d27a3aa93f76c91 -var auto_repair=true -var url=https://api.stage.openshift.com -var replicas=3 -var machine_type=m5.2xlarge -var autoscaling_enabled=false -var tags={\"aaa\":\"bbb\",\"ccc\":\"ddd\"} -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var name=np-72510-j5]"
time="2024-04-05T09:24:32+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var auto_repair=true -var cluster=2ae5mq021okjdp0sb3e7l32r7ald84em -var url=https://api.stage.openshift.com -var replicas=3 -var subnet_id=subnet-04d27a3aa93f76c91 -var name=np-72510-j5 -var machine_type=m5.2xlarge -var autoscaling_enabled=false -var tags={"aaa":"bbb","ccc":"ddd"}
•SSSSSSS

Ran 1 of 69 Specs in 18.249 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 67 Skipped
PASS

</details>

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-7141


**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
