### PR TITLE
OCM-7141 | ci: Automate 72628

### DIFF
--- a/tests/ci/profile_handler.go
+++ b/tests/ci/profile_handler.go
@@ -372,7 +372,7 @@ func GenerateClusterCreationArgsByProfile(token string, profile *Profile) (clust
 	}
 
 	if profile.Tagging {
-		clusterArgs.Tagging = CON.Tags
+		clusterArgs.Tags = CON.Tags
 	}
 
 	if profile.AdminEnabled {

--- a/tests/e2e/cluster_edit_test.go
+++ b/tests/e2e/cluster_edit_test.go
@@ -389,6 +389,42 @@ var _ = Describe("Edit cluster", ci.Day2, ci.NonClassicCluster, func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no-proxy value: '*' should match the regular expression"))
 		})
+
+		It("tags - [id:72628]", ci.Medium, ci.FeatureClusterMisc, func() {
+			By("Retrieve current tags")
+			out, err := clusterService.Output()
+			Expect(err).ToNot(HaveOccurred())
+			currentTags := out.UserTags
+
+			By("Try to edit tags")
+			tags := helper.CopyStringMap(currentTags)
+			var firstKey string
+			// Remove first key
+			for k := range tags {
+				firstKey = k
+				break
+			}
+			if firstKey != "" {
+				delete(tags, firstKey)
+			}
+			// Edit second key
+			for k := range tags {
+				firstKey = k
+				break
+			}
+			if firstKey != "" {
+				tags[firstKey] = "newValue"
+			}
+			// Add new key
+			tags["newTag"] = "appendTag"
+
+			clusterArgs = &exec.ClusterCreationArgs{
+				Tags: tags,
+			}
+			err = clusterService.Apply(clusterArgs, false, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Attribute tags, cannot be changed from"))
+		})
 	})
 
 })

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/output.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/output.tf
@@ -13,3 +13,7 @@ output "cluster_version" {
 output "properties" {
   value = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.properties
 }
+
+output "tags" {
+ value = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.tags 
+}

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -22,7 +22,7 @@ type ClusterCreationArgs struct {
 	PrivateLink                          bool               `json:"private_link,omitempty"`
 	Private                              bool               `json:"private,omitempty"`
 	Fips                                 bool               `json:"fips,omitempty"`
-	Tagging                              map[string]string  `json:"tags,omitempty"`
+	Tags                                 map[string]string  `json:"tags,omitempty"`
 	AuditLogForward                      bool               `json:"audit_log_forward,omitempty"`
 	Autoscale                            bool               `json:"autoscaling_enabled,omitempty"`
 	Etcd                                 *bool              `json:"etcd_encryption,omitempty"`
@@ -77,6 +77,7 @@ type ClusterOutput struct {
 	AdditionalInfraSecurityGroups        []string          `json:"additional_infra_security_groups,omitempty"`
 	AdditionalControlPlaneSecurityGroups []string          `json:"additional_control_plane_security_groups,omitempty"`
 	Properties                           map[string]string `json:"properties,omitempty"`
+	UserTags                             map[string]string `json:"tags,omitempty"`
 }
 
 // ******************************************************
@@ -151,6 +152,7 @@ func (creator *ClusterService) Output() (*ClusterOutput, error) {
 		AdditionalInfraSecurityGroups:        h.DigArrayToString(out["additional_infra_security_groups"], "value"),
 		AdditionalControlPlaneSecurityGroups: h.DigArrayToString(out["additional_control_plane_security_groups"], "value"),
 		Properties:                           h.DigMapToString(out["properties"], "value"),
+		UserTags:                             h.DigMapToString(out["tags"], "value"),
 	}
 
 	return clusterOutput, nil


### PR DESCRIPTION
<details>
<summary>Logs</summary>
Will run 1 of 88 specs
time="2024-04-29T11:23:55+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-04-29T11:23:55+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-29T11:23:58+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2024-04-29T11:24:00+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-04-29T11:24:00+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-29T11:24:03+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-04-29T11:24:04+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var tags={\"newTag\":\"appendTag\",\"tag2\":\"newValue\"}]"
time="2024-04-29T11:24:10+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 0s [id=301721915996]\ndata.rhcs_versions.version: Read complete after 2s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=2aug0iceq3dfg2c4pi1rrkr7r5d27vg9]\nrhcs_cluster_wait.rosa_cluster: Refreshing state...\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_cluster_rosa_hcp.rosa_hcp_cluster will be updated in-place\n  ~ resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n      + admin_credentials          = (known after apply)\n      ~ api_url                    = \"https://api.rhcs-hcp-ad-q8r.67n0.example.com:443\" -> (known after apply)\n      ~ console_url                = \"https://console-openshift-console.apps.rosa.rhcs-hcp-ad-q8r.67n0.example.com\" -> (known after apply)\n      ~ current_version            = \"4.15.11\" -> (known after apply)\n      ~ domain                     = \"rhcs-hcp-ad-q8r.67n0.example.com\" -> (known after apply)\n        id                         = \"2aug0iceq3dfg2c4pi1rrkr7r5d27vg9\"\n        name                       = \"rhcs-hcp-ad-q8r\"\n      ~ ocm_properties             = {\n          - \"custom_property\"  = \"test\"\n          - \"qe_usage\"         = null\n          - \"rosa_creator_arn\" = \"arn:aws:iam::XXXXXX:user/tradisso\"\n          - \"rosa_tf_commit\"   = \"b8ce58e\"\n          - \"rosa_tf_version\"  = \"1.6.0\"\n        } -> (known after apply)\n      ~ state                      = \"ready\" -> (known after apply)\n      ~ tags                       = {\n          + \"newTag\" = \"appendTag\"\n          - \"tag1\"   = \"test_tag1\" -> null\n          ~ \"tag2\"   = \"test_tag2\" -> \"newValue\"\n        }\n        # (25 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\n\nChanges to Outputs:\n  ~ cluster_version = \"4.15.11\" -> (known after apply)\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Modifying... [id=2aug0iceq3dfg2c4pi1rrkr7r5d27vg9]\n\nError: Attribute value cannot be changed\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 48, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  48: resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n\nAttribute tags, cannot be changed from\n{\"tag1\":\"test_tag1\",\"tag2\":\"test_tag2\"} to\n{\"newTag\":\"appendTag\",\"tag2\":\"newValue\"}"
•SSS

</details>

**What this PR does / why we need it**:
Day2 TF HCP automation

**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/OCM-7141

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
