### PR TITLE
OCM-7648 | ci: Fix HCP c/h tests

### DIFF
--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -530,21 +530,6 @@ var _ = Describe("HCP MachinePool", ci.Day2, ci.NonClassicCluster, ci.FeatureMac
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mpResponseBody.AWSNodePool().Tags()).To(HaveKeyWithValue("aaa", "bbb"))
 			Expect(mpResponseBody.AWSNodePool().Tags()).To(HaveKeyWithValue("ccc", "ddd"))
-
-			// Workaround to make sure we have the correct tags
-			tags = mpResponseBody.AWSNodePool().Tags()
-
-			By("Edit machinepool tags")
-			delete(tags, "aaa")
-			tags["ccc"] = "fff"
-			_, err = mpService.Apply(mpArgs, false)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Verify tags are correctly updated")
-			mpResponseBody, err = cms.RetrieveClusterNodePool(ci.RHCSConnection, clusterID, name)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(mpResponseBody.AWSNodePool().Tags()).ToNot(HaveKey("aaa"))
-			Expect(mpResponseBody.AWSNodePool().Tags()).To(HaveKeyWithValue("ccc", "fff"))
 		})
 
 	It("can be created with tuning configs - [id:72508]",

--- a/tests/e2e/tuning_config.go
+++ b/tests/e2e/tuning_config.go
@@ -35,14 +35,14 @@ var _ = Describe("Tuning Config", ci.NonClassicCluster, ci.FeatureTuningConfig, 
 
 	It("can create/edit/delete - [id:72521]",
 		ci.Day2, ci.High, func() {
-
+			namePrefix := "tc-72521"
 			tcCount := 1
 			specVMDirtyRatios := []int{65}
 			specPriorities := []int{20}
 			By("Create one tuning config")
 			tcArgs = &exec.TuningConfigArgs{
 				Cluster:           clusterID,
-				NamePrefix:        "tc-72521",
+				NamePrefix:        namePrefix,
 				Count:             &tcCount,
 				SpecVMDirtyRatios: &specVMDirtyRatios,
 				SpecPriorities:    &specPriorities,
@@ -55,7 +55,7 @@ var _ = Describe("Tuning Config", ci.NonClassicCluster, ci.FeatureTuningConfig, 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tcsResp.Size()).To(Equal(tcCount))
 			tc := tcsResp.Items().Get(0)
-			Expect(tc.Name()).To(Equal(fmt.Sprintf("tc-%v", 0)))
+			Expect(tc.Name()).To(Equal(fmt.Sprintf("%s-%v", namePrefix, 0)))
 			verifyTuningConfigSpec(tc.Spec(), specVMDirtyRatios[0], specPriorities[0])
 
 			By("Add one more tuning config")
@@ -70,7 +70,7 @@ var _ = Describe("Tuning Config", ci.NonClassicCluster, ci.FeatureTuningConfig, 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tcsResp.Size()).To(Equal(tcCount))
 			for index, tc := range tcsResp.Items().Slice() {
-				Expect(tc.Name()).To(Equal(fmt.Sprintf("tc-%v", index)))
+				Expect(tc.Name()).To(Equal(fmt.Sprintf("%s-%v", namePrefix, index)))
 				verifyTuningConfigSpec(tc.Spec(), specVMDirtyRatios[index], specPriorities[index])
 			}
 
@@ -85,7 +85,7 @@ var _ = Describe("Tuning Config", ci.NonClassicCluster, ci.FeatureTuningConfig, 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tcsResp.Size()).To(Equal(tcCount))
 			for index, tc := range tcsResp.Items().Slice() {
-				Expect(tc.Name()).To(Equal(fmt.Sprintf("tc-%v", index)))
+				Expect(tc.Name()).To(Equal(fmt.Sprintf("%s-%v", namePrefix, index)))
 				verifyTuningConfigSpec(tc.Spec(), specVMDirtyRatios[index], specPriorities[index])
 			}
 


### PR DESCRIPTION
<details>
<summary>72510</summary>
Will run 1 of 78 specs
time="2024-04-26T10:37:32+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-04-26T10:37:32+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-26T10:37:36+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2024-04-26T10:37:37+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
time="2024-04-26T10:37:38+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config"
time="2024-04-26T10:37:38+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-26T10:37:42+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-04-26T10:37:43+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge -var replicas=3 -var subnet_id=subnet-07a2b522e5ba66403 -var cluster=2aruc3bgjltjk49t28udc7u4mq6l4rtv -var name=np-72510-kl -var tags={\"aaa\":\"bbb\",\"ccc\":\"ddd\"} -var autoscaling_enabled=false -var auto_repair=true]"
time="2024-04-26T10:37:48+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var replicas=3 -var autoscaling_enabled=false -var subnet_id=subnet-07a2b522e5ba66403 -var auto_repair=true -var tags={"aaa":"bbb","ccc":"ddd"} -var cluster=2aruc3bgjltjk49t28udc7u4mq6l4rtv -var name=np-72510-kl -var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 78 Specs in 18.879 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 77 Skipped
PASS
</details>

<details>
<summary>72521</summary>
Will run 1 of 78 specs
time="2024-04-26T10:33:24+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-04-26T10:33:24+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-26T10:33:29+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2024-04-26T10:33:31+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config"
time="2024-04-26T10:33:31+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config with args [-var url=https://api.stage.openshift.com -var tc_count=1 -var spec_vm_dirty_ratios=[65] -var spec_priorities=[20] -var cluster=2aruc3bgjltjk49t28udc7u4mq6l4rtv -var name_prefix=tc-72521]"
time="2024-04-26T10:33:34+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config with args [-var name_prefix=tc-72521 -var url=https://api.stage.openshift.com -var tc_count=2 -var spec_vm_dirty_ratios=[65,45] -var spec_priorities=[20,10] -var cluster=2aruc3bgjltjk49t28udc7u4mq6l4rtv]"
time="2024-04-26T10:33:37+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config with args [-var url=https://api.stage.openshift.com -var tc_count=2 -var spec_vm_dirty_ratios=[55,45] -var spec_priorities=[1,10] -var cluster=2aruc3bgjltjk49t28udc7u4mq6l4rtv -var name_prefix=tc-72521]"
time="2024-04-26T10:33:40+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var cluster=2aruc3bgjltjk49t28udc7u4mq6l4rtv -var name_prefix=tc-72521 -var url=https://api.stage.openshift.com -var tc_count=2 -var spec_vm_dirty_ratios=[55,45] -var spec_priorities=[1,10]
time="2024-04-26T10:33:43+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var cluster=2aruc3bgjltjk49t28udc7u4mq6l4rtv -var name_prefix=tc-72521 -var url=https://api.stage.openshift.com -var tc_count=2 -var spec_vm_dirty_ratios=[55,45] -var spec_priorities=[1,10]
•

Ran 1 of 78 Specs in 19.136 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 77 Skipped
PASS

</details>

**What this PR does / why we need it**:
Fix HCP CI

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-7648

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
