### PR TITLE
OCM-10607 | ci: fix the cluster leak issue

### DIFF
--- a/tests/e2e/idps_test.go
+++ b/tests/e2e/idps_test.go
@@ -459,7 +459,7 @@ var _ = Describe("Identity Providers", ci.Day2, ci.FeatureIDP, func() {
 
 				// login to the cluster using cluster-admin creds
 				username := constants.ClusterAdminUser
-				password := helper.GetClusterAdminPassword()
+				password, _ := helper.GetClusterAdminPassword()
 				Expect(password).ToNot(BeEmpty())
 
 				ocAtter = &openshift.OcAttributes{

--- a/tests/e2e/verification_post_day1_test.go
+++ b/tests/e2e/verification_post_day1_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Verify cluster", func() {
 			server := getResp.Body().API().URL()
 
 			username := constants.ClusterAdminUser
-			password := helper.GetClusterAdminPassword()
+			password, _ := helper.GetClusterAdminPassword()
 			Expect(password).ToNot(BeEmpty())
 
 			ocAtter := &openshift.OcAttributes{

--- a/tests/utils/constants/config.go
+++ b/tests/utils/constants/config.go
@@ -36,6 +36,7 @@ type RHCSconfig struct {
 	RHCSClusterName       string `env:"RHCS_CLUSTER_NAME" yaml:"clusterName,omitempty"`
 	RHCSClusterNamePrefix string `env:"RHCS_CLUSTER_NAME_PREFIX" yaml:"clusterNamePrefix,omitempty"`
 	RHCSClusterNameSuffix string `env:"RHCS_CLUSTER_NAME_SUFFIX" yaml:"clusterNameSuffix,omitempty"`
+	ClusterNameFile       string
 	ComputeMachineType    string `env:"COMPUTE_MACHINE_TYPE" yaml:"computeMachineType,omitempty"`
 }
 
@@ -65,6 +66,7 @@ func init() {
 	RHCS.RhcsOutputDir = GetRHCSOutputDir()
 	RHCS.KubeConfigDir = GetKubeConfigDir()
 	RHCS.YAMLProfilesDir = path.Join(RHCS.RootDir, "tests", "ci", "profiles")
+	RHCS.ClusterNameFile = path.Join(RHCS.RhcsOutputDir, "cluster-name")
 }
 
 // ocmEnv retrieve the env name based on

--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -510,13 +510,16 @@ func GenerateClusterName(profileName string) string {
 	return strings.Join(clusterNameParts, constants.HyphenConnector)
 }
 
-func GetClusterAdminPassword() string {
-	path := fmt.Sprintf(path.Join(constants.GetRHCSOutputDir(), constants.ClusterAdminUser))
-	b, err := os.ReadFile(path)
+func ReadFile(absPath string) (string, error) {
+	b, err := os.ReadFile(absPath)
 	if err != nil {
-		fmt.Print(err)
+		return "", err
 	}
-	return string(b)
+	return string(b), nil
+}
+func GetClusterAdminPassword() (string, error) {
+	path := fmt.Sprintf(path.Join(constants.GetRHCSOutputDir(), constants.ClusterAdminUser))
+	return ReadFile(path)
 }
 
 var (


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:
Cluster state file cannot be recorded once process terminated. This caused the resource leak in pull requests testing.
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #
[OCM-10607](https://issues.redhat.com//browse/OCM-10607)
**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
