### PR TITLE
OCM-7493 | fix: allow datasource to fetch isolated support role

### DIFF
--- a/docs/data-sources/hcp_policies.md
+++ b/docs/data-sources/hcp_policies.md
@@ -28,6 +28,7 @@ Read-Only:
 - `sts_hcp_installer_permission_policy` (String)
 - `sts_hcp_instance_worker_permission_policy` (String)
 - `sts_hcp_support_permission_policy` (String)
+- `sts_support_rh_sre_role` (String)
 
 
 <a id="nestedatt--operator_role_policies"></a>
@@ -43,4 +44,3 @@ Read-Only:
 - `openshift_hcp_ingress_operator_cloud_credentials_policy` (String)
 - `openshift_hcp_kms_provider_credentials_policy` (String)
 - `openshift_hcp_kube_controller_manager_credentials_policy` (String)
-- `shared_vpc_openshift_ingress_operator_cloud_credentials_policy` (String)

--- a/docs/data-sources/policies.md
+++ b/docs/data-sources/policies.md
@@ -33,6 +33,7 @@ Read-Only:
 - `sts_instance_controlplane_permission_policy` (String)
 - `sts_instance_worker_permission_policy` (String)
 - `sts_support_permission_policy` (String)
+- `sts_support_rh_sre_role` (String)
 
 
 <a id="nestedatt--operator_role_policies"></a>

--- a/provider/ocm_policies/classic/ocm_policies_state.go
+++ b/provider/ocm_policies/classic/ocm_policies_state.go
@@ -36,6 +36,7 @@ type OperatorRolePolicies struct {
 type AccountRolePolicies struct {
 	Installer            types.String `tfsdk:"sts_installer_permission_policy"`
 	Support              types.String `tfsdk:"sts_support_permission_policy"`
+	SupportRhSreRole     types.String `tfsdk:"sts_support_rh_sre_role"`
 	InstanceWorker       types.String `tfsdk:"sts_instance_worker_permission_policy"`
 	InstanceControlPlane types.String `tfsdk:"sts_instance_controlplane_permission_policy"`
 }

--- a/provider/ocm_policies/common/rh_support_role.go
+++ b/provider/ocm_policies/common/rh_support_role.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+func ParseRhSupportRole(ctx context.Context, awsPolicyDetails string) (string, error) {
+	var trustPolicy map[string]any
+	if err := json.Unmarshal([]byte(awsPolicyDetails), &trustPolicy); err != nil {
+		return "", fmt.Errorf("failed to parse jit support role: %v", err)
+	}
+	statementList := trustPolicy["Statement"].([]any)
+	if len(statementList) != 1 {
+		return "", fmt.Errorf("failed to parse jit support role: expected a single statement")
+	}
+	principalMap := statementList[0].(map[string]any)["Principal"].(map[string]any)
+	jitRoles := principalMap["AWS"].([]any)
+	if len(jitRoles) != 1 {
+		return "", fmt.Errorf("failed to parse jit support role: expected a single role")
+	}
+	return jitRoles[0].(string), nil
+}

--- a/provider/ocm_policies/hcp/ocm_policies_state.go
+++ b/provider/ocm_policies/hcp/ocm_policies_state.go
@@ -28,7 +28,6 @@ type OperatorRolePolicies struct {
 	IngressOperator                 types.String `tfsdk:"openshift_hcp_ingress_operator_cloud_credentials_policy"`
 	ClusterCSI                      types.String `tfsdk:"openshift_hcp_cluster_csi_drivers_ebs_cloud_credentials_policy"`
 	CloudNetwork                    types.String `tfsdk:"openshift_hcp_cloud_network_config_controller_cloud_credentials_policy"`
-	SharedVpcIngressOperator        types.String `tfsdk:"shared_vpc_openshift_ingress_operator_cloud_credentials_policy"`
 	KubeControllerManagerKubeSystem types.String `tfsdk:"openshift_hcp_kube_controller_manager_credentials_policy"`
 	CapaControllerManagerKubeSystem types.String `tfsdk:"openshift_hcp_capa_controller_manager_credentials_policy"`
 	ControlPlaneOperatorKubeSystem  types.String `tfsdk:"openshift_hcp_control_plane_operator_credentials_policy"`
@@ -36,7 +35,8 @@ type OperatorRolePolicies struct {
 }
 
 type AccountRolePolicies struct {
-	Installer      types.String `tfsdk:"sts_hcp_installer_permission_policy"`
-	Support        types.String `tfsdk:"sts_hcp_support_permission_policy"`
-	InstanceWorker types.String `tfsdk:"sts_hcp_instance_worker_permission_policy"`
+	Installer        types.String `tfsdk:"sts_hcp_installer_permission_policy"`
+	Support          types.String `tfsdk:"sts_hcp_support_permission_policy"`
+	SupportRhSreRole types.String `tfsdk:"sts_support_rh_sre_role"`
+	InstanceWorker   types.String `tfsdk:"sts_hcp_instance_worker_permission_policy"`
 }

--- a/subsystem/hcp/rosa_ocm_policies_data_source_test.go
+++ b/subsystem/hcp/rosa_ocm_policies_data_source_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package hcp
 
 import (
+	"fmt"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"             // nolint
@@ -181,7 +182,14 @@ const (
 				"details": "{}",
 				"arn": "arn:aws:iam::aws:policy/service-role/ROSASRESupportPolicy",
 				"type": "AccountRole"
-			  }
+			  },
+			  {
+				"kind":"STSPolicy",
+				"id":"sts_support_trust_policy",
+				"details":"{\"Version\": \"2012-10-17\", \"Statement\": [{\"Action\": [\"sts:AssumeRole\"], \"Effect\": \"Allow\", \"Principal\": {\"AWS\": [\"arn:aws:iam::12345678912:role/RH-Technical-Support-12345678\"]}}]}",
+				"arn":"",
+				"type":"AccountRole"
+			  }	 
 			],
 		"kind": "STSPoliciesList",
 		"page": 1,
@@ -210,14 +218,13 @@ var _ = Describe("Hcp OCM policies data source", func() {
 
 		// Check the state:
 		resource := terraform.Resource("rhcs_hcp_policies", "my_policies").(map[string]interface{})
-		Expect(resource["attributes"]).To(Equal(
+		Expect(fmt.Sprint(resource["attributes"])).To(Equal(fmt.Sprint(
 			map[string]interface{}{
 				"operator_role_policies": map[string]interface{}{
 					"openshift_hcp_image_registry_installer_cloud_credentials_policy":        "arn:aws:iam::aws:policy/service-role/ROSAImageRegistryOperatorPolicy",
 					"openshift_hcp_ingress_operator_cloud_credentials_policy":                "arn:aws:iam::aws:policy/service-role/ROSAIngressOperatorPolicy",
 					"openshift_hcp_cluster_csi_drivers_ebs_cloud_credentials_policy":         "arn:aws:iam::aws:policy/service-role/ROSAAmazonEBSCSIDriverOperatorPolicy",
 					"openshift_hcp_cloud_network_config_controller_cloud_credentials_policy": "arn:aws:iam::aws:policy/service-role/ROSACloudNetworkConfigOperatorPolicy",
-					"shared_vpc_openshift_ingress_operator_cloud_credentials_policy":         "",
 					"openshift_hcp_kube_controller_manager_credentials_policy":               "arn:aws:iam::aws:policy/service-role/ROSAKubeControllerPolicy",
 					"openshift_hcp_capa_controller_manager_credentials_policy":               "arn:aws:iam::aws:policy/service-role/ROSANodePoolManagementPolicy",
 					"openshift_hcp_control_plane_operator_credentials_policy":                "arn:aws:iam::aws:policy/service-role/ROSAControlPlaneOperatorPolicy",
@@ -227,8 +234,9 @@ var _ = Describe("Hcp OCM policies data source", func() {
 					"sts_hcp_installer_permission_policy":       "arn:aws:iam::aws:policy/service-role/ROSAInstallerPolicy",
 					"sts_hcp_support_permission_policy":         "arn:aws:iam::aws:policy/service-role/ROSASRESupportPolicy",
 					"sts_hcp_instance_worker_permission_policy": "arn:aws:iam::aws:policy/service-role/ROSAWorkerInstancePolicy",
+					"sts_support_rh_sre_role":                   "arn:aws:iam::12345678912:role/RH-Technical-Support-12345678",
 				},
 			},
-		))
+		)))
 	})
 })

--- a/subsystem/rosa_ocm_policies_data_source_test.go
+++ b/subsystem/rosa_ocm_policies_data_source_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package provider
 
 import (
+	"fmt"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"             // nolint
@@ -181,12 +182,19 @@ const (
 			"details": "{}",
 			"arn": "arn:aws:iam::aws:policy/service-role/ROSASRESupportPolicy",
 			"type": "AccountRole"
-		  }
+		  },
+		  {
+			"kind":"STSPolicy",
+			"id":"sts_support_trust_policy",
+			"details":"{\"Version\": \"2012-10-17\", \"Statement\": [{\"Action\": [\"sts:AssumeRole\"], \"Effect\": \"Allow\", \"Principal\": {\"AWS\": [\"arn:aws:iam::12345678912:role/RH-Technical-Support-12345678\"]}}]}",
+			"arn":"",
+			"type":"AccountRole"
+		  }	  
 		],
 		"kind": "STSPoliciesList",
 		"page": 1,
