### PR TITLE
OCM-9457 | ci: Fix `oc` command issue on ubi8

### DIFF
--- a/build/ci-tf-e2e.Dockerfile
+++ b/build/ci-tf-e2e.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 WORKDIR /root
 
 # oc


### PR DESCRIPTION
**What this PR does / why we need it**:
`oc` command is failing on CI due to glibc needed by the command line

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-9457

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
