### PR TITLE
OCM-9975 | ci: Remove `NonClassicCluster` and `NonHCPCluster` labels

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -90,7 +90,6 @@ Please read the structure and contribte code to the correct place
 * Label your case with importance defined in terraform-provider-rhcs/tests/ci/labels.go
 * Label your case with ***CI.Day1Post/CI.Day2/CI.Day3*** according to the case runtime
 * Label your case with ***CI.Exclude*** if it fails CI all  the time and you can't fix it in time
-* Label you case with ***CI.NonClassicCluster/CI.NonHCPCluster*** if it does not fit a type of cluster
 
 ## Running
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-9975

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
