### PR TITLE
OCM-9263 | ci: Automate ids 72960/72954/72513/72512

### DIFF
--- a/tests/e2e/classic_machine_pool_test.go
+++ b/tests/e2e/classic_machine_pool_test.go
@@ -58,8 +58,11 @@ var _ = Describe("Create MachinePool", ci.Day2, ci.FeatureMachinepool, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verify the parameters of the created machinepool")
-		mpOut, err := mpService.Output()
+		mpsOut, err := mpService.Output()
 		Expect(err).ToNot(HaveOccurred())
+		Expect(len(mpsOut.MachinePools)).To(Equal(1))
+		mpOut := mpsOut.MachinePools[0]
+
 		mpResponseBody, err := cms.RetrieveClusterMachinePool(ci.RHCSConnection, clusterID, name)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(mpResponseBody.Replicas()).To(Equal(mpOut.Replicas))

--- a/tests/e2e/kubelet_config_test.go
+++ b/tests/e2e/kubelet_config_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Kubelet config", func() {
 		kcArgs = &exe.KubeletConfigArgs{
 			PodPidsLimit:        helper.IntPointer(podPidsLimit),
 			Cluster:             helper.StringPointer(clusterID),
-			KubeLetConfigNumber: helper.IntPointer(2),
+			KubeletConfigNumber: helper.IntPointer(2),
 			NamePrefix:          helper.StringPointer("kube-70128"),
 		}
 		_, err = kcService.Apply(kcArgs)
@@ -110,7 +110,7 @@ var _ = Describe("Kubelet config", func() {
 			Expect(err).ToNot(HaveOccurred())
 			kubeletconfigs, err = kcService.Output()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(kubeletconfigs)).To(Equal(*kcArgs.KubeLetConfigNumber))
+			Expect(len(kubeletconfigs)).To(Equal(*kcArgs.KubeletConfigNumber))
 		} else {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("classic cluster can only have 1 kubeletconfig"))
@@ -143,11 +143,14 @@ var _ = Describe("Kubelet config", func() {
 		if cluster.Hypershift().Enabled() {
 			By("Create more than 100 kubeletconfig is not allowed")
 			kcArgs.PodPidsLimit = helper.IntPointer(4096)
-			kcArgs.KubeLetConfigNumber = helper.IntPointer(300)
+			kcArgs.KubeletConfigNumber = helper.IntPointer(300)
 			kcArgs.NamePrefix = helper.StringPointer("kc-70129")
 			_, err = kcService.Apply(kcArgs)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("Maximum allowed is '100'"))
+
+			// Create the TF vars file to make sure created Kubeletconfigs are deleted
+			kcService.WriteTFVars(kcArgs)
 		}
 
 	})

--- a/tests/tf-manifests/rhcs/machine-pools/hcp/main.tf
+++ b/tests/tf-manifests/rhcs/machine-pools/hcp/main.tf
@@ -23,9 +23,10 @@ locals {
   }
 }
 
