### PR TITLE
OCM-8983 | ci: Review Profile Handler errors

### DIFF
--- a/tests/e2e/cluster_creation_test.go
+++ b/tests/e2e/cluster_creation_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Create cluster", func() {
 			By("Retrieve creation args")
 			defer func() {
 				By("Clean resources")
-				ci.DestroyRHCSClusterByProfile(token, profile)
+				ci.DestroyRHCSClusterResourcesByProfile(token, profile)
 			}()
 			creationArgs, err := ci.GenerateClusterCreationArgsByProfile(token, profile)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/cluster_destroy_test.go
+++ b/tests/e2e/cluster_destroy_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Delete cluster", func() {
 
 			// Generate/build cluster by profile selected
 			profile := ci.LoadProfileYamlFileByENV()
-			err := ci.DestroyRHCSClusterByProfile(token, profile)
+			err := ci.DestroyRHCSClusterResourcesByProfile(token, profile)
 			Expect(err).ToNot(HaveOccurred())
 		})
 })

--- a/tests/e2e/negative_day_one_test.go
+++ b/tests/e2e/negative_day_one_test.go
@@ -50,13 +50,13 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 
 		originalClusterArgs, err := ci.GenerateClusterCreationArgsByProfile(token, profile)
 		if err != nil {
-			defer ci.DestroyRHCSClusterByProfile(token, profile)
+			defer ci.DestroyRHCSClusterResourcesByProfile(token, profile)
 		}
 		Expect(err).ToNot(HaveOccurred())
 
 		clusterService, err = exec.NewClusterService(profile.GetClusterManifestsDir())
 		if err != nil {
-			defer ci.DestroyRHCSClusterByProfile(token, profile)
+			defer ci.DestroyRHCSClusterResourcesByProfile(token, profile)
 		}
 		Expect(err).ToNot(HaveOccurred())
 
@@ -69,7 +69,7 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 			exec.DeleteTFvarsFile(originalClusterVarsFile)
 		}
 
-		err := ci.DestroyRHCSClusterByProfile(token, profile)
+		err := ci.DestroyRHCSClusterResourcesByProfile(token, profile)
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove fail fast error when deleting cluster resources, preventing other resources to be deleted
- Removed some `Expect` usage

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-8983

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
