### PR TITLE
OCM-7820 | ci: Update 72487 (edit etcd key)

### DIFF
--- a/tests/e2e/cluster_edit_test.go
+++ b/tests/e2e/cluster_edit_test.go
@@ -265,14 +265,13 @@ var _ = Describe("Edit cluster", ci.Day2, ci.NonClassicCluster, func() {
 			Expect(err).To(HaveOccurred())
 			helper.ExpectTFErrorContains(err, "Attribute etcd_encryption, cannot be changed from")
 
-			// Waiting for OCM-7820
-			// By("Try to edit etcd_kms_key_arn")
-			// clusterArgs = &exec.ClusterCreationArgs{
-			// 	EtcdKmsKeyARN: helper.StringPointer("anything"),
-			// }
-			// err = clusterService.Apply(clusterArgs, false, false)
-			// Expect(err).To(HaveOccurred())
-			// helper.ExpectTFErrorContains(err, "Attribute etcd_kms_key_arn, cannot be changed from")
+			By("Try to edit etcd_kms_key_arn")
+			clusterArgs = &exec.ClusterCreationArgs{
+				EtcdKmsKeyARN: helper.StringPointer("anything"),
+			}
+			err = clusterService.Apply(clusterArgs, false, false)
+			Expect(err).To(HaveOccurred())
+			helper.ExpectTFErrorContains(err, "Attribute etcd_kms_key_arn, cannot be changed from")
 
 			By("Try to edit kms_key_arn")
 			clusterArgs = &exec.ClusterCreationArgs{


### PR DESCRIPTION
<details>
<summary>Logs</summary>
Will run 1 of 101 specs
time="2024-05-03T14:38:50+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-05-03T14:38:50+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-05-03T14:38:54+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2024-05-03T14:38:56+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-05-03T14:38:56+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-05-03T14:39:00+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var etcd_encryption=false]"
time="2024-05-03T14:39:08+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 0s [id=XXXXXXXXXXXXXXXX]\ndata.rhcs_versions.version: Read complete after 1s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=XXXXXXXXXXXXXXXX]\nrhcs_cluster_wait.rosa_cluster: Refreshing state...\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_cluster_rosa_hcp.rosa_hcp_cluster will be updated in-place\n  ~ resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n      + admin_credentials          = (known after apply)\n      ~ api_url                    = \"https://api.rhcs-hcp-ad-ogn.yuf6.example.com:443\" -> (known after apply)\n      ~ console_url                = \"https://console-openshift-console.apps.rosa.rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n      ~ current_version            = \"4.15.11\" -> (known after apply)\n      ~ domain                     = \"rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n      ~ etcd_encryption            = true -> false\n        id                         = \"XXXXXXXXXXXXXXXX\"\n        name                       = \"rhcs-hcp-ad-ogn\"\n      ~ ocm_properties             = {\n          - \"custom_property\"  = \"test\"\n          - \"qe_usage\"         = null\n          - \"rosa_creator_arn\" = \"arn:aws:iam::XXXXXXXXXXXXXXXX:user/tradisso\"\n          - \"rosa_tf_commit\"   = \"2430f5c\"\n          - \"rosa_tf_version\"  = \"1.6.0\"\n        } -> (known after apply)\n      ~ state                      = \"ready\" -> (known after apply)\n        tags                       = {\n            \"tag1\" = \"test_tag1\"\n            \"tag2\" = \"test_tag2\"\n        }\n        # (24 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\n\nChanges to Outputs:\n  ~ cluster_name    = \"any_name\" -> \"rhcs-hcp-ad-ogn\"\n  ~ cluster_version = \"4.15.11\" -> (known after apply)\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Modifying... [id=XXXXXXXXXXXXXXXX]\n\nError: Attribute value cannot be changed\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 53, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  53: resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n\nAttribute etcd_encryption, cannot be changed from true to false"
time="2024-05-03T14:39:08+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var etcd_kms_key_arn=anything]"
time="2024-05-03T14:39:14+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 1s [id=XXXXXXXXXXXXXXXX]\ndata.rhcs_versions.version: Read complete after 1s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=XXXXXXXXXXXXXXXX]\nrhcs_cluster_wait.rosa_cluster: Refreshing state...\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_cluster_rosa_hcp.rosa_hcp_cluster will be updated in-place\n  ~ resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n      + admin_credentials          = (known after apply)\n      ~ api_url                    = \"https://api.rhcs-hcp-ad-ogn.yuf6.example.com:443\" -> (known after apply)\n      ~ console_url                = \"https://console-openshift-console.apps.rosa.rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n      ~ current_version            = \"4.15.11\" -> (known after apply)\n      ~ domain                     = \"rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n      ~ etcd_kms_key_arn           = \"arn:aws:kms:us-west-2:XXXXXXXXXXXXXXXX:key/678ca48d-88ac-47d6-9de7-bb659ecd1887\" -> \"anything\"\n        id                         = \"XXXXXXXXXXXXXXXX\"\n        name                       = \"rhcs-hcp-ad-ogn\"\n      ~ ocm_properties             = {\n          - \"custom_property\"  = \"test\"\n          - \"qe_usage\"         = null\n          - \"rosa_creator_arn\" = \"arn:aws:iam::XXXXXXXXXXXXXXXX:user/tradisso\"\n          - \"rosa_tf_commit\"   = \"2430f5c\"\n          - \"rosa_tf_version\"  = \"1.6.0\"\n        } -> (known after apply)\n      ~ state                      = \"ready\" -> (known after apply)\n        tags                       = {\n            \"tag1\" = \"test_tag1\"\n            \"tag2\" = \"test_tag2\"\n        }\n        # (24 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\n\nChanges to Outputs:\n  ~ cluster_version = \"4.15.11\" -> (known after apply)\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Modifying... [id=XXXXXXXXXXXXXXXX]\n\nError: Attribute value cannot be changed\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 53, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  53: resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n\nAttribute etcd_kms_key_arn, cannot be changed from\n\"arn:aws:kms:us-west-2:XXXXXXXXXXXXXXXX:key/678ca48d-88ac-47d6-9de7-bb659ecd1887\"\nto \"anything\""
time="2024-05-03T14:39:14+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp with args [-var url=https://api.stage.openshift.com -var kms_key_arn=anything]"
•time="2024-05-03T14:39:20+02:00" level=error msg="data.rhcs_versions.version: Reading...\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 0s [id=XXXXXXXXXXXXXXXX]\ndata.rhcs_versions.version: Read complete after 1s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=XXXXXXXXXXXXXXXX]\nrhcs_cluster_wait.rosa_cluster: Refreshing state...\n\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  ~ update in-place\n\nTerraform will perform the following actions:\n\n  # rhcs_cluster_rosa_hcp.rosa_hcp_cluster will be updated in-place\n  ~ resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n      + admin_credentials          = (known after apply)\n      ~ api_url                    = \"https://api.rhcs-hcp-ad-ogn.yuf6.example.com:443\" -> (known after apply)\n      ~ console_url                = \"https://console-openshift-console.apps.rosa.rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n      ~ current_version            = \"4.15.11\" -> (known after apply)\n      ~ domain                     = \"rhcs-hcp-ad-ogn.yuf6.example.com\" -> (known after apply)\n        id                         = \"XXXXXXXXXXXXXXXX\"\n      ~ kms_key_arn                = \"arn:aws:kms:us-west-2:XXXXXXXXXXXXXXXX:key/678ca48d-88ac-47d6-9de7-bb659ecd1887\" -> \"anything\"\n        name                       = \"rhcs-hcp-ad-ogn\"\n      ~ ocm_properties             = {\n          - \"custom_property\"  = \"test\"\n          - \"qe_usage\"         = null\n          - \"rosa_creator_arn\" = \"arn:aws:iam::XXXXXXXXXXXXXXXX:user/tradisso\"\n          - \"rosa_tf_commit\"   = \"2430f5c\"\n          - \"rosa_tf_version\"  = \"1.6.0\"\n        } -> (known after apply)\n      ~ state                      = \"ready\" -> (known after apply)\n        tags                       = {\n            \"tag1\" = \"test_tag1\"\n            \"tag2\" = \"test_tag2\"\n        }\n        # (24 unchanged attributes hidden)\n    }\n\nPlan: 0 to add, 1 to change, 0 to destroy.\n\nChanges to Outputs:\n  ~ cluster_version = \"4.15.11\" -> (known after apply)\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Modifying... [id=XXXXXXXXXXXXXXXX]\n\nError: Attribute value cannot be changed\n\n  with rhcs_cluster_rosa_hcp.rosa_hcp_cluster,\n  on main.tf line 53, in resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\":\n  53: resource \"rhcs_cluster_rosa_hcp\" \"rosa_hcp_cluster\" {\n\nAttribute kms_key_arn, cannot be changed from\n\"arn:aws:kms:us-west-2:XXXXXXXXXXXXXXXX:key/678ca48d-88ac-47d6-9de7-bb659ecd1887\"\nto \"anything\""
SSSSSSSSSSSSSSSSSSSS

</details>

**What this PR does / why we need it**:
Update tc 72487 to validate etcd key edit

**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/OCM-7820

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
