### PR TITLE
OCM-10640 | ci: Fix destroy resources if error in apply

### DIFF
--- a/tests/e2e/negative_day_one_test.go
+++ b/tests/e2e/negative_day_one_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -60,7 +61,11 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 		}
 		Expect(err).ToNot(HaveOccurred())
 
-		originalClusterVarsFile, err = exec.WriteTemporaryTFVarsFile(originalClusterArgs)
+		// Save original cluster values before any update
+		f, err := os.CreateTemp("", "tfvars-")
+		Expect(err).ToNot(HaveOccurred())
+		originalClusterVarsFile = f.Name()
+		err = exec.WriteTFvarsFile(originalClusterArgs, originalClusterVarsFile)
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In e2e tests, if an error occurs during apply, some resources may have been created already. But the TF vars file is not saved, thus the destroy will not occurs.
This fix is storing the values in a tfvars tmp file and destroy will consider it if existing if the default TF vars file is not existing.

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-10640

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
