### PR TITLE
OCM-10439 | fix: Set component_routes to empty object will cause provider bug

### DIFF
--- a/provider/defaultingress/classic/resource.go
+++ b/provider/defaultingress/classic/resource.go
@@ -509,7 +509,11 @@ func validateDefaultIngress(ctx context.Context, state *DefaultIngress, diags di
 		tflog.Error(ctx, msg)
 		return fmt.Errorf(msg)
 	}
-
+	if !state.ComponentRoutes.IsNull() && len(state.ComponentRoutes.Elements()) == 0 {
+		msg := "Component route cannot be empty, if you would like to reset whole component route please remove the key instead"
+		tflog.Error(ctx, msg)
+		return fmt.Errorf(msg)
+	}
 	for _, v := range state.ComponentRoutes.Elements() {
 		object, ok := v.(types.Object)
 		if !ok {


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:
 Set component_routes to empty object will cause provider bug
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #
[OCM-10439](https://issues.redhat.com//browse/OCM-10439)
**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
