### PR TITLE
OCM-10684 | ci: Fix tags issue when creating default MP

### DIFF
--- a/provider/machinepool/classic/machine_pool_resource.go
+++ b/provider/machinepool/classic/machine_pool_resource.go
@@ -1093,6 +1093,8 @@ func populateState(ctx context.Context, object *cmv1.MachinePool, state *Machine
 			if err != nil {
 				return err
 			}
+		} else {
+			state.AwsTags = types.MapNull(types.StringType)
 		}
 	} else {
 		state.AwsTags = types.MapNull(types.StringType)


### PR DESCRIPTION
**What this PR does / why we need it**:
When creating the default Machinepool, the provider is first importing it as already existing and then performing an update.
One condition was missing in the Populate State, when importing.

**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/OCM-10684

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
