### PR TITLE
OCM-8959 | ci: Remove Non*Cluster labels

### DIFF
--- a/tests/ci/labels.go
+++ b/tests/ci/labels.go
@@ -42,7 +42,3 @@ var Low = Label("Low")
 
 // exclude
 var Exclude = Label("Exclude")
-
-// Cluster Type
-var NonClassicCluster = Label("NonClassicCluster")
-var NonHCPCluster = Label("NonHCPCluster")

--- a/tests/e2e/account_roles_test.go
+++ b/tests/e2e/account_roles_test.go
@@ -99,7 +99,10 @@ var _ = Describe("Create Account roles with shared vpc role", ci.Exclude, func()
 		accService.Destroy()
 	})
 
-	It("create and destroy account roles for shared vpc - [id:67574]", ci.Day2, ci.Medium, ci.NonHCPCluster, func() {
+	It("create and destroy account roles for shared vpc - [id:67574]", ci.Day2, ci.Medium, func() {
+		if profile.GetClusterType().HCP {
+			Skip("Test can run only on Classic cluster")
+		}
 		By("Create account role without shared vpc role arn")
 		accArgs := &exec.AccountRolesArgs{
 			AccountRolePrefix: helper.StringPointer("OCP-67574"),

--- a/tests/e2e/classic_machine_pool_test.go
+++ b/tests/e2e/classic_machine_pool_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
-var _ = Describe("Create MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureMachinepool, func() {
+var _ = Describe("Create MachinePool", ci.Day2, ci.FeatureMachinepool, func() {
 	defer GinkgoRecover()
 
 	var (
@@ -27,6 +27,9 @@ var _ = Describe("Create MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureMach
 
 	BeforeEach(func() {
 		profile = ci.LoadProfileYamlFileByENV()
+		if profile.GetClusterType().HCP {
+			Skip("Test can run only on Classic cluster")
+		}
 
 		var err error
 		mpService, err = exec.NewMachinePoolService(constants.ClassicMachinePoolDir)
@@ -624,7 +627,7 @@ var _ = Describe("Create MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureMach
 		Expect(mpResponseBody.InstanceType()).To(Equal("m5.2xlarge"))
 	})
 
-	It("can create machinepool with customized tags - [id:73942]", ci.High, ci.NonHCPCluster, func() {
+	It("can create machinepool with customized tags - [id:73942]", ci.High, func() {
 
 		By("Create a machinepool with variable aws_tags")
 		name := "mp-73942"
@@ -700,7 +703,8 @@ var _ = Describe("Create MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureMach
 			Expect(taint.Value()).To(Equal(taints[index]["value"]))
 		}
 	})
-	It("will validate well - [id:63139]", ci.Medium, ci.NonHCPCluster, func() {
+
+	It("will validate well - [id:63139]", ci.Medium, func() {
 		By("Will validate the subnet")
 		mpArgs := &exe.MachinePoolArgs{
 			Cluster:     helper.StringPointer(clusterID),
@@ -746,11 +750,15 @@ var _ = Describe("Create MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureMach
 	})
 })
 
-var _ = Describe("Import MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureImport, func() {
+var _ = Describe("Import MachinePool", ci.Day2, ci.FeatureImport, func() {
 	var mpService exec.MachinePoolService
 	var importService exec.ImportService
 
 	BeforeEach(func() {
+		profile := ci.LoadProfileYamlFileByENV()
+		if profile.GetClusterType().HCP {
+			Skip("Test can run only on Classic cluster")
+		}
 		var err error
 
 		mpService, err = exec.NewMachinePoolService(constants.ClassicMachinePoolDir)
@@ -806,7 +814,7 @@ var _ = Describe("Import MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureImpo
 	})
 })
 
-var _ = Describe("Edit MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureMachinepool, func() {
+var _ = Describe("Edit MachinePool", ci.Day2, ci.FeatureMachinepool, func() {
 
 	var (
 		dmpService                     exec.MachinePoolService
@@ -817,6 +825,11 @@ var _ = Describe("Edit MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureMachin
 	)
 
 	BeforeEach(func() {
+		profile := ci.LoadProfileYamlFileByENV()
+		if profile.GetClusterType().HCP {
+			Skip("Test can run only on Classic cluster")
+		}
+
 		var err error
 		dmpService, err = exec.NewMachinePoolService(constants.DefaultMachinePoolDir)
 		Expect(err).ToNot(HaveOccurred())
@@ -982,7 +995,7 @@ var _ = Describe("Edit MachinePool", ci.Day2, ci.NonHCPCluster, ci.FeatureMachin
 
 })
 
-var _ = Describe("Destroy MachinePool", ci.Day3, ci.NonHCPCluster, ci.FeatureMachinepool, func() {
+var _ = Describe("Destroy MachinePool", ci.Day3, ci.FeatureMachinepool, func() {
 	var (
 		dmpService                 exec.MachinePoolService
 		defaultMachinePoolArgs     *exec.MachinePoolArgs
@@ -992,6 +1005,11 @@ var _ = Describe("Destroy MachinePool", ci.Day3, ci.NonHCPCluster, ci.FeatureMac
 	)
 
 	BeforeEach(func() {
+		profile := ci.LoadProfileYamlFileByENV()
+		if profile.GetClusterType().HCP {
+			Skip("Test can run only on Classic cluster")
+		}
+
 		var err error
 		dmpService, err = exec.NewMachinePoolService(constants.DefaultMachinePoolDir)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/cluster_autoscaler_day2_test.go
+++ b/tests/e2e/cluster_autoscaler_day2_test.go
@@ -25,8 +25,10 @@ var _ = Describe("Cluster Autoscaler", ci.Day2, ci.FeatureClusterAutoscaler, fun
 	var caService exec.ClusterAutoscalerService
 	var clusterAutoScalerBodyForRecreate *cmsv1.ClusterAutoscaler
 	var clusterAutoscalerStatusBefore int
+	var profile *ci.Profile
 
 	BeforeEach(func() {
+		profile = ci.LoadProfileYamlFileByENV()
 		caRetrieveBody, _ := cms.RetrieveClusterAutoscaler(ci.RHCSConnection, clusterID)
 		clusterAutoscalerStatusBefore = caRetrieveBody.Status()
 		if clusterAutoscalerStatusBefore == http.StatusOK {
@@ -50,7 +52,11 @@ var _ = Describe("Cluster Autoscaler", ci.Day2, ci.FeatureClusterAutoscaler, fun
 			Expect(recreateAutoscaler.Status()).To(Equal(http.StatusCreated))
 		}
 	})
-	It("can be added/destroyed to Classic cluster - [id:69137]", ci.High, ci.NonHCPCluster, func() {
+	It("can be added/destroyed to Classic cluster - [id:69137]", ci.High, func() {
+		if profile.GetClusterType().HCP {
+			Skip("Test can run only on Classic cluster")
+		}
+
 		var err error
 		caService, err = exec.NewClusterAutoscalerService(constants.ClassicClusterAutoscalerDir)
 		Expect(err).NotTo(HaveOccurred())
@@ -139,8 +145,11 @@ var _ = Describe("Cluster Autoscaler", ci.Day2, ci.FeatureClusterAutoscaler, fun
 
 	It("can be created/edited/deleted to HCP cluster - [id:72524][id:72525]",
 		ci.High,
-		ci.NonClassicCluster,
 		func() {
+			if !profile.GetClusterType().HCP {
+				Skip("Test can run only on Hosted cluster")
+			}
+
 			var err error
 			caService, err = exec.NewClusterAutoscalerService(constants.HCPClusterAutoscalerDir)
 			Expect(err).NotTo(HaveOccurred())
@@ -216,7 +225,11 @@ var _ = Describe("Cluster Autoscaler", ci.Day2, ci.FeatureClusterAutoscaler, fun
 			Expect(caResponse.Status()).To(Equal(http.StatusNotFound))
 		})
 
-	It("can be validated against HCP cluster - [id:72526]", ci.Medium, ci.NonClassicCluster, func() {
+	It("can be validated against HCP cluster - [id:72526]", ci.Medium, func() {
+		if !profile.GetClusterType().HCP {
+			Skip("Test can run only on Hosted cluster")
+		}
+
 		var err error
 		caService, err = exec.NewClusterAutoscalerService(constants.HCPClusterAutoscalerDir)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/cluster_edit_test.go
+++ b/tests/e2e/cluster_edit_test.go
@@ -112,7 +112,13 @@ var _ = Describe("Edit cluster", ci.Day2, func() {
 		})
 	})
 
-	Context("validate", ci.NonClassicCluster, func() {
+	Context("validate", func() {
+		BeforeEach(func() {
+			if !profile.GetClusterType().HCP {
+				Skip("Test can run only on Hosted cluster")
+			}
+		})
+
 		validateClusterArg := func(updateFields func(args *exec.ClusterArgs), validateErrFunc func(err error)) {
 			updateFields(clusterArgs)
 			_, err := clusterService.Apply(clusterArgs)
@@ -451,8 +457,11 @@ var _ = Describe("Edit cluster", ci.Day2, func() {
 
 		// Skip this tests until OCM-5079 fixed
 		It("security groups - [id:69145]",
-			ci.NonHCPCluster, ci.Exclude, ci.Day2,
+			ci.Exclude, ci.Day2,
 			func() {
+				if profile.GetClusterType().HCP {
+					Skip("Test can run only on Classic cluster")
+				}
 				clusterService, err := exec.NewClusterService(profile.GetClusterManifestsDir())
 				Expect(err).ToNot(HaveOccurred())
 				output, err := clusterService.Output()

--- a/tests/e2e/cluster_misc_day2_test.go
+++ b/tests/e2e/cluster_misc_day2_test.go
@@ -51,7 +51,10 @@ var _ = Describe("Cluster miscellaneous", func() {
 	})
 
 	It("should validate custom property operations on cluster - [id:64907]",
-		ci.Day2, ci.Medium, ci.FeatureClusterMisc, ci.NonHCPCluster, func() {
+		ci.Day2, ci.Medium, ci.FeatureClusterMisc, func() {
+			if profile.GetClusterType().HCP {
+				Skip("Test can run only on Classic cluster")
+			}
 
 			By("Adding additional custom property to the existing cluster")
 			updatedCustomProperties := constants.CustomProperties
@@ -77,7 +80,11 @@ var _ = Describe("Cluster miscellaneous", func() {
 			Expect(err.Error()).Should(ContainSubstring("Can not override reserved properties keys"))
 		})
 
-	It("can edit/delete cluster properties - [id:72451]", ci.Day2, ci.Medium, ci.NonClassicCluster, ci.FeatureClusterMisc, func() {
+	It("can edit/delete cluster properties - [id:72451]", ci.Day2, ci.Medium, ci.FeatureClusterMisc, func() {
+		if !profile.GetClusterType().HCP {
+			Skip("Test can run only on Hosted cluster")
+		}
+
 		updatedCustomProperties := helper.CopyStringMap(originalCustomProperties)
 
 		By("Add properties to cluster")

--- a/tests/e2e/cluster_upgrade_test.go
+++ b/tests/e2e/cluster_upgrade_test.go
@@ -43,216 +43,232 @@ var _ = Describe("Upgrade", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("ROSA STS cluster on Z-stream - [id:63153]", ci.Upgrade, ci.NonHCPCluster,
-		func() {
-			if profile.VersionPattern != "z-1" {
-				Skip("The test is configured only for Z-stream upgrade")
+	Context("ROSA STS cluster", func() {
+		BeforeEach(func() {
+			if profile.GetClusterType().HCP {
+				Skip("Test can run only on Classic cluster")
 			}
-			clusterResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred())
-			targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
-				constants.Z, clusterResp.Body().Version().AvailableUpgrades())
-			Expect(err).ToNot(HaveOccurred())
+		})
 
-			By("Validate invalid OCP version - downgrade")
-			currentVersion := string(clusterResp.Body().Version().RawID())
-			splittedVersion := strings.Split(currentVersion, ".")
-			zStreamV, err := strconv.Atoi(splittedVersion[2])
-			Expect(err).ToNot(HaveOccurred())
+		It("on Z-stream - [id:63153]", ci.Upgrade,
+			func() {
+				if profile.VersionPattern != "z-1" {
+					Skip("The test is configured only for Z-stream upgrade")
+				}
+				clusterResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
+					constants.Z, clusterResp.Body().Version().AvailableUpgrades())
+				Expect(err).ToNot(HaveOccurred())
 
-			downgradedVersion := fmt.Sprintf("%s.%s.%s", splittedVersion[0], splittedVersion[1], fmt.Sprint(zStreamV-1))
+				By("Validate invalid OCP version - downgrade")
+				currentVersion := string(clusterResp.Body().Version().RawID())
+				splittedVersion := strings.Split(currentVersion, ".")
+				zStreamV, err := strconv.Atoi(splittedVersion[2])
+				Expect(err).ToNot(HaveOccurred())
 
-			imageVersionsList := cms.EnabledVersions(ci.RHCSConnection, profile.ChannelGroup, profile.MajorVersion, true)
-			versionsList := cms.GetRawVersionList(imageVersionsList)
-			if slices.Contains(versionsList, downgradedVersion) {
-				clusterArgs.OpenshiftVersion = helper.StringPointer(downgradedVersion)
+				downgradedVersion := fmt.Sprintf("%s.%s.%s", splittedVersion[0], splittedVersion[1], fmt.Sprint(zStreamV-1))
+
+				imageVersionsList := cms.EnabledVersions(ci.RHCSConnection, profile.ChannelGroup, profile.MajorVersion, true)
+				versionsList := cms.GetRawVersionList(imageVersionsList)
+				if slices.Contains(versionsList, downgradedVersion) {
+					clusterArgs.OpenshiftVersion = helper.StringPointer(downgradedVersion)
+					_, err = clusterService.Apply(clusterArgs)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("cluster version is already above the\nrequested version"))
+
+				}
+
+				By("Run the cluster update")
+				clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
+				_, err = clusterService.Apply(clusterArgs)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Wait the upgrade finished")
+				err = openshift.WaitClassicClusterUpgradeFinished(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred(), "Cluster upgrade %s failed with the error %v", clusterID, err)
+
+				By("Wait for 10 minutes to be sure the version is synced in clusterdeployment")
+				time.Sleep(10 * time.Minute)
+
+				By("Check the cluster status and OCP version")
+				clusterResp, err = cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
+				Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
+
+				if constants.GetEnvWithDefault(constants.WaitOperators, "false") == "true" && !profile.Private {
+					// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
+					timeout := 60
+					err = openshift.WaitForOperatorsToBeReady(ci.RHCSConnection, clusterID, timeout)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+
+		It("on Y-stream - [id:63152]", ci.Upgrade,
+			func() {
+
+				if profile.VersionPattern != "y-1" {
+					Skip("The test is configured only for Y-stream upgrade")
+				}
+
+				clusterResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
+					constants.Y, clusterResp.Body().Version().AvailableUpgrades())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(targetV).ToNot(Equal(""))
+
+				By("Upgrade account-roles")
+				majorVersion := ci.GetMajorVersion(targetV)
+				Expect(majorVersion).ToNot(Equal(""))
+				_, err = ci.PrepareAccountRoles(token, clusterResp.Body().Name(), profile.UnifiedAccRolesPath, profile.Region, majorVersion, profile.ChannelGroup, profile.GetClusterType(), "")
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Validate invalid OCP version field - downgrade")
+				currentVersion := string(clusterResp.Body().Version().RawID())
+				splittedVersion := strings.Split(currentVersion, ".")
+				yStreamV, err := strconv.Atoi(splittedVersion[1])
+				Expect(err).ToNot(HaveOccurred())
+
+				downgradedVersion := fmt.Sprintf("%s.%s.%s", splittedVersion[0], fmt.Sprint(yStreamV-1), splittedVersion[2])
+				imageVersionsList := cms.EnabledVersions(ci.RHCSConnection, profile.ChannelGroup, profile.MajorVersion, true)
+				versionsList := cms.GetRawVersionList(imageVersionsList)
+				if slices.Contains(versionsList, downgradedVersion) {
+					clusterArgs.OpenshiftVersion = helper.StringPointer(downgradedVersion)
+					_, err = clusterService.Apply(clusterArgs)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("cluster version is already above the\nrequested version"))
+
+				}
+
+				By("Validate  the cluster Upgrade upgrade_acknowledge field")
+				clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
 				_, err = clusterService.Apply(clusterArgs)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("cluster version is already above the\nrequested version"))
+				Expect(err.Error()).To(ContainSubstring("Missing required acknowledgements to schedule upgrade"))
 
-			}
-
-			By("Run the cluster update")
-			clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
-			_, err = clusterService.Apply(clusterArgs)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Wait the upgrade finished")
-			err = openshift.WaitClassicClusterUpgradeFinished(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred(), "Cluster upgrade %s failed with the error %v", clusterID, err)
-
-			By("Wait for 10 minutes to be sure the version is synced in clusterdeployment")
-			time.Sleep(10 * time.Minute)
-
-			By("Check the cluster status and OCP version")
-			clusterResp, err = cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
-			Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
-
-			if constants.GetEnvWithDefault(constants.WaitOperators, "false") == "true" && !profile.Private {
-				// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
-				timeout := 60
-				err = openshift.WaitForOperatorsToBeReady(ci.RHCSConnection, clusterID, timeout)
-				Expect(err).ToNot(HaveOccurred())
-			}
-		})
-
-	It("ROSA STS cluster on Y-stream - [id:63152]", ci.Upgrade, ci.NonHCPCluster,
-		func() {
-
-			if profile.VersionPattern != "y-1" {
-				Skip("The test is configured only for Y-stream upgrade")
-			}
-
-			clusterResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred())
-			targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
-				constants.Y, clusterResp.Body().Version().AvailableUpgrades())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(targetV).ToNot(Equal(""))
-
-			By("Upgrade account-roles")
-			majorVersion := ci.GetMajorVersion(targetV)
-			Expect(majorVersion).ToNot(Equal(""))
-			_, err = ci.PrepareAccountRoles(token, clusterResp.Body().Name(), profile.UnifiedAccRolesPath, profile.Region, majorVersion, profile.ChannelGroup, profile.GetClusterType(), "")
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Validate invalid OCP version field - downgrade")
-			currentVersion := string(clusterResp.Body().Version().RawID())
-			splittedVersion := strings.Split(currentVersion, ".")
-			yStreamV, err := strconv.Atoi(splittedVersion[1])
-			Expect(err).ToNot(HaveOccurred())
-
-			downgradedVersion := fmt.Sprintf("%s.%s.%s", splittedVersion[0], fmt.Sprint(yStreamV-1), splittedVersion[2])
-			imageVersionsList := cms.EnabledVersions(ci.RHCSConnection, profile.ChannelGroup, profile.MajorVersion, true)
-			versionsList := cms.GetRawVersionList(imageVersionsList)
-			if slices.Contains(versionsList, downgradedVersion) {
-				clusterArgs.OpenshiftVersion = helper.StringPointer(downgradedVersion)
+				By("Apply the cluster Upgrade")
+				clusterArgs.UpgradeAcknowledgementsFor = helper.StringPointer(majorVersion)
 				_, err = clusterService.Apply(clusterArgs)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("cluster version is already above the\nrequested version"))
-
-			}
-
-			By("Validate  the cluster Upgrade upgrade_acknowledge field")
-			clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
-			_, err = clusterService.Apply(clusterArgs)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Missing required acknowledgements to schedule upgrade"))
-
-			By("Apply the cluster Upgrade")
-			clusterArgs.UpgradeAcknowledgementsFor = helper.StringPointer(majorVersion)
-			_, err = clusterService.Apply(clusterArgs)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Wait the upgrade finished")
-			err = openshift.WaitClassicClusterUpgradeFinished(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred(), "Cluster %s failed with the error %v", clusterID, err)
-
-			By("Wait for 10 minutes to be sure the version is synced in clusterdeployment")
-			time.Sleep(10 * time.Minute)
-
-			By("Check the cluster status and OCP version")
-			clusterResp, err = cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
-			Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
-
-			if constants.GetEnvWithDefault(constants.WaitOperators, "false") == "true" && !profile.Private {
-				// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
-				timeout := 60
-				err = openshift.WaitForOperatorsToBeReady(ci.RHCSConnection, clusterID, timeout)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("Wait the upgrade finished")
+				err = openshift.WaitClassicClusterUpgradeFinished(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred(), "Cluster %s failed with the error %v", clusterID, err)
+
+				By("Wait for 10 minutes to be sure the version is synced in clusterdeployment")
+				time.Sleep(10 * time.Minute)
+
+				By("Check the cluster status and OCP version")
+				clusterResp, err = cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
+				Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
+
+				if constants.GetEnvWithDefault(constants.WaitOperators, "false") == "true" && !profile.Private {
+					// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
+					timeout := 60
+					err = openshift.WaitForOperatorsToBeReady(ci.RHCSConnection, clusterID, timeout)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+	})
+
+	Context("ROSA HCP cluster", func() {
+		BeforeEach(func() {
+			if !profile.GetClusterType().HCP {
+				Skip("Test can run only on Hosted cluster")
 			}
 		})
 
-	It("ROSA HCP cluster on Z-stream - [id:72474]", ci.Upgrade, ci.NonClassicCluster,
-		func() {
-			if profile.VersionPattern != "z-1" {
-				Skip("The test is configured only for Z-stream upgrade")
-			}
+		It("ROSA HCP cluster on Z-stream - [id:72474]", ci.Upgrade,
+			func() {
+				if profile.VersionPattern != "z-1" {
+					Skip("The test is configured only for Z-stream upgrade")
+				}
 
-			By("Retrieve cluster information and upgrade version")
-			clusterResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred())
-			targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
-				constants.Z, clusterResp.Body().Version().AvailableUpgrades())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(targetV).ToNot(BeEmpty())
-
-			Logger.Infof("Gonna upgrade to version %s", targetV)
-
-			By("Run the cluster update")
-			clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
-			_, err = clusterService.Apply(clusterArgs)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Wait the upgrade finished")
-			err = openshift.WaitHCPClusterUpgradeFinished(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred(), "Cluster upgrade %s failed with the error %v", clusterID, err)
-
-			By("Check the cluster status and OCP version")
-			clusterResp, err = cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
-			Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
-
-			if constants.GetEnvWithDefault(constants.WaitOperators, "false") == "true" && !profile.Private {
-				// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
-				timeout := 60
-				err = openshift.WaitForOperatorsToBeReady(ci.RHCSConnection, clusterID, timeout)
+				By("Retrieve cluster information and upgrade version")
+				clusterResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
 				Expect(err).ToNot(HaveOccurred())
-			}
-		})
-
-	It("ROSA HCP cluster on Y-stream - [id:72475]", ci.Upgrade, ci.NonClassicCluster,
-		func() {
-			if profile.VersionPattern != "y-1" {
-				Skip("The test is configured only for Y-stream upgrade")
-			}
-
-			By("Retrieve cluster information and upgrade version")
-			clusterResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred())
-			targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
-				constants.Y, clusterResp.Body().Version().AvailableUpgrades())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(targetV).ToNot(BeEmpty())
-			majorVersion := ci.GetMajorVersion(targetV)
-			Expect(majorVersion).ToNot(BeEmpty())
-
-			Logger.Infof("Gonna upgrade to version %s", targetV)
-
-			clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
-			// Blocked by OCM-7641
-			// By("Validate the cluster Upgrade upgrade_acknowledge field")
-			// err = clusterService.Apply(clusterArgs)
-			// Expect(err).To(HaveOccurred())
-			// Expect(err.Error()).To(ContainSubstring("Missing required acknowledgements to schedule upgrade"))
-
-			By("Apply the cluster Upgrade")
-			clusterArgs.UpgradeAcknowledgementsFor = helper.StringPointer(majorVersion)
-			_, err = clusterService.Apply(clusterArgs)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Wait the upgrade finished")
-			err = openshift.WaitHCPClusterUpgradeFinished(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred(), "Cluster %s failed with the error %v", clusterID, err)
-
-			By("Check the cluster status and OCP version")
-			clusterResp, err = cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
-			Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
-
-			if constants.GetEnvWithDefault(constants.WaitOperators, "false") == "true" && !profile.Private {
-				// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
-				timeout := 60
-				err = openshift.WaitForOperatorsToBeReady(ci.RHCSConnection, clusterID, timeout)
+				targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
+					constants.Z, clusterResp.Body().Version().AvailableUpgrades())
 				Expect(err).ToNot(HaveOccurred())
-			}
-		})
+				Expect(targetV).ToNot(BeEmpty())
+
+				Logger.Infof("Gonna upgrade to version %s", targetV)
+
+				By("Run the cluster update")
+				clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
+				_, err = clusterService.Apply(clusterArgs)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Wait the upgrade finished")
+				err = openshift.WaitHCPClusterUpgradeFinished(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred(), "Cluster upgrade %s failed with the error %v", clusterID, err)
+
+				By("Check the cluster status and OCP version")
+				clusterResp, err = cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
+				Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
+
+				if constants.GetEnvWithDefault(constants.WaitOperators, "false") == "true" && !profile.Private {
+					// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
+					timeout := 60
+					err = openshift.WaitForOperatorsToBeReady(ci.RHCSConnection, clusterID, timeout)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+
+		It("ROSA HCP cluster on Y-stream - [id:72475]", ci.Upgrade,
+			func() {
+				if profile.VersionPattern != "y-1" {
+					Skip("The test is configured only for Y-stream upgrade")
+				}
+
+				By("Retrieve cluster information and upgrade version")
+				clusterResp, err := cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
+					constants.Y, clusterResp.Body().Version().AvailableUpgrades())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(targetV).ToNot(BeEmpty())
+				majorVersion := ci.GetMajorVersion(targetV)
+				Expect(majorVersion).ToNot(BeEmpty())
+
+				Logger.Infof("Gonna upgrade to version %s", targetV)
+
+				clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
+				// Blocked by OCM-7641
+				// By("Validate the cluster Upgrade upgrade_acknowledge field")
+				// err = clusterService.Apply(clusterArgs)
+				// Expect(err).To(HaveOccurred())
+				// Expect(err.Error()).To(ContainSubstring("Missing required acknowledgements to schedule upgrade"))
+
+				By("Apply the cluster Upgrade")
+				clusterArgs.UpgradeAcknowledgementsFor = helper.StringPointer(majorVersion)
+				_, err = clusterService.Apply(clusterArgs)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Wait the upgrade finished")
+				err = openshift.WaitHCPClusterUpgradeFinished(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred(), "Cluster %s failed with the error %v", clusterID, err)
+
+				By("Check the cluster status and OCP version")
+				clusterResp, err = cms.RetrieveClusterDetail(ci.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
+				Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
+
+				if constants.GetEnvWithDefault(constants.WaitOperators, "false") == "true" && !profile.Private {
+					// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
+					timeout := 60
+					err = openshift.WaitForOperatorsToBeReady(ci.RHCSConnection, clusterID, timeout)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+	})
 })

--- a/tests/e2e/dns_test.go
+++ b/tests/e2e/dns_test.go
@@ -21,7 +21,11 @@ var _ = Describe("DNS Domain", func() {
 	})
 
 	It("can create and destroy dnsdomain - [id:67570]",
-		ci.Day2, ci.Medium, ci.FeatureIDP, ci.NonHCPCluster, func() {
+		ci.Day2, ci.Medium, ci.FeatureIDP, func() {
+			profile := ci.LoadProfileYamlFileByENV()
+			if profile.GetClusterType().HCP {
+				Skip("Test can run only on Classic cluster")
+			}
 
 			By("Retrieve DNS creation args")
 			dnsArgs, err := dnsService.ReadTFVars()

--- a/tests/e2e/hcp_ingress_test.go
+++ b/tests/e2e/hcp_ingress_test.go
@@ -20,7 +20,7 @@ import (
 var internalListeningMethod = "internal"
 var externalListeningMethod = "external"
 
-var _ = Describe("HCP Ingress", ci.NonClassicCluster, ci.FeatureIngress, ci.Day2, func() {
+var _ = Describe("HCP Ingress", ci.FeatureIngress, ci.Day2, func() {
 
 	var (
 		err            error
@@ -38,6 +38,11 @@ var _ = Describe("HCP Ingress", ci.NonClassicCluster, ci.FeatureIngress, ci.Day2
 	}
 
 	BeforeEach(func() {
+		profile := ci.LoadProfileYamlFileByENV()
+		if !profile.GetClusterType().HCP {
+			Skip("Test can run only on Hosted cluster")
+		}
+
 		ingressBefore, err = cms.RetrieveClusterIngress(ci.RHCSConnection, clusterID)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var _ = Describe("HCP MachinePool", ci.Day2, ci.NonClassicCluster, ci.FeatureMachinepool, func() {
+var _ = Describe("HCP MachinePool", ci.Day2, ci.FeatureMachinepool, func() {
 	defer GinkgoRecover()
 	var (
 		mpService exec.MachinePoolService
@@ -31,6 +31,10 @@ var _ = Describe("HCP MachinePool", ci.Day2, ci.NonClassicCluster, ci.FeatureMac
 
 	BeforeEach(func() {
 		profile = ci.LoadProfileYamlFileByENV()
+
+		if !profile.GetClusterType().HCP {
+			Skip("Test can run only on Hosted cluster")
+		}
 
 		var err error
 		mpService, err = exec.NewMachinePoolService(constants.HCPMachinePoolDir)

--- a/tests/e2e/kubelet_config_test.go
+++ b/tests/e2e/kubelet_config_test.go
@@ -13,12 +13,17 @@ import (
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
-var _ = Describe("Kubelet config", ci.NonHCPCluster, func() {
+var _ = Describe("Kubelet config", func() {
 	defer GinkgoRecover()
 
 	var kcService exe.KubeletConfigService
 
 	BeforeEach(func() {
+		profile := ci.LoadProfileYamlFileByENV()
+		if profile.GetClusterType().HCP {
+			Skip("Test can run only on Classic cluster")
+		}
+
 		var err error
 		kcService, err = exe.NewKubeletConfigService(CON.KubeletConfigDir)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/negative_day_one_test.go
+++ b/tests/e2e/negative_day_one_test.go
@@ -73,8 +73,11 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	Describe("cluster admin", ci.NonHCPCluster, ci.Day1Negative, func() {
+	Describe("cluster admin", ci.Day1Negative, func() {
 		BeforeEach(OncePerOrdered, func() {
+			if profile.GetClusterType().HCP {
+				Skip("Test can run only on Classic cluster")
+			}
 			if !profile.AdminEnabled {
 				Skip("The tests configured for cluster admin only")
 			}
@@ -121,7 +124,13 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 		})
 	})
 
-	Describe("Create HCP cluster", ci.NonClassicCluster, ci.Day1Negative, func() {
+	Describe("Create HCP cluster", ci.Day1Negative, func() {
+		BeforeEach(OncePerOrdered, func() {
+			if !profile.GetClusterType().HCP {
+				Skip("Test can run only on Hosted cluster")
+			}
+		})
+
 		It("validate required fields - [id:72445]", ci.High, func() {
 			By("Create cluster with wrong billing account")
 			newValue := "012345678912"

--- a/tests/e2e/tuning_config_test.go
+++ b/tests/e2e/tuning_config_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/log"
 )
 
-var _ = Describe("Tuning Config", ci.NonClassicCluster, ci.FeatureTuningConfig, ci.Day2, func() {
+var _ = Describe("Tuning Config", ci.FeatureTuningConfig, ci.Day2, func() {
 	var (
 		tcService exec.TuningConfigService
 		mpService exec.MachinePoolService
@@ -30,6 +30,10 @@ var _ = Describe("Tuning Config", ci.NonClassicCluster, ci.FeatureTuningConfig, 
 
 	BeforeEach(func() {
 		profile = ci.LoadProfileYamlFileByENV()
+
+		if !profile.GetClusterType().HCP {
+			Skip("Test can run only on Hosted cluster")
+		}
 
 		var err error
 		mpService, err = exec.NewMachinePoolService(constants.HCPMachinePoolDir)

--- a/tests/e2e/verification_post_day1_test.go
+++ b/tests/e2e/verification_post_day1_test.go
@@ -149,7 +149,12 @@ var _ = Describe("Verify cluster", func() {
 		}
 	})
 	It("can be imported - [id:65684]",
-		ci.Day2, ci.Medium, ci.NonHCPCluster, ci.FeatureImport, func() {
+		ci.Day2, ci.Medium, ci.FeatureImport, func() {
+
+			if profile.GetClusterType().HCP {
+				Skip("Test can run only on Classic cluster")
+			}
+
 			importService, err := exec.NewImportService(constants.ImportResourceDir) // init new import service
 			Expect(err).ToNot(HaveOccurred())
 
@@ -237,8 +242,11 @@ var _ = Describe("Verify cluster", func() {
 		})
 
 	It("additional security group are correctly set - [id:69145]",
-		ci.Day1Post, ci.Critical, ci.NonHCPCluster,
+		ci.Day1Post, ci.Critical,
 		func() {
+			if profile.GetClusterType().HCP {
+				Skip("Test can run only on Classic cluster")
+			}
 			By("Check the profile settings")
 			if profile.AdditionalSGNumber == 0 {
 				Expect(cluster.AWS().AdditionalComputeSecurityGroupIds()).To(BeEmpty())
@@ -262,8 +270,12 @@ var _ = Describe("Verify cluster", func() {
 		})
 
 	It("worker disk size is set correctly - [id:69143]",
-		ci.Day1Post, ci.Critical, ci.NonHCPCluster,
+		ci.Day1Post, ci.Critical,
 		func() {
+			if profile.GetClusterType().HCP {
+				Skip("Test can run only on Classic cluster")
+			}
+
 			switch profile.WorkerDiskSize {
 			case 0:
 				Expect(cluster.Nodes().ComputeRootVolume().AWS().Size()).To(Equal(300))
@@ -302,7 +314,10 @@ var _ = Describe("Verify cluster", func() {
 		}
 	})
 
-	It("imdsv2 value is set correctly - [id:63950]", ci.Day1Post, ci.Critical, ci.NonHCPCluster, func() {
+	It("imdsv2 value is set correctly - [id:63950]", ci.Day1Post, ci.Critical, func() {
+		if profile.GetClusterType().HCP {
+			Skip("Test can run only on Classic cluster")
+		}
 		if profile.Ec2MetadataHttpTokens != "" {
 			Expect(string(cluster.AWS().Ec2MetadataHttpTokens())).To(Equal(profile.Ec2MetadataHttpTokens))
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `NonClassicCluster` and `NonHCPCluster` as the logic is now done into the code itself.

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-8959

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
