### PR TITLE
OCM-9358 | ci: TF destroy should ignore missing tfvars file

### DIFF
--- a/tests/utils/helper/file.go
+++ b/tests/utils/helper/file.go
@@ -8,3 +8,14 @@ import (
 func DeleteFile(filename string) error {
 	return os.Remove(filename)
 }
+
+func IsFileExists(filePath string) (bool, error) {
+	_, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-9358

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