-resource "rhcs_hcp_machine_pool" "mp" {
+resource "rhcs_hcp_machine_pool" "mps" {
+  count                        = var.mp_count
   cluster                      = var.cluster
-  name                         = var.name
+  name                         = var.mp_count == 1 ? var.name : "${var.name}-${count.index}"
   subnet_id                    = var.subnet_id
   labels                       = var.labels
   replicas                     = var.replicas

--- a/tests/tf-manifests/rhcs/machine-pools/hcp/output.tf
+++ b/tests/tf-manifests/rhcs/machine-pools/hcp/output.tf
@@ -1,37 +1,14 @@
-output "machine_pool_id" {
-  value = rhcs_hcp_machine_pool.mp.id
-}
-output "name" {
-  value = rhcs_hcp_machine_pool.mp.name
-}
-output "cluster_id" {
-  value = rhcs_hcp_machine_pool.mp.cluster
-}
-
-output "replicas" {
-  value = rhcs_hcp_machine_pool.mp.replicas
-}
-
-output "machine_type" {
-  value = rhcs_hcp_machine_pool.mp.aws_node_pool.instance_type
-}
-
-output "autoscaling_enabled" {
-  value = rhcs_hcp_machine_pool.mp.autoscaling
-}
-
-output "labels" {
-  value = rhcs_hcp_machine_pool.mp.labels
-}
-
-output "taints" {
-  value = rhcs_hcp_machine_pool.mp.taints
-}
-
-output "tuning_configs" {
-  value = rhcs_hcp_machine_pool.mp.tuning_configs
-}
-
-output "kubelet_configs" {
-  value = rhcs_hcp_machine_pool.mp.kubelet_configs
+output "machine_pools" {
+  value = [ for mp in rhcs_hcp_machine_pool.mps : {
+    machine_pool_id: mp.id
+    name: mp.name
+    cluster_id: mp.cluster
+    replicas: mp.replicas
+    machine_type: mp.aws_node_pool.instance_type
+    autoscaling_enabled: mp.autoscaling.enabled
+    labels: mp.labels
+    taints: mp.taints
+    tuning_configs: mp.tuning_configs
+    kubelet_configs: mp.kubelet_configs
+  } ]
 }

--- a/tests/tf-manifests/rhcs/machine-pools/hcp/variable.tf
+++ b/tests/tf-manifests/rhcs/machine-pools/hcp/variable.tf
@@ -1,3 +1,8 @@
+variable mp_count {
+  type = number
+  default = 1
+}
+
 variable "cluster" {
   type    = string
   default = null

--- a/tests/tf-manifests/rhcs/resource-import/main.tf
+++ b/tests/tf-manifests/rhcs/resource-import/main.tf
@@ -15,11 +15,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster_import" {
   cloud_region   = ""
   name           = ""
 }
-resource "rhcs_cluster_rosa_classic" "rosa_import_no_cluster_id" {
-  aws_account_id = ""
-  cloud_region   = ""
-  name           = ""
-}
+
 resource "rhcs_identity_provider" "idp_google_import" {
   name    = ""
   cluster = ""
@@ -62,4 +58,29 @@ resource "rhcs_default_ingress" "default_ingress" {
   cluster            = ""
   load_balancer_type = ""
   id                 = ""
+}
+
+## HCP resources
+
+resource "rhcs_cluster_rosa_hcp" "rosa_hcp_cluster_import" {
+  aws_account_id         = ""
+  aws_billing_account_id = ""
+  cloud_region           = ""
+  name                   = ""
+  availability_zones     = []
+  aws_subnet_ids         = []
+  sts                    = {}
+}
+
+resource "rhcs_hcp_machine_pool" "mp_import" {
+  name        = ""
+  cluster     = ""
+  auto_repair = true
+  aws_node_pool = {
+    instance_type = ""
+  }
+  autoscaling = {
+    enabled = false
+  }
+  subnet_id = ""
 }

--- a/tests/utils/cms/cms.go
+++ b/tests/utils/cms/cms.go
@@ -331,6 +331,22 @@ func RetrieveControlPlaneUpgradePolicy(connection *client.Connection, clusterID 
 	return resp, err
 }
 
+// NodePool Upgrade policies related
+func ListNodePoolUpgradePolicies(connection *client.Connection, clusterID string, npID string, params ...map[string]interface{}) (*cmv1.NodePoolUpgradePoliciesListResponse, error) {
+	request := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).NodePools().NodePool(npID).UpgradePolicies().List()
+	for _, param := range params {
+		for k, v := range param {
+			request = request.Parameter(k, v)
+		}
+	}
+	return request.Send()
+}
+
+func RetrieveNodePoolUpgradePolicy(connection *client.Connection, clusterID string, npID string, upgradepolicyID string) (*cmv1.NodePoolUpgradePolicyGetResponse, error) {
+	resp, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).NodePools().NodePool(npID).UpgradePolicies().NodePoolUpgradePolicy(upgradepolicyID).Get().Send()
+	return resp, err
+}
+
 // RetrieveCurrentAccount return the response of retrieve current account
 func RetrieveCurrentAccount(connection *client.Connection, params ...map[string]interface{}) (resp *v1.CurrentAccountGetResponse, err error) {
 	if len(params) > 1 {

--- a/tests/utils/exec/kubelet-config.go
+++ b/tests/utils/exec/kubelet-config.go
@@ -7,7 +7,7 @@ import (
 type KubeletConfigArgs struct {
 	Cluster             *string `hcl:"cluster"`
 	PodPidsLimit        *int    `hcl:"pod_pids_limit"`
-	KubeLetConfigNumber *int    `hcl:"kubelet_config_number"`
+	KubeletConfigNumber *int    `hcl:"kubelet_config_number"`
 	NamePrefix          *string `hcl:"name_prefix"`
 }
 
@@ -29,6 +29,7 @@ type KubeletConfigService interface {
 	Destroy() (string, error)
 
 	ReadTFVars() (*KubeletConfigArgs, error)
+	WriteTFVars(args *KubeletConfigArgs) error
 	DeleteTFVars() error
 }
 
@@ -78,6 +79,11 @@ func (svc *kubeletConfigService) ReadTFVars() (*KubeletConfigArgs, error) {
 	args := &KubeletConfigArgs{}
 	err := svc.tfExecutor.ReadTerraformVars(args)
 	return args, err
+}
+
+func (svc *kubeletConfigService) WriteTFVars(args *KubeletConfigArgs) error {
+	err := svc.tfExecutor.WriteTerraformVars(args)
+	return err
 }
 
 func (svc *kubeletConfigService) DeleteTFVars() error {

--- a/tests/utils/exec/machine-pools.go
+++ b/tests/utils/exec/machine-pools.go
@@ -9,6 +9,7 @@ import (
 )
 
 type MachinePoolArgs struct {
+	Count                    *int                 `hcl:"mp_count"`
 	Cluster                  *string              `hcl:"cluster"`
 	Name                     *string              `hcl:"name"`
 	MachineType              *string              `hcl:"machine_type"`
@@ -36,6 +37,10 @@ type MachinePoolArgs struct {
 	KubeletConfigs             *string   `hcl:"kubelet_configs"`
 }
 
+type MachinePoolsOutput struct {
+	MachinePools []MachinePoolOutput `json:"machine_pools,omitempty"`
+}
+
 type MachinePoolOutput struct {
 	ID                 string             `json:"machine_pool_id,omitempty"`
 	Name               string             `json:"name,omitempty"`
@@ -46,6 +51,7 @@ type MachinePoolOutput struct {
 	Labels             map[string]string  `json:"labels,omitempty"`
 	Taints             []MachinePoolTaint `json:"taints,omitempty"`
 	TuningConfigs      []string           `json:"tuning_configs,omitempty"`
+	KubeletConfigs     string             `json:"kubelet_configs"`
 }
 
 type MachinePoolTaint struct {
@@ -58,7 +64,7 @@ type MachinePoolService interface {
 	Init() error
 	Plan(args *MachinePoolArgs) (string, error)
 	Apply(args *MachinePoolArgs) (string, error)
-	Output() (*MachinePoolOutput, error)
+	Output() (*MachinePoolsOutput, error)
 	Destroy() (string, error)
 
 	ReadTFVars() (*MachinePoolArgs, error)
@@ -94,8 +100,8 @@ func (svc *machinePoolService) Apply(args *MachinePoolArgs) (string, error) {
 	return svc.tfExecutor.RunTerraformApply(args)
 }
 
-func (svc *machinePoolService) Output() (*MachinePoolOutput, error) {
-	var output MachinePoolOutput
+func (svc *machinePoolService) Output() (*MachinePoolsOutput, error) {
+	var output MachinePoolsOutput
 	err := svc.tfExecutor.RunTerraformOutputIntoObject(&output)
 	if err != nil {
 		return nil, err

--- a/tests/utils/log/logger.go
+++ b/tests/utils/log/logger.go
@@ -11,7 +11,7 @@ func GetLogger() *Log {
 	// Create the logger
 	logger := logging.New()
 	// Set logger level for your debug command
-	logger.SetLevel(logging.DebugLevel) // TODO set back
+	logger.SetLevel(logging.InfoLevel)
 	return &Log{logger: logger, redActSensitive: true}
 }
 


### PR DESCRIPTION
<details>
<summary>72512</summary>
time="2024-07-01T22:06:30+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"

time="2024-07-01T22:06:30+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"

[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0mtime="2024-07-01T22:06:35+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"

time="2024-07-01T22:06:35+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:06:35+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config"

time="2024-07-01T22:06:35+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc/rosa-hcp"

time="2024-07-01T22:06:40+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"

time="2024-07-01T22:06:47+02:00" level=info msg="Running terraform apply against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:06:51+02:00" level=info msg="Write tfvars file"

time="2024-07-01T22:06:52+02:00" level=info msg="Running terraform apply against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:06:59+02:00" level=info msg="Write tfvars file"

time="2024-07-01T22:06:59+02:00" level=info msg="Running terraform destroy against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:07:02+02:00" level=info msg="Deleting tfvars file"

[38;5;10m•[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m

  

[38;5;10m[1mRan 1 of 115 Specs in 32.391 seconds[0m

[38;5;10m[1mSUCCESS![0m -- [38;5;10m[1m1 Passed[0m | [38;5;9m[1m0 Failed[0m | [38;5;11m[1m0 Pending[0m | [38;5;14m[1m114 Skipped[0m

PASS

  

Ginkgo ran 1 suite in 38.351923519s

Test Suite Passed
</details>

<details>
<summary>72513</summary>
time="2024-07-01T22:07:31+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"

time="2024-07-01T22:07:31+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"

[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0mtime="2024-07-01T22:07:36+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"

time="2024-07-01T22:07:36+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:07:36+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config"

time="2024-07-01T22:07:37+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc/rosa-hcp"

time="2024-07-01T22:07:42+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"

time="2024-07-01T22:07:48+02:00" level=info msg="Got versions [0xc000976a40 0xc000976d40 0xc000976d80 0xc000976dc0 0xc000976e00 0xc000976e40 0xc000976e80 0xc000976ec0 0xc000976a80 0xc000976ac0 0xc000976b00 0xc000976b40 0xc000976bc0 0xc000976c00 0xc000976c40 0xc000976c80 0xc000976cc0 0xc000976d00]"

time="2024-07-01T22:07:48+02:00" level=info msg="Running terraform apply against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:07:53+02:00" level=info msg="Write tfvars file"

time="2024-07-01T22:07:53+02:00" level=info msg="Running terraform apply against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:07:59+02:00" level=info msg="Write tfvars file"

time="2024-07-01T22:07:59+02:00" level=info msg="Running terraform destroy against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:08:04+02:00" level=info msg="Deleting tfvars file"

[38;5;10m•[0m[38;5;14mS[0m

  

[38;5;10m[1mRan 1 of 115 Specs in 32.291 seconds[0m

[38;5;10m[1mSUCCESS![0m -- [38;5;10m[1m1 Passed[0m | [38;5;9m[1m0 Failed[0m | [38;5;11m[1m0 Pending[0m | [38;5;14m[1m114 Skipped[0m

PASS

  

Ginkgo ran 1 suite in 35.300462389s

Test Suite Passed
</details>

<details>
<summary>72960</summary>
Will run [1m1[0m of [1m115[0m specs

time="2024-07-01T22:10:31+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"

time="2024-07-01T22:10:31+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"

[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0mtime="2024-07-01T22:10:36+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"

time="2024-07-01T22:10:36+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:10:37+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config"

time="2024-07-01T22:10:37+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc/rosa-hcp"

time="2024-07-01T22:10:42+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/resource-import"

time="2024-07-01T22:10:42+02:00" level=info msg="Running terraform apply against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:10:46+02:00" level=info msg="Write tfvars file"

time="2024-07-01T22:10:46+02:00" level=info msg="Running terraform import against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/resource-import"

time="2024-07-01T22:10:48+02:00" level=info msg="Running terraform state against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/resource-import"

time="2024-07-01T22:10:48+02:00" level=info msg="Running terraform state against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/resource-import"

time="2024-07-01T22:10:48+02:00" level=info msg="Running terraform state against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/resource-import"

time="2024-07-01T22:10:49+02:00" level=info msg="Running terraform destroy against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:10:52+02:00" level=info msg="Deleting tfvars file"

[38;5;10m•[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m

  

[38;5;10m[1mRan 1 of 115 Specs in 20.881 seconds[0m

[38;5;10m[1mSUCCESS![0m -- [38;5;10m[1m1 Passed[0m | [38;5;9m[1m0 Failed[0m | [38;5;11m[1m0 Pending[0m | [38;5;14m[1m114 Skipped[0m

PASS

  

Ginkgo ran 1 suite in 24.732937322s

Test Suite Passed
</details>

<details>
<summary>72954</summary>
Will run [1m1[0m of [1m115[0m specs

time="2024-07-01T22:11:08+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"

time="2024-07-01T22:11:08+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"

[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0mtime="2024-07-01T22:11:13+02:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[admin_enabled:false autoscale:true byok:true byovpc:true channel_group:candidate cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge compute_replicas:6 etcd_encryption:true fips:false kms_key_arn:true labeling:false major_version:4.15 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ version: version_pattern:latest zones:a,b,c]"

time="2024-07-01T22:11:13+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:11:13+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/tuning-config"

time="2024-07-01T22:11:13+02:00" level=info msg="Running terraform init against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/aws/vpc/rosa-hcp"

time="2024-07-01T22:11:18+02:00" level=info msg="Running terraform apply against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:11:25+02:00" level=info msg="Write tfvars file"

time="2024-07-01T22:11:25+02:00" level=info msg="Running terraform destroy against the dir /home/tradisso/projects/openshift/terraform-provider-rhcs/tests/tf-manifests/rhcs/machine-pools/hcp"

time="2024-07-01T22:11:30+02:00" level=info msg="Deleting tfvars file"

[38;5;10m•[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m[38;5;14mS[0m

  

[38;5;10m[1mRan 1 of 115 Specs in 22.190 seconds[0m

[38;5;10m[1mSUCCESS![0m -- [38;5;10m[1m1 Passed[0m | [38;5;9m[1m0 Failed[0m | [38;5;11m[1m0 Pending[0m | [38;5;14m[1m114 Skipped[0m

PASS

  

Ginkgo ran 1 suite in 24.714871364s

Test Suite Passed
</details>

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-9263

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