-		"size": 22,
-		"total": 22
+		"size": 23,
+		"total": 23
 	  }`
 )
 
@@ -210,7 +218,7 @@ var _ = Describe("OCM policies data source", func() {
 
 		// Check the state:
 		resource := terraform.Resource("rhcs_policies", "my_policies").(map[string]interface{})
-		Expect(resource["attributes"]).To(Equal(
+		Expect(fmt.Sprint(resource["attributes"])).To(Equal(fmt.Sprint(
 			map[string]interface{}{
 				"operator_role_policies": map[string]interface{}{
 					"openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy": "{}",
@@ -226,8 +234,9 @@ var _ = Describe("OCM policies data source", func() {
 					"sts_support_permission_policy":               "{}",
 					"sts_instance_worker_permission_policy":       "{}",
 					"sts_instance_controlplane_permission_policy": "{}",
+					"sts_support_rh_sre_role":                     "arn:aws:iam::12345678912:role/RH-Technical-Support-12345678",
 				},
 			},
-		))
+		)))
 	})
 })


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

[OCM-7493](https://issues.redhat.com//browse/OCM-7493)
The isolated support role (org based) is generated from the /sts_policies API, the API fetches the whole trust policy details. However, as TF is generating the trust policy details by itself this role is not being set as the principal. This needs to be adjusted so that it is possible to attach the isolated support role.

This PR fetches the details and parses the role so that it is possible to insert it in the trust policy generated by the module

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [x] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [x] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
