### PR TITLE
OCM-7534 | ci: Replace deprecated proxy image

### DIFF
--- a/tests/tf-manifests/aws/proxy/main.tf
+++ b/tests/tf-manifests/aws/proxy/main.tf
@@ -12,7 +12,7 @@ provider "aws" {
 }
 
 locals {
-  proxy_image_name = "al2023-ami-2023.3.20240122.0-kernel-6.1-x86_64"
+  proxy_image_name = "al2023-ami-2023.4.20240416.0-kernel-6.1-x86_64"
 }
 
 data "aws_ami" "proxy_img" {


### PR DESCRIPTION
[OCM-7534](https://issues.redhat.com//browse/OCM-7534) | ci: Replace deprecated proxy image