### PR TITLE
OCM-6805 | ci: Update 72452 (edit billing account)

### DIFF
--- a/tests/e2e/cluster_edit_test.go
+++ b/tests/e2e/cluster_edit_test.go
@@ -47,13 +47,21 @@ var _ = Describe("Edit cluster", ci.Day2, ci.NonClassicCluster, func() {
 			helper.ExpectTFErrorContains(err, "Attribute aws_account_id, cannot be changed from")
 
 			// To be activated once issue is solved
-			// By("Try to edit billing account")
-			// clusterArgs = &exec.ClusterCreationArgs{
-			// 	AWSBillingAccountID: "anything",
-			// }
-			// err = clusterService.Apply(clusterArgs, false, true)
-			// Expect(err).To(HaveOccurred())
-			// helper.ExpectTFErrorContains(err, "Attribute aws_billing_account_id, cannot be changed from")
+			By("Try to edit billing account with wrong value")
+			clusterArgs = &exec.ClusterCreationArgs{
+				AWSBillingAccountID: helper.StringPointer("anything"),
+			}
+			err = clusterService.Apply(clusterArgs, false, false)
+			Expect(err).To(HaveOccurred())
+			helper.ExpectTFErrorContains(err, "Attribute aws_billing_account_id aws billing account ID must be only digits and exactly 12 in length")
+
+			By("Try to edit billing account with wrong account")
+			clusterArgs = &exec.ClusterCreationArgs{
+				AWSBillingAccountID: helper.StringPointer("000000000000"),
+			}
+			err = clusterService.Apply(clusterArgs, false, false)
+			Expect(err).To(HaveOccurred())
+			helper.ExpectTFErrorContains(err, "billing account 000000000000 not linked to organization")
 
 			By("Try to edit cloud region")
 			region := "us-east-1"


### PR DESCRIPTION
<details>
<summary>Logs</summary>
Will run 1 of 101 specs
time="2024-05-03T11:45:16+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-05-03T11:45:16+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-05-03T11:45:19+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2024-05-03T11:45:21+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-05-03T11:45:21+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-05-03T11:45:24+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var aws_account_id=another_account -var url=https://api.stage.openshift.com]"
time="2024-05-03T11:45:30+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 0s [id=XXXXX]\ndata.rhcs_versions.version: Read complete after 2s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=XXXXXXXXXXXXXXXXXXXXXXX]\n\nError: Invalid Attribute Value Match\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 58, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  58:   aws_account_id         = var.aws_account_id != null ? var.aws_account_id : data.aws_caller_identity.current.account_id\n\nAttribute aws_account_id aws account ID must be only digits and exactly 12 in\nlength, got: another_account"
time="2024-05-03T11:45:30+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var aws_account_id=000000000000 -var url=https://api.stage.openshift.com]"
time="2024-05-03T11:45:36+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 1s [id=XXXXX]\ndata.rhcs_versions.version: Read complete after 1s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=XXXXXXXXXXXXXXXXXXXXXXX]\nrhcs_cluster_wait.rosa_cluster: Refreshing state...\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_cluster_rosa_hcp.rosa_hcp_cluster will be updated in-place\n  ~ resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n      + admin_credentials          = (known after apply)\n      ~ api_url                    = \"https://api.rhcs-hcp-ad-ogn.yuf6.example.com:443\" -> (known after apply)\n      ~ aws_account_id             = \"XXXXX\" -> \"000000000000\"\n      ~ console_url                = \"https://console-openshift-console.apps.rosa.rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n      ~ current_version            = \"4.15.11\" -> (known after apply)\n      ~ domain                     = \"rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n        id                         = \"XXXXXXXXXXXXXXXXXXXXXXX\"\n        name                       = \"rhcs-hcp-ad-ogn\"\n      ~ ocm_properties             = {\n          - \"custom_property\"  = \"test\"\n          - \"qe_usage\"         = null\n          - \"rosa_creator_arn\" = \"arn:aws:iam::XXXXX:user/tradisso\"\n          - \"rosa_tf_commit\"   = \"2430f5c\"\n          - \"rosa_tf_version\"  = \"1.6.0\"\n        } -> (known after apply)\n      ~ state                      = \"ready\" -> (known after apply)\n        tags                       = {\n            \"tag1\" = \"test_tag1\"\n            \"tag2\" = \"test_tag2\"\n        }\n        # (24 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\n\nChanges to Outputs:\n  ~ cluster_version = \"4.15.11\" -> (known after apply)\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Modifying... [id=XXXXXXXXXXXXXXXXXXXXXXX]\n\nError: Attribute value cannot be changed\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 53, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  53: resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n\nAttribute aws_account_id, cannot be changed from \"XXXXX\" to\n\"000000000000\""
time="2024-05-03T11:45:36+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var aws_billing_account_id=anything]"
time="2024-05-03T11:45:41+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 0s [id=XXXXX]\ndata.rhcs_versions.version: Read complete after 2s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=XXXXXXXXXXXXXXXXXXXXXXX]\n\nError: Invalid Attribute Value Match\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 59, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  59:   aws_billing_account_id = var.aws_billing_account_id != null ? var.aws_billing_account_id : data.aws_caller_identity.current.account_id\n\nAttribute aws_billing_account_id aws billing account ID must be only digits\nand exactly 12 in length, got: anything"
time="2024-05-03T11:45:41+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var aws_billing_account_id=000000000000]"
time="2024-05-03T11:45:49+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 1s [id=XXXXX]\ndata.rhcs_versions.version: Read complete after 1s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=XXXXXXXXXXXXXXXXXXXXXXX]\nrhcs_cluster_wait.rosa_cluster: Refreshing state...\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_cluster_rosa_hcp.rosa_hcp_cluster will be updated in-place\n  ~ resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n      + admin_credentials          = (known after apply)\n      ~ api_url                    = \"https://api.rhcs-hcp-ad-ogn.yuf6.example.com:443\" -> (known after apply)\n      ~ aws_billing_account_id     = \"XXXXX\" -> \"000000000000\"\n      ~ console_url                = \"https://console-openshift-console.apps.rosa.rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n      ~ current_version            = \"4.15.11\" -> (known after apply)\n      ~ domain                     = \"rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n        id                         = \"XXXXXXXXXXXXXXXXXXXXXXX\"\n        name                       = \"rhcs-hcp-ad-ogn\"\n      ~ ocm_properties             = {\n          - \"custom_property\"  = \"test\"\n          - \"qe_usage\"         = null\n          - \"rosa_creator_arn\" = \"arn:aws:iam::XXXXX:user/tradisso\"\n          - \"rosa_tf_commit\"   = \"2430f5c\"\n          - \"rosa_tf_version\"  = \"1.6.0\"\n        } -> (known after apply)\n      ~ state                      = \"ready\" -> (known after apply)\n        tags                       = {\n            \"tag1\" = \"test_tag1\"\n            \"tag2\" = \"test_tag2\"\n        }\n        # (24 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\n\nChanges to Outputs:\n  ~ cluster_version = \"4.15.11\" -> (known after apply)\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Modifying... [id=XXXXXXXXXXXXXXXXXXXXXXX]\n\nError: Can't update cluster\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 53, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  53: resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n\nCan't update cluster with identifier 'XXXXXXXXXXXXXXXXXXXXXXX':\nstatus is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation\nidentifier is '14abcc24-c79b-4b0e-ad33-a8ee58f9ccd6': billing account\n000000000000 not linked to organization 1jlfDskrR39egznAq3T18Ul0Xxv at the\naws marketplace"
time="2024-05-03T11:45:49+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var aws_region=us-east-1]"
time="2024-05-03T11:45:54+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 0s [id=XXXXX]\ndata.rhcs_versions.version: Read complete after 2s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=XXXXXXXXXXXXXXXXXXXXXXX]\n\nError: Invalid AZ\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 60, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  60:   availability_zones     = var.aws_availability_zones\n\nInvalid AZ 'us-west-2a' for region 'us-east-1'.\n\nError: Invalid AZ\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 60, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  60:   availability_zones     = var.aws_availability_zones\n\nInvalid AZ 'us-west-2b' for region 'us-east-1'.\n\nError: Invalid AZ\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 60, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  60:   availability_zones     = var.aws_availability_zones\n\nInvalid AZ 'us-west-2c' for region 'us-east-1'."
time="2024-05-03T11:45:54+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var cluster_name=any_name]"
time="2024-05-03T11:46:00+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 0s [id=XXXXX]\ndata.rhcs_versions.version: Read complete after 2s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=XXXXXXXXXXXXXXXXXXXXXXX]\nrhcs_cluster_wait.rosa_cluster: Refreshing state...\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_cluster_rosa_hcp.rosa_hcp_cluster will be updated in-place\n  ~ resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n      + admin_credentials          = (known after apply)\n      ~ api_url                    = \"https://api.rhcs-hcp-ad-ogn.yuf6.example.com:443\" -> (known after apply)\n      ~ console_url                = \"https://console-openshift-console.apps.rosa.rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n      ~ current_version            = \"4.15.11\" -> (known after apply)\n      ~ domain                     = \"rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n        id                         = \"XXXXXXXXXXXXXXXXXXXXXXX\"\n      ~ name                       = \"rhcs-hcp-ad-ogn\" -> \"any_name\"\n      ~ ocm_properties             = {\n          - \"custom_property\"  = \"test\"\n          - \"qe_usage\"         = null\n          - \"rosa_creator_arn\" = \"arn:aws:iam::XXXXX:user/tradisso\"\n          - \"rosa_tf_commit\"   = \"2430f5c\"\n          - \"rosa_tf_version\"  = \"1.6.0\"\n        } -> (known after apply)\n      ~ state                      = \"ready\" -> (known after apply)\n        tags                       = {\n            \"tag1\" = \"test_tag1\"\n            \"tag2\" = \"test_tag2\"\n        }\n        # (25 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\n\nChanges to Outputs:\n  ~ cluster_name    = \"rhcs-hcp-ad-ogn\" -> \"any_name\"\n  ~ cluster_version = \"4.15.11\" -> (known after apply)\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Modifying... [id=XXXXXXXXXXXXXXXXXXXXXXX]\n\nError: Attribute value cannot be changed\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 53, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  53: resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n\nAttribute name, cannot be changed from \"rhcs-hcp-ad-ogn\" to \"any_name\""
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

</details>

**What this PR does / why we need it**:
Update automation for edit billing account

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-6805

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
