### PR TITLE
OCM-7852 | fix: allow assumed-role into creator arn property

### DIFF
--- a/provider/clusterrosa/common/consts.go
+++ b/provider/clusterrosa/common/consts.go
@@ -25,7 +25,7 @@ const (
 	MaxClusterDomainPrefixLength = 15
 )
 
-var UserArnRE = regexp.MustCompile("^(arn:(aws|aws-us-gov|aws-cn):iam::\\d{12}(?:|:(?:root|user\\/[0-9A-Za-z\\+\\.@_,-]{1,64})))$")
+var UserArnRE = regexp.MustCompile("^(arn:(?:aws|aws-us-gov|aws-cn):(?:iam|sts)::\\d{12}(?:|:(?:root|user|assumed-role(?:\\/?.+\\/?)?)(?:\\/[0-9A-Za-z\\+\\.@_,-]{1,64})))$")
 
 var OCMProperties = map[string]string{
 	PropertyRosaTfVersion: build.Version,

--- a/provider/clusterrosa/common/consts_test.go
+++ b/provider/clusterrosa/common/consts_test.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
+	. "github.com/onsi/gomega"             // nolint
+)
+
+func TestResource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster Rosa HCP Resource Suite")
+}
+
+var _ = Describe("User arn property test", func() {
+	It("assumed-role with path", func() {
+		Expect(UserArnRE.MatchString("arn:aws:sts::123456789012:assumed-role/123456789012-poweruser/someuser")).To(BeTrue())
+	})
+
+	It("assumed-role", func() {
+		Expect(UserArnRE.MatchString("arn:aws:sts::123456789012:assumed-role/someuser")).To(BeTrue())
+	})
+
+	It("user", func() {
+		Expect(UserArnRE.MatchString("arn:aws:iam::123456789012:user/dummy")).To(BeTrue())
+	})
+
+	It("user with path", func() {
+		Expect(UserArnRE.MatchString("arn:aws:iam::123456789012:user/path/dummy")).To(BeFalse())
+	})
+})


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->
[OCM-7852](https://issues.redhat.com//browse/OCM-7852) 

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [x] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
