### PR TITLE
OCM-7749 | ci: Remove `RHCS_ENV` support

### DIFF
--- a/tests/ci/connection.go
+++ b/tests/ci/connection.go
@@ -47,7 +47,7 @@ func createConnectionWithToken(token string) *client.Connection {
 		Logger(logger).
 		Insecure(true).
 		TokenURL(CON.TokenURL).
-		URL(CON.GateWayURL).
+		URL(CON.RHCS.RHCSURL).
 		Client(CON.ClientID, CON.ClientSecret).
 		Tokens(token).
 		Build()

--- a/tests/tf-manifests/aws/account-roles/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-classic/main.tf
@@ -11,10 +11,6 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
-
 data "aws_caller_identity" "current" {
 }
 

--- a/tests/tf-manifests/aws/account-roles/rosa-classic/output.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-classic/output.tf
@@ -18,10 +18,6 @@ output "channel_group" {
   value = var.channel_group
 }
 
-output "rhcs_gateway_url" {
-  value = var.url
-}
-
 output "installer_role_arn" {
   value = local.installer_role_arn
 }

--- a/tests/tf-manifests/aws/account-roles/rosa-classic/variables.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-classic/variables.tf
@@ -13,12 +13,6 @@ variable "account_role_prefix" {
   default = ""
 }
 
-
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "channel_group" {
   type    = string
   default = "stable"

--- a/tests/tf-manifests/aws/account-roles/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-hcp/main.tf
@@ -11,9 +11,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 locals {
   major_version = "${split(".", var.openshift_version)[0]}.${split(".", var.openshift_version)[1]}"

--- a/tests/tf-manifests/aws/account-roles/rosa-hcp/output.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-hcp/output.tf
@@ -17,7 +17,3 @@ output "major_version" {
 output "channel_group" {
   value = var.channel_group
 }
-
-output "rhcs_gateway_url" {
-  value = var.url
-}

--- a/tests/tf-manifests/aws/account-roles/rosa-hcp/variables.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-hcp/variables.tf
@@ -31,11 +31,6 @@ variable "openshift_version" {
   default = "4.13.13"
 }
 
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "channel_group" {
   type    = string
   default = "stable"

--- a/tests/tf-manifests/aws/add-account-roles/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/add-account-roles/rosa-classic/main.tf
@@ -11,9 +11,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 locals {
   major_version = "${split(".", var.openshift_version)[0]}.${split(".", var.openshift_version)[1]}"

--- a/tests/tf-manifests/aws/add-account-roles/rosa-classic/output.tf
+++ b/tests/tf-manifests/aws/add-account-roles/rosa-classic/output.tf
@@ -17,7 +17,3 @@ output "major_version" {
 output "channel_group" {
   value = var.channel_group
 }
-
-output "rhcs_gateway_url" {
-  value = var.url
-}

--- a/tests/tf-manifests/aws/add-account-roles/rosa-classic/variables.tf
+++ b/tests/tf-manifests/aws/add-account-roles/rosa-classic/variables.tf
@@ -18,11 +18,6 @@ variable "shared_vpc_role_arn" {
   default = null
 }
 
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "channel_group" {
   type    = string
   default = "stable"

--- a/tests/tf-manifests/aws/add-account-roles/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/add-account-roles/rosa-hcp/main.tf
@@ -11,9 +11,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 locals {
   major_version = "${split(".", var.openshift_version)[0]}.${split(".", var.openshift_version)[1]}"

--- a/tests/tf-manifests/aws/add-account-roles/rosa-hcp/output.tf
+++ b/tests/tf-manifests/aws/add-account-roles/rosa-hcp/output.tf
@@ -18,6 +18,3 @@ output "channel_group" {
   value = var.channel_group
 }
 
-output "rhcs_gateway_url" {
-  value = var.url
-}

--- a/tests/tf-manifests/aws/add-account-roles/rosa-hcp/variables.tf
+++ b/tests/tf-manifests/aws/add-account-roles/rosa-hcp/variables.tf
@@ -31,11 +31,6 @@ variable "openshift_version" {
   default = "4.13.13"
 }
 
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "channel_group" {
   type    = string
   default = "stable"

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-classic/main.tf
@@ -12,9 +12,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 provider "aws" {
   region = var.aws_region
 }

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-classic/variables.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-classic/variables.tf
@@ -8,11 +8,6 @@ variable "account_role_prefix" {
   default = ""
 }
 
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "oidc_config" {
   type    = string
   default = ""

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-hcp/main.tf
@@ -21,9 +21,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 provider "aws" {
   region = var.aws_region
 }

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-hcp/variables.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-hcp/variables.tf
@@ -8,11 +8,6 @@ variable "account_role_prefix" {
   default = ""
 }
 
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "oidc_config" {
   type    = string
   default = ""

--- a/tests/tf-manifests/rhcs/cluster-autoscaler/classic/main.tf
+++ b/tests/tf-manifests/rhcs/cluster-autoscaler/classic/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_cluster_autoscaler" "cluster_autoscaler" {
   cluster                       = var.cluster_id

--- a/tests/tf-manifests/rhcs/cluster-autoscaler/classic/variable.tf
+++ b/tests/tf-manifests/rhcs/cluster-autoscaler/classic/variable.tf
@@ -1,8 +1,3 @@
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "cluster_id" {
   type = string
 }

--- a/tests/tf-manifests/rhcs/cluster-autoscaler/hcp/main.tf
+++ b/tests/tf-manifests/rhcs/cluster-autoscaler/hcp/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_hcp_cluster_autoscaler" "cluster_autoscaler" {
   cluster                 = var.cluster_id

--- a/tests/tf-manifests/rhcs/cluster-autoscaler/hcp/variable.tf
+++ b/tests/tf-manifests/rhcs/cluster-autoscaler/hcp/variable.tf
@@ -1,8 +1,3 @@
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "cluster_id" {
   type = string
 }

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -11,9 +11,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 provider "aws" {
   region = var.aws_region
 }

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -1,9 +1,3 @@
-
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "operator_role_prefix" {
   type    = string
   default = ""
@@ -37,11 +31,6 @@ variable "openshift_version" {
 variable "channel_group" {
   type    = string
   default = "stable"
-}
-
-variable "rhcs_environment" {
-  type    = string
-  default = "staging"
 }
 
 variable "product" {

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
@@ -11,9 +11,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 provider "aws" {
   region = var.aws_region

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/variables.tf
@@ -1,9 +1,3 @@
-
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "operator_role_prefix" {
   type    = string
   default = ""
@@ -37,11 +31,6 @@ variable "openshift_version" {
 variable "channel_group" {
   type    = string
   default = "stable"
-}
-
-variable "rhcs_environment" {
-  type    = string
-  default = "staging"
 }
 
 variable "product" {

--- a/tests/tf-manifests/rhcs/default-machine-pool/main.tf
+++ b/tests/tf-manifests/rhcs/default-machine-pool/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_machine_pool" "mp" {
   cluster                           = var.cluster

--- a/tests/tf-manifests/rhcs/default-machine-pool/variable.tf
+++ b/tests/tf-manifests/rhcs/default-machine-pool/variable.tf
@@ -44,10 +44,6 @@ variable "use_spot_instances" {
   type    = bool
   default = false
 }
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
 
 variable "availability_zone" {
   type    = string

--- a/tests/tf-manifests/rhcs/dns/main.tf
+++ b/tests/tf-manifests/rhcs/dns/main.tf
@@ -7,8 +7,6 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_dns_domain" "dns_domain" {}

--- a/tests/tf-manifests/rhcs/dns/variable.tf
+++ b/tests/tf-manifests/rhcs/dns/variable.tf
@@ -1,4 +1,0 @@
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}

--- a/tests/tf-manifests/rhcs/idps/github/main.tf
+++ b/tests/tf-manifests/rhcs/idps/github/main.tf
@@ -22,9 +22,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 resource "rhcs_identity_provider" "github_idp" {
   cluster        = var.cluster_id
   mapping_method = var.mapping_method

--- a/tests/tf-manifests/rhcs/idps/github/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/github/variables.tf
@@ -3,12 +3,6 @@ variable "cluster_id" {
   description = "The OCP cluster ID"
 }
 
-variable "url" {
-  type        = string
-  description = "Provide RHCS environment by setting a value to url"
-  default     = "https://api.stage.openshift.com"
-}
-
 # IDP Variables
 variable "client_id" {
   type        = string

--- a/tests/tf-manifests/rhcs/idps/gitlab/main.tf
+++ b/tests/tf-manifests/rhcs/idps/gitlab/main.tf
@@ -22,9 +22,6 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.gateway
-}
 locals {
 
 }
@@ -35,6 +32,6 @@ resource "rhcs_identity_provider" "gitlab_idp" {
   gitlab = {
     client_id     = var.client_id
     client_secret = var.client_secret
-    url           = var.url
+    url           = var.idp_url
   }
 }

--- a/tests/tf-manifests/rhcs/idps/gitlab/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/gitlab/variables.tf
@@ -1,6 +1,5 @@
-variable "gateway" {
+variable "idp_url" {
   type    = string
-  default = "https://api.stage.openshift.com"
 }
 // Shared by all of the IDPs
 variable "cluster_id" {
@@ -35,9 +34,5 @@ variable "organizations" {
 }
 variable "teams" {
   type    = list(string)
-  default = null
-}
-variable "url" {
-  type    = string
   default = null
 }

--- a/tests/tf-manifests/rhcs/idps/google/main.tf
+++ b/tests/tf-manifests/rhcs/idps/google/main.tf
@@ -22,9 +22,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 resource "rhcs_identity_provider" "google_idp" {
   cluster        = var.cluster_id
   name           = var.name

--- a/tests/tf-manifests/rhcs/idps/google/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/google/variables.tf
@@ -1,9 +1,3 @@
-variable "url" {
-  type        = string
-  description = "Provide RHCS environment by setting a value to url"
-  default     = "https://api.stage.openshift.com"
-}
-
 // Shared by all of the IDPs
 variable "cluster_id" {
   type = string

--- a/tests/tf-manifests/rhcs/idps/htpasswd/main.tf
+++ b/tests/tf-manifests/rhcs/idps/htpasswd/main.tf
@@ -23,9 +23,7 @@ terraform {
 }
 
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_identity_provider" "htpasswd_idp" {
   cluster        = var.cluster_id

--- a/tests/tf-manifests/rhcs/idps/htpasswd/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/htpasswd/variables.tf
@@ -1,7 +1,3 @@
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
 // Shared by all of the IDPs
 variable "cluster_id" {
   type = string

--- a/tests/tf-manifests/rhcs/idps/ldap/main.tf
+++ b/tests/tf-manifests/rhcs/idps/ldap/main.tf
@@ -23,10 +23,6 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.gateway
-}
-
 resource "rhcs_identity_provider" "ldap_idp" {
   cluster        = var.cluster_id
   name           = var.name
@@ -34,7 +30,7 @@ resource "rhcs_identity_provider" "ldap_idp" {
   ldap = {
     ca       = var.ca
     insecure = true
-    url      = var.url
+    url      = var.idp_url
 
     # optional
     attributes = var.attributes

--- a/tests/tf-manifests/rhcs/idps/ldap/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/ldap/variables.tf
@@ -1,6 +1,5 @@
-variable "gateway" {
+variable "idp_url" {
   type    = string
-  default = "https://api.stage.openshift.com"
 }
 // Shared by all of the IDPs
 variable "cluster_id" {
@@ -40,10 +39,6 @@ variable "attributes" {
 }
 
 variable "ca" {
-  type    = string
-  default = null
-}
-variable "url" {
   type    = string
   default = null
 }

--- a/tests/tf-manifests/rhcs/idps/multi-idp/main.tf
+++ b/tests/tf-manifests/rhcs/idps/multi-idp/main.tf
@@ -22,10 +22,6 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.gateway
-}
-
 resource "rhcs_identity_provider" "google_idp" {
   cluster        = var.cluster_id
   name           = "multi-google-idp"
@@ -44,7 +40,7 @@ resource "rhcs_identity_provider" "ldap_idp" {
   ldap = {
     ca       = var.ca
     insecure = true
-    url      = var.url
+    url      = var.idp_url
 
     # optional
     attributes = var.attributes

--- a/tests/tf-manifests/rhcs/idps/multi-idp/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/multi-idp/variables.tf
@@ -1,6 +1,5 @@
-variable "gateway" {
+variable "idp_url" {
   type    = string
-  default = "https://api.stage.openshift.com"
 }
 
 // Shared by all of the IDPs
@@ -44,10 +43,6 @@ variable "attributes" {
 }
 
 variable "ca" {
-  type    = string
-  default = null
-}
-variable "url" {
   type    = string
   default = null
 }

--- a/tests/tf-manifests/rhcs/idps/openid/main.tf
+++ b/tests/tf-manifests/rhcs/idps/openid/main.tf
@@ -23,12 +23,6 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.gateway
-}
-
-
-
 resource "rhcs_identity_provider" "openid_idp" {
   cluster        = var.cluster_id
   name           = var.name

--- a/tests/tf-manifests/rhcs/idps/openid/variables.tf
+++ b/tests/tf-manifests/rhcs/idps/openid/variables.tf
@@ -1,7 +1,3 @@
-variable "gateway" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
 // Shared by all of the IDPs
 variable "cluster_id" {
   type = string

--- a/tests/tf-manifests/rhcs/ingresses/classic/main.tf
+++ b/tests/tf-manifests/rhcs/ingresses/classic/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_default_ingress" "default_ingress" {
   cluster                          = var.cluster

--- a/tests/tf-manifests/rhcs/ingresses/classic/variables.tf
+++ b/tests/tf-manifests/rhcs/ingresses/classic/variables.tf
@@ -1,10 +1,6 @@
 variable "cluster" {
   type = string
 }
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
 
 variable "cluster_routes_hostname" {
   type    = string

--- a/tests/tf-manifests/rhcs/ingresses/hcp/main.tf
+++ b/tests/tf-manifests/rhcs/ingresses/hcp/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_hcp_default_ingress" "default_ingress" {
   cluster          = var.cluster

--- a/tests/tf-manifests/rhcs/ingresses/hcp/variables.tf
+++ b/tests/tf-manifests/rhcs/ingresses/hcp/variables.tf
@@ -1,8 +1,3 @@
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "cluster" {
   type = string
 }

--- a/tests/tf-manifests/rhcs/kubelet-config/main.tf
+++ b/tests/tf-manifests/rhcs/kubelet-config/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_kubeletconfig" "kubeletconfig" {
   cluster        = var.cluster

--- a/tests/tf-manifests/rhcs/kubelet-config/variable.tf
+++ b/tests/tf-manifests/rhcs/kubelet-config/variable.tf
@@ -1,8 +1,3 @@
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "cluster" {
   type    = string
   default = null

--- a/tests/tf-manifests/rhcs/machine-pools/classic/main.tf
+++ b/tests/tf-manifests/rhcs/machine-pools/classic/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_machine_pool" "mp" {
   cluster                           = var.cluster

--- a/tests/tf-manifests/rhcs/machine-pools/classic/variable.tf
+++ b/tests/tf-manifests/rhcs/machine-pools/classic/variable.tf
@@ -44,10 +44,6 @@ variable "use_spot_instances" {
   type    = bool
   default = false
 }
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
 
 variable "availability_zone" {
   type    = string

--- a/tests/tf-manifests/rhcs/machine-pools/hcp/main.tf
+++ b/tests/tf-manifests/rhcs/machine-pools/hcp/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 locals {
   autoscaling = var.autoscaling_enabled == null && var.min_replicas == null && var.max_replicas == null ? null : {
     enabled      = var.autoscaling_enabled,

--- a/tests/tf-manifests/rhcs/machine-pools/hcp/variable.tf
+++ b/tests/tf-manifests/rhcs/machine-pools/hcp/variable.tf
@@ -39,11 +39,6 @@ variable "taints" {
   }))
 }
 
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "availability_zone" {
   type    = string
   default = null

--- a/tests/tf-manifests/rhcs/resource-import/main.tf
+++ b/tests/tf-manifests/rhcs/resource-import/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster_import" {
   aws_account_id = ""

--- a/tests/tf-manifests/rhcs/resource-import/variable.tf
+++ b/tests/tf-manifests/rhcs/resource-import/variable.tf
@@ -1,4 +1,0 @@
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}

--- a/tests/tf-manifests/rhcs/rhcs-info/main.tf
+++ b/tests/tf-manifests/rhcs/rhcs-info/main.tf
@@ -6,7 +6,5 @@ terraform {
     }
   }
 }
-provider "rhcs" {
-  url = var.url
-}
+
 data "rhcs_info" "info" {}

--- a/tests/tf-manifests/rhcs/rhcs-info/variable.tf
+++ b/tests/tf-manifests/rhcs/rhcs-info/variable.tf
@@ -1,4 +1,0 @@
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}

--- a/tests/tf-manifests/rhcs/tuning-config/main.tf
+++ b/tests/tf-manifests/rhcs/tuning-config/main.tf
@@ -7,9 +7,7 @@ terraform {
   }
 }
 
-provider "rhcs" {
-  url = var.url
-}
+
 
 locals {
   defaultSpec = jsonencode(

--- a/tests/tf-manifests/rhcs/tuning-config/variable.tf
+++ b/tests/tf-manifests/rhcs/tuning-config/variable.tf
@@ -9,11 +9,6 @@ variable "name" {
   description = "name will be used as it is if tc_count == 1, else it will be considered as a prefix for the instance names"
 }
 
-variable "url" {
-  type    = string
-  default = "https://api.stage.openshift.com"
-}
-
 variable "tc_count"{
   type    = number
   default = 1

--- a/tests/utils/constants/constants.go
+++ b/tests/utils/constants/constants.go
@@ -47,7 +47,7 @@ var (
 const (
 	TokenENVName              = "RHCS_TOKEN"
 	ClusterIDEnv              = "CLUSTER_ID"
-	RHCSENV                   = "RHCS_ENV"
+	RHCSURL                   = "RHCS_URL"
 	RhcsClusterProfileENV     = "CLUSTER_PROFILE"
 	QEUsage                   = "QE_USAGE"
 	ClusterTypeManifestDirEnv = "CLUSTER_ROSA_TYPE"

--- a/tests/utils/exec/account-roles.go
+++ b/tests/utils/exec/account-roles.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
-	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
 type AccountRolesArgs struct {
 	AccountRolePrefix   string `json:"account_role_prefix,omitempty"`
 	OCMENV              string `json:"rhcs_environment,omitempty"`
 	OpenshiftVersion    string `json:"openshift_version,omitempty"`
-	URL                 string `json:"url,omitempty"`
 	ChannelGroup        string `json:"channel_group,omitempty"`
 	UnifiedAccRolesPath string `json:"path,omitempty"`
 	SharedVpcRoleArn    string `json:"shared_vpc_role_arn,omitempty"`
@@ -22,7 +21,6 @@ type AccountRolesOutput struct {
 	AccountRolePrefix string        `json:"account_role_prefix,omitempty"`
 	MajorVersion      string        `json:"major_version,omitempty"`
 	ChannelGroup      string        `json:"channel_group,omitempty"`
-	RHCSGatewayUrl    string        `json:"rhcs_gateway_url,omitempty"`
 	RHCSVersions      []interface{} `json:"rhcs_versions,omitempty"`
 	InstallerRoleArn  string        `json:"installer_role_arn,omitempty"`
 	AWSAccountId      string        `json:"aws_account_id,omitempty"`
@@ -35,7 +33,7 @@ type AccountRoleService struct {
 }
 
 func (acc *AccountRoleService) Init(manifestDirs ...string) error {
-	acc.ManifestDir = CON.AccountRolesClassicDir
+	acc.ManifestDir = constants.AccountRolesClassicDir
 	if len(manifestDirs) != 0 {
 		acc.ManifestDir = manifestDirs[0]
 	}
@@ -50,8 +48,7 @@ func (acc *AccountRoleService) Init(manifestDirs ...string) error {
 }
 
 func (acc *AccountRoleService) Apply(createArgs *AccountRolesArgs, recordtfvars bool, extraArgs ...string) (*AccountRolesOutput, error) {
-	createArgs.URL = CON.GateWayURL
-	createArgs.OCMENV = CON.OCMENV
+	createArgs.OCMENV = constants.RHCS.OCMEnv
 	acc.CreationArgs = createArgs
 	args, tfvars := combineStructArgs(createArgs, extraArgs...)
 	_, err := runTerraformApply(acc.Context, acc.ManifestDir, args...)
@@ -71,13 +68,12 @@ func (acc *AccountRoleService) Output() (*AccountRolesOutput, error) {
 		return nil, err
 	}
 	var accOutput = &AccountRolesOutput{
-		AccountRolePrefix: h.DigString(out["account_role_prefix"], "value"),
-		MajorVersion:      h.DigString(out["major_version"], "value"),
-		ChannelGroup:      h.DigString(out["channel_group"], "value"),
-		RHCSGatewayUrl:    h.DigString(out["rhcs_gateway_url"], "value"),
-		RHCSVersions:      h.DigArray(out["rhcs_versions"], "value"),
-		InstallerRoleArn:  h.DigString(out["installer_role_arn"], "value"),
-		AWSAccountId:      h.DigString(out["aws_account_id"], "value"),
+		AccountRolePrefix: helper.DigString(out["account_role_prefix"], "value"),
+		MajorVersion:      helper.DigString(out["major_version"], "value"),
+		ChannelGroup:      helper.DigString(out["channel_group"], "value"),
+		RHCSVersions:      helper.DigArray(out["rhcs_versions"], "value"),
+		InstallerRoleArn:  helper.DigString(out["installer_role_arn"], "value"),
+		AWSAccountId:      helper.DigString(out["aws_account_id"], "value"),
 	}
 	return accOutput, nil
 }
@@ -90,8 +86,7 @@ func (acc *AccountRoleService) Destroy(createArgs ...*AccountRolesArgs) error {
 	if len(createArgs) != 0 {
 		destroyArgs = createArgs[0]
 	}
-	destroyArgs.URL = CON.GateWayURL
-	destroyArgs.OCMENV = CON.OCMENV
+	destroyArgs.OCMENV = constants.RHCS.OCMEnv
 	args, _ := combineStructArgs(destroyArgs)
 	_, err := runTerraformDestroy(acc.Context, acc.ManifestDir, args...)
 	return err

--- a/tests/utils/exec/cluster-autoscaler.go
+++ b/tests/utils/exec/cluster-autoscaler.go
@@ -10,7 +10,6 @@ import (
 
 type ClusterAutoscalerArgs struct {
 	Cluster                     *string         `json:"cluster_id,omitempty"`
-	OCMENV                      string          `json:"ocm_environment,omitempty"`
 	BalanceSimilarNodeGroups    bool            `json:"balance_similar_node_groups,omitempty"`
 	SkipNodesWithLocalStorage   bool            `json:"skip_nodes_with_local_storage,omitempty"`
 	LogVerbosity                int             `json:"log_verbosity,omitempty"`

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -3,17 +3,15 @@ package exec
 import (
 	"context"
 
-	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
-	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
 type ClusterCreationArgs struct {
 	AccountRolePrefix                    string             `json:"account_role_prefix,omitempty"`
-	OCMENV                               string             `json:"rhcs_environment,omitempty"`
 	ClusterName                          *string            `json:"cluster_name,omitempty"`
 	OperatorRolePrefix                   *string            `json:"operator_role_prefix,omitempty"`
 	OpenshiftVersion                     string             `json:"openshift_version,omitempty"`
-	URL                                  string             `json:"url,omitempty"`
 	AWSRegion                            *string            `json:"aws_region,omitempty"`
 	AWSAvailabilityZones                 *[]string          `json:"aws_availability_zones,omitempty"`
 	Replicas                             int                `json:"replicas,omitempty"`
@@ -114,7 +112,7 @@ type ClusterService struct {
 }
 
 func (creator *ClusterService) Init(manifestDir string) error {
-	creator.ManifestDir = CON.GrantClusterManifestDir(manifestDir)
+	creator.ManifestDir = constants.GrantClusterManifestDir(manifestDir)
 	ctx := context.TODO()
 	creator.Context = ctx
 	err := runTerraformInit(ctx, creator.ManifestDir)
@@ -126,7 +124,6 @@ func (creator *ClusterService) Init(manifestDir string) error {
 }
 
 func (creator *ClusterService) Apply(createArgs *ClusterCreationArgs, recordtfvars bool, tfvarsDeletion bool, extraArgs ...string) error {
-	createArgs.URL = CON.GateWayURL
 	args, tfvars := combineStructArgs(createArgs, extraArgs...)
 	if recordtfvars {
 		recordTFvarsFile(creator.ManifestDir, tfvars) // Record the tfvars before apply in case cluster creation error and we need clean
@@ -148,27 +145,25 @@ func (creator *ClusterService) Output() (*ClusterOutput, error) {
 		return nil, err
 	}
 	clusterOutput := &ClusterOutput{
-		ClusterID:                            h.DigString(out["cluster_id"], "value"),
-		ClusterName:                          h.DigString(out["cluster_name"], "value"),
-		ClusterVersion:                       h.DigString(out["cluster_version"], "value"),
-		AdditionalComputeSecurityGroups:      h.DigArrayToString(out["additional_compute_security_groups"], "value"),
-		AdditionalInfraSecurityGroups:        h.DigArrayToString(out["additional_infra_security_groups"], "value"),
-		AdditionalControlPlaneSecurityGroups: h.DigArrayToString(out["additional_control_plane_security_groups"], "value"),
-		Properties:                           h.DigMapToString(out["properties"], "value"),
-		UserTags:                             h.DigMapToString(out["tags"], "value"),
+		ClusterID:                            helper.DigString(out["cluster_id"], "value"),
+		ClusterName:                          helper.DigString(out["cluster_name"], "value"),
+		ClusterVersion:                       helper.DigString(out["cluster_version"], "value"),
+		AdditionalComputeSecurityGroups:      helper.DigArrayToString(out["additional_compute_security_groups"], "value"),
+		AdditionalInfraSecurityGroups:        helper.DigArrayToString(out["additional_infra_security_groups"], "value"),
+		AdditionalControlPlaneSecurityGroups: helper.DigArrayToString(out["additional_control_plane_security_groups"], "value"),
+		Properties:                           helper.DigMapToString(out["properties"], "value"),
+		UserTags:                             helper.DigMapToString(out["tags"], "value"),
 	}
 
 	return clusterOutput, nil
 }
 
 func (creator *ClusterService) Destroy(createArgs *ClusterCreationArgs, extraArgs ...string) (string, error) {
-	createArgs.URL = CON.GateWayURL
 	args, _ := combineStructArgs(createArgs, extraArgs...)
 	return runTerraformDestroy(creator.Context, creator.ManifestDir, args...)
 }
 
 func (creator *ClusterService) Plan(planargs *ClusterCreationArgs, extraArgs ...string) (string, error) {
-	planargs.URL = CON.GateWayURL
 	args, _ := combineStructArgs(planargs, extraArgs...)
 	output, err := runTerraformPlan(creator.Context, creator.ManifestDir, args...)
 	return output, err

--- a/tests/utils/exec/idps.go
+++ b/tests/utils/exec/idps.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
-	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
 type IDPArgs struct {
 	ClusterID     string        `json:"cluster_id,omitempty"`
 	Name          string        `json:"name,omitempty"`
 	ID            string        `json:"id,omitempty"`
-	OCMENV        string        `json:"ocm_environment,omitempty"`
-	URL           string        `json:"url,omitempty"`
 	CA            string        `json:"ca,omitempty"`
 	Attributes    interface{}   `json:"attributes,omitempty"`
 	ClientID      string        `json:"client_id,omitempty"`
@@ -23,6 +21,7 @@ type IDPArgs struct {
 	Insecure      bool          `json:"insecure,omitempty"`
 	MappingMethod string        `json:"mapping_method,omitempty"`
 	HtpasswdUsers []interface{} `json:"htpasswd_users,omitempty"`
+	URL           string        `json:"idp_url,omitempty"`
 }
 
 type IDPService struct {
@@ -37,7 +36,7 @@ type IDPOutput struct {
 }
 
 func (idp *IDPService) Init(manifestDirs ...string) error {
-	idp.ManifestDir = CON.IDPsDir
+	idp.ManifestDir = constants.IDPsDir
 	if len(manifestDirs) != 0 {
 		idp.ManifestDir = manifestDirs[0]
 	}
@@ -65,7 +64,7 @@ func (idp *IDPService) Apply(createArgs *IDPArgs, recordtfvars bool, extraArgs .
 }
 
 func (idp *IDPService) Output() (IDPOutput, error) {
-	idpDir := CON.IDPsDir
+	idpDir := constants.IDPsDir
 	if idp.ManifestDir != "" {
 		idpDir = idp.ManifestDir
 	}
@@ -77,7 +76,7 @@ func (idp *IDPService) Output() (IDPOutput, error) {
 	if err != nil {
 		return output, err
 	}
-	id := h.DigString(out["idp_id"], "value")
+	id := helper.DigString(out["idp_id"], "value")
 
 	// right now only "holds" id, more vars might be needed in the future
 	output = IDPOutput{
@@ -93,7 +92,6 @@ func (idp *IDPService) Destroy(createArgs ...*IDPArgs) error {
 	destroyArgs := idp.CreationArgs
 	if len(createArgs) != 0 {
 		destroyArgs = createArgs[0]
-		destroyArgs.URL = CON.GateWayURL
 	}
 	args, _ := combineStructArgs(destroyArgs)
 	_, err := runTerraformDestroy(idp.Context, idp.ManifestDir, args...)

--- a/tests/utils/exec/import.go
+++ b/tests/utils/exec/import.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	con "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
 )
 
 type ImportArgs struct {
-	URL          string `json:"url,omitempty"`
 	ResourceKind string `json:"resource_kind,omitempty"`
 	ResourceName string `json:"resource_name,omitempty"`
 	ClusterID    string `json:"cluster_id,omitempty"`
@@ -22,7 +21,7 @@ type ImportService struct {
 }
 
 func (importTF *ImportService) InitImport(manifestDirs ...string) error {
-	importTF.ManifestDir = con.ImportResourceDir
+	importTF.ManifestDir = constants.ImportResourceDir
 	if len(manifestDirs) > 0 {
 		importTF.ManifestDir = manifestDirs[0]
 	}
@@ -51,7 +50,6 @@ func combineImportStructArgs(importObj *ImportArgs) []string {
 }
 
 func (importService *ImportService) Import(importArgs *ImportArgs, extraArgs ...string) error {
-	importArgs.URL = con.GateWayURL
 	importService.CreationArgs = importArgs
 
 	args := combineImportStructArgs(importArgs)

--- a/tests/utils/exec/ingress.go
+++ b/tests/utils/exec/ingress.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
-	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
 type IngressArgs struct {
 	ID      string  `json:"id,omitempty"`
 	Cluster *string `json:"cluster,omitempty"`
-	URL     string  `json:"url,omitempty"`
 
 	// Classic
 	RouteNamespaceOwnershipPolicy string            `json:"route_namespace_ownership_policy,omitempty"`
@@ -37,7 +36,7 @@ type IngressService struct {
 }
 
 func (ing *IngressService) Init(manifestDirs ...string) error {
-	ing.ManifestDir = CON.ClassicIngressDir
+	ing.ManifestDir = constants.ClassicIngressDir
 	if len(manifestDirs) != 0 {
 		ing.ManifestDir = manifestDirs[0]
 	}
@@ -62,7 +61,7 @@ func (ing *IngressService) Apply(createArgs *IngressArgs, extraArgs ...string) e
 }
 
 func (ing *IngressService) Output() (IngressOutput, error) {
-	ingressDir := CON.ClassicIngressDir
+	ingressDir := constants.ClassicIngressDir
 	if ing.ManifestDir != "" {
 		ingressDir = ing.ManifestDir
 	}
@@ -72,7 +71,7 @@ func (ing *IngressService) Output() (IngressOutput, error) {
 		return ingressOut, err
 	}
 	ingressOut = IngressOutput{
-		ID: h.DigString(out["id"], "value"),
+		ID: helper.DigString(out["id"], "value"),
 	}
 
 	return ingressOut, nil

--- a/tests/utils/exec/kubelet-config.go
+++ b/tests/utils/exec/kubelet-config.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
-	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
 type KubeletConfigArgs struct {
-	URL          string `json:"url,omitempty"`
 	Cluster      string `json:"cluster,omitempty"`
 	PodPidsLimit int    `json:"pod_pids_limit,omitempty"`
 }
@@ -26,7 +25,7 @@ type KubeletConfigService struct {
 }
 
 func (kc *KubeletConfigService) Init(manifestDirs ...string) error {
-	kc.ManifestDir = CON.KubeletConfigDir
+	kc.ManifestDir = constants.KubeletConfigDir
 	if len(manifestDirs) != 0 {
 		kc.ManifestDir = manifestDirs[0]
 	}
@@ -41,7 +40,6 @@ func (kc *KubeletConfigService) Init(manifestDirs ...string) error {
 }
 
 func (kc *KubeletConfigService) Apply(createArgs *KubeletConfigArgs, recordtfvars bool, extraArgs ...string) (*KubeletConfigOutput, error) {
-	createArgs.URL = CON.GateWayURL
 	kc.CreationArgs = createArgs
 	args, tfvars := combineStructArgs(createArgs, extraArgs...)
 	_, err := runTerraformApply(kc.Context, kc.ManifestDir, args...)
@@ -55,7 +53,6 @@ func (kc *KubeletConfigService) Apply(createArgs *KubeletConfigArgs, recordtfvar
 	return output, err
 }
 func (kc *KubeletConfigService) Plan(createArgs *KubeletConfigArgs, extraArgs ...string) (string, error) {
-	createArgs.URL = CON.GateWayURL
 	kc.CreationArgs = createArgs
 	args, _ := combineStructArgs(createArgs, extraArgs...)
 	output, err := runTerraformPlan(kc.Context, kc.ManifestDir, args...)
@@ -68,7 +65,7 @@ func (kc *KubeletConfigService) Output() (*KubeletConfigOutput, error) {
 		return nil, err
 	}
 	var accOutput = &KubeletConfigOutput{
-		PodPidsLimit: h.DigInt(out["pod_pids_limit"], "value"),
+		PodPidsLimit: helper.DigInt(out["pod_pids_limit"], "value"),
 	}
 	return accOutput, nil
 }
@@ -81,7 +78,6 @@ func (kc *KubeletConfigService) Destroy(createArgs ...*KubeletConfigArgs) (strin
 	if len(createArgs) != 0 {
 		destroyArgs = createArgs[0]
 	}
-	destroyArgs.URL = CON.GateWayURL
 	args, _ := combineStructArgs(destroyArgs)
 	output, err := runTerraformDestroy(kc.Context, kc.ManifestDir, args...)
 	return output, err

--- a/tests/utils/exec/oidc-provider-operator-roles.go
+++ b/tests/utils/exec/oidc-provider-operator-roles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
 	CON "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
 	h "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
@@ -11,7 +12,6 @@ import (
 type OIDCProviderOperatorRolesArgs struct {
 	AccountRolePrefix   string `json:"account_role_prefix,omitempty"`
 	OperatorRolePrefix  string `json:"operator_role_prefix,omitempty"`
-	URL                 string `json:"url,omitempty"`
 	OIDCConfig          string `json:"oidc_config,omitempty"`
 	AWSRegion           string `json:"aws_region,omitempty"`
 	OCMENV              string `json:"rhcs_environment,omitempty"`
@@ -48,8 +48,7 @@ func (oidcOP *OIDCProviderOperatorRolesService) Init(manifestDirs ...string) err
 
 func (oidcOP *OIDCProviderOperatorRolesService) Apply(createArgs *OIDCProviderOperatorRolesArgs, recordtfvars bool, extraArgs ...string) (
 	*OIDCProviderOperatorRolesOutput, error) {
-	createArgs.URL = CON.GateWayURL
-	createArgs.OCMENV = CON.OCMENV
+	createArgs.OCMENV = constants.RHCS.OCMEnv
 	oidcOP.CreationArgs = createArgs
 	args, tfvars := combineStructArgs(createArgs, extraArgs...)
 	_, err := runTerraformApply(oidcOP.Context, oidcOP.ManifestDir, args...)
@@ -89,8 +88,7 @@ func (oidcOP *OIDCProviderOperatorRolesService) Destroy(createArgs ...*OIDCProvi
 	if len(createArgs) != 0 {
 		destroyArgs = createArgs[0]
 	}
-	destroyArgs.URL = CON.GateWayURL
-	destroyArgs.OCMENV = CON.OCMENV
+	destroyArgs.OCMENV = constants.RHCS.OCMEnv
 	args, _ := combineStructArgs(destroyArgs)
 	_, err := runTerraformDestroy(oidcOP.Context, oidcOP.ManifestDir, args...)
 	return err

--- a/tests/utils/exec/tuning-configs.go
+++ b/tests/utils/exec/tuning-configs.go
@@ -11,7 +11,6 @@ import (
 type TuningConfigArgs struct {
 	Cluster           *string `json:"cluster,omitempty"`
 	Name              *string `json:"name,omitempty"`
-	URL               string  `json:"url,omitempty"`
 	Count             *int    `json:"tc_count,omitempty"`
 	Spec              *string `json:"spec,omitempty"`
 	SpecVMDirtyRatios *[]int  `json:"spec_vm_dirty_ratios,omitempty"`
@@ -44,7 +43,6 @@ func (tcs *TuningConfigService) Init(manifestDirs ...string) error {
 }
 
 func (tcs *TuningConfigService) Apply(createArgs *TuningConfigArgs, recordtfargs bool, extraArgs ...string) (string, error) {
-	createArgs.URL = CON.GateWayURL
 	tcs.CreationArgs = createArgs
 	args, tfvars := combineStructArgs(createArgs, extraArgs...)
 	output, err := runTerraformApply(tcs.Context, tcs.ManifestDir, args...)
@@ -77,7 +75,6 @@ func (tcs *TuningConfigService) Destroy(createArgs ...*TuningConfigArgs) (output
 	if len(createArgs) != 0 {
 		destroyArgs = createArgs[0]
 	}
-	destroyArgs.URL = CON.GateWayURL
 	args, _ := combineStructArgs(destroyArgs)
 
 	return runTerraformDestroy(tcs.Context, tcs.ManifestDir, args...)


### PR DESCRIPTION
**What this PR does / why we need it**:
`RHCS_ENV` is replaced with `RHCS_URL`

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-7749

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
