### PR TITLE
OCM-7083 | ci: Enable tc 72509 (upgrade np)

### DIFF
--- a/tests/utils/cms/versions.go
+++ b/tests/utils/cms/versions.go
@@ -259,38 +259,32 @@ func GetDefaultVersion(connection *client.Connection) *v1.Version {
 }
 
 // It will return all the versions lower that throttle version for the specified channel
-func GetHcpLowerVersions(connection *client.Connection, throttleVersion string, channel string) (versions []string) {
-	resp, _ := connection.ClustersMgmt().V1().Versions().List().Parameter("size", "-1").Send()
+func GetHcpLowerVersions(connection *client.Connection, throttleVersion string, channel string) (versions []*ImageVersion) {
 	throttleVersionSem, semVersionError := semver.NewVersion(throttleVersion)
-	semver.NewVersion(throttleVersion)
-	for _, ver := range resp.Items().Slice() {
-		if semVersionError != nil {
-			continue
-		}
-		if (ver.ChannelGroup() == channel) && ver.HostedControlPlaneEnabled() && ver.Enabled() {
-			versionSem, _ := semver.NewVersion(ver.RawID())
-			if versionSem.LessThan(throttleVersionSem) {
-				versions = append(versions, ver.RawID())
-			}
+	if semVersionError != nil {
+		return
+	}
+	hcpVersions := HCPEnabledVersions(connection, channel)
+	for _, ver := range hcpVersions {
+		versionSem, _ := semver.NewVersion(ver.RawID)
+		if versionSem.LessThan(throttleVersionSem) {
+			versions = append(versions, ver)
 		}
 	}
-	return versions
+	return
 }
 
 // It will return all the versions higher that throttle version for the specified channel
-func GetHcpHigherVersions(connection *client.Connection, throttleVersion string, channel string) (versions []string) {
-	resp, _ := connection.ClustersMgmt().V1().Versions().List().Parameter("size", "-1").Send()
+func GetHcpHigherVersions(connection *client.Connection, throttleVersion string, channel string) (versions []*ImageVersion) {
 	throttleVersionSem, semVersionError := semver.NewVersion(throttleVersion)
-	semver.NewVersion(throttleVersion)
-	for _, ver := range resp.Items().Slice() {
-		if semVersionError != nil {
-			continue
-		}
-		if (ver.ChannelGroup() == channel) && ver.HostedControlPlaneEnabled() && ver.Enabled() {
-			versionSem, _ := semver.NewVersion(ver.RawID())
-			if versionSem.GreaterThan(throttleVersionSem) {
-				versions = append(versions, ver.RawID())
-			}
+	if semVersionError != nil {
+		return
+	}
+	hcpVersions := HCPEnabledVersions(connection, channel)
+	for _, ver := range hcpVersions {
+		versionSem, _ := semver.NewVersion(ver.RawID)
+		if versionSem.GreaterThan(throttleVersionSem) {
+			versions = append(versions, ver)
 		}
 	}
 	return versions


### PR DESCRIPTION
<details>
<summary></summary>
Will run 1 of 101 specs
time="2024-05-03T15:41:08+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-05-03T15:41:08+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-05-03T15:41:17+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
SSSSSSSSSSSSSSStime="2024-05-03T15:41:19+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"
time="2024-05-03T15:41:19+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
time="2024-05-03T15:41:19+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config"
time="2024-05-03T15:41:19+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-05-03T15:41:24+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc"
time="2024-05-03T15:41:26+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-05-03T15:41:30+02:00" level=info msg="Running terraform output against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2024-05-03T15:41:34+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var openshift_version=4.15.10 -var auto_repair=true -var cluster=XXXXXXXXXXXXXXXX -var name=np-72509-sm -var subnet_id=subnet-0b5490b2eb5420d58 -var autoscaling_enabled=false -var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge -var replicas=3]"
time="2024-05-03T15:41:38+02:00" level=info msg="Recording tfvars file /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp/terraform.tfvars"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var cluster=XXXXXXXXXXXXXXXX -var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge -var replicas=3 -var subnet_id=subnet-0b5490b2eb5420d58 -var auto_repair=true -var name=np-72509-sm -var autoscaling_enabled=false -var openshift_version=4.15.10
time="2024-05-03T15:41:38+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
time="2024-05-03T15:41:43+02:00" level=info msg="Deleting tfvars file /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp/terraform.tfvars"
time="2024-05-03T15:41:43+02:00" level=info msg="Running terraform apply against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp with args [-var url=https://api.stage.openshift.com -var machine_type=m5.2xlarge -var replicas=3 -var autoscaling_enabled=false -var subnet_id=subnet-0b5490b2eb5420d58 -var openshift_version=4.15.0-rc.8 -var cluster=XXXXXXXXXXXXXXXX -var name=np-72509-sm -var auto_repair=true]"
time="2024-05-03T15:41:47+02:00" level=info msg="Recording tfvars file /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp/terraform.tfvars"
time="2024-05-03T15:41:47+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var machine_type=m5.2xlarge -var replicas=3 -var cluster=XXXXXXXXXXXXXXXX -var name=np-72509-sm -var subnet_id=subnet-0b5490b2eb5420d58 -var openshift_version=4.15.0-rc.8 -var auto_repair=true -var url=https://api.stage.openshift.com -var autoscaling_enabled=false
time="2024-05-03T15:41:51+02:00" level=info msg="Deleting tfvars file /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp/terraform.tfvars"
time="2024-05-03T15:41:51+02:00" level=info msg="Running terraform destroy against the dir: /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"
args:  /usr/bin/terraform destroy -auto-approve -no-color -var openshift_version=4.15.0-rc.8 -var machine_type=m5.2xlarge -var name=np-72509-sm -var url=https://api.stage.openshift.com -var replicas=3 -var autoscaling_enabled=false -var subnet_id=subnet-0b5490b2eb5420d58 -var auto_repair=true -var cluster=XXXXXXXXXXXXXXXX
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 101 Specs in 42.687 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 100 Skipped
PASS
</details>

**What this PR does / why we need it**:
Activate tc 72509 for candidate clusters

**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/OCM-7083

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
