### PR TITLE
OCM-10609 | ci: Tuning Configs support yaml

### DIFF
--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -5,6 +5,7 @@ import (
 	// nolint
 
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -538,12 +539,18 @@ var _ = Describe("HCP MachinePool", ci.Day2, ci.FeatureMachinepool, func() {
 			By("Create tuning configs")
 			tcCount := 3
 			tcName := "tc"
+			var specs []exec.TuningConfigSpec
+			for i := 0; i < tcCount; i++ {
+				spec := helper.NewTuningConfigSpecRootStub(fmt.Sprintf("%s-%d", tcName, i), 65, 10)
+				tc, err := json.Marshal(spec)
+				Expect(err).ToNot(HaveOccurred())
+				specs = append(specs, exec.NewTuningConfigSpecFromString(string(tc)))
+			}
 			tcArgs = &exec.TuningConfigArgs{
-				Cluster:           helper.StringPointer(clusterID),
-				Name:              helper.StringPointer(tcName),
-				Count:             helper.IntPointer(tcCount),
-				SpecVMDirtyRatios: helper.IntSlicePointer([]int{65, 65, 65}),
-				SpecPriorities:    helper.IntSlicePointer([]int{10, 10, 10}),
+				Cluster: helper.StringPointer(clusterID),
+				Name:    helper.StringPointer(tcName),
+				Count:   helper.IntPointer(tcCount),
+				Specs:   &specs,
 			}
 			_, err = tcService.Apply(tcArgs)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/tf-manifests/rhcs/tuning-config/main.tf
+++ b/tests/tf-manifests/rhcs/tuning-config/main.tf
@@ -10,45 +10,10 @@ terraform {
 provider "rhcs" {
 }
 
-locals {
-  defaultSpec = jsonencode(
-    {
-      "profile" : [
-        {
-          "data" : "[main]\nsummary=Custom OpenShift profile\ninclude=openshift-node\n\n[sysctl]\nvm.dirty_ratio=\"65\"\n",
-          "name" : "tuned-profile"
-        }
-      ],
-      "recommend" : [
-        {
-          "priority" : 10,
-          "profile" : "tuned-profile"
-        }
-      ]
-    }
-  )
-  spec = var.spec != null ? (var.spec != "" ? jsonencode(var.spec) : var.spec) : local.defaultSpec
-}
-
 resource "rhcs_tuning_config" "tcs" {
   count = var.tc_count
 
   cluster = var.cluster
   name    = var.tc_count == 1 ? var.name : "${var.name}-${count.index}"
-  spec = var.tc_count == 1 ? local.spec : jsonencode(
-    {
-      "profile" : [
-        {
-          "data" : "[main]\nsummary=Custom OpenShift profile\ninclude=openshift-node\n\n[sysctl]\nvm.dirty_ratio=\"${var.spec_vm_dirty_ratios[count.index]}\"\n",
-          "name" : "tuned-${count.index}-profile"
-        }
-      ],
-      "recommend" : [
-        {
-          "priority" : var.spec_priorities[count.index],
-          "profile" : "tuned-${count.index}-profile"
-        }
-      ]
-    }
-  )
+  spec    = var.specs[count.index].spec_type == "file" ? file(var.specs[count.index].spec_value) : var.specs[count.index].spec_value
 }

--- a/tests/tf-manifests/rhcs/tuning-config/variable.tf
+++ b/tests/tf-manifests/rhcs/tuning-config/variable.tf
@@ -14,21 +14,10 @@ variable "tc_count" {
   default = 1
 }
 
-variable "spec" {
-  type        = string
-  default     = null
-  description = "To use if tc_count == 1"
+variable "specs" {
+  type = list(object({
+    spec_type  = string
+    spec_value = string
+  }))
+  description = "List of spec objects (spec_type = [\"file\" or \"string\"] and spec_value) to use. Length of that list should be the same as tc_count"
 }
-
-variable "spec_vm_dirty_ratios" {
-  type        = list(number)
-  default     = null
-  description = "To use if tc_count != 1"
-}
-
-variable "spec_priorities" {
-  type        = list(number)
-  default     = null
-  description = "To use if tc_count != 1"
-}
-

--- a/tests/utils/exec/tuning-configs.go
+++ b/tests/utils/exec/tuning-configs.go
@@ -2,16 +2,21 @@ package exec
 
 import (
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
 )
 
 type TuningConfigArgs struct {
-	Cluster           *string `hcl:"cluster"`
-	Name              *string `hcl:"name"`
-	Count             *int    `hcl:"tc_count"`
-	Spec              *string `hcl:"spec"`
-	SpecVMDirtyRatios *[]int  `hcl:"spec_vm_dirty_ratios"`
-	SpecPriorities    *[]int  `hcl:"spec_priorities"`
+	Cluster *string             `hcl:"cluster"`
+	Name    *string             `hcl:"name"`
+	Count   *int                `hcl:"tc_count"`
+	Specs   *[]TuningConfigSpec `hcl:"specs"`
 }
+
+type TuningConfigSpec struct {
+	Type  *string `cty:"spec_type"`
+	Value *string `cty:"spec_value"`
+}
+
 type TuningConfigOutput struct {
 	Names []string `json:"names,omitempty"`
 	Specs []string `json:"specs,omitempty"`
@@ -78,4 +83,18 @@ func (svc *tuningConfigService) ReadTFVars() (*TuningConfigArgs, error) {
 
 func (svc *tuningConfigService) DeleteTFVars() error {
 	return svc.tfExecutor.DeleteTerraformVars()
+}
+
+func NewTuningConfigSpecFromString(specValue string) TuningConfigSpec {
+	return TuningConfigSpec{
+		Type:  helper.StringPointer("string"),
+		Value: &specValue,
+	}
+}
+
+func NewTuningConfigSpecFromFile(specFile string) TuningConfigSpec {
+	return TuningConfigSpec{
+		Type:  helper.StringPointer("file"),
+		Value: &specFile,
+	}
 }

--- a/tests/utils/helper/file.go
+++ b/tests/utils/helper/file.go
@@ -1,7 +1,10 @@
 package helper
 
 import (
+	"encoding/json"
 	"os"
+
+	. "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/log"
 )
 
 // Delete a file
@@ -18,4 +21,40 @@ func IsFileExists(filePath string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func CreateTempFileWithContent(fileContent string) (string, error) {
+	return CreateTempFileWithPrefixAndContent("tmpfile", fileContent)
+}
+
+func CreateTempFileWithPrefixAndContent(prefix string, fileContent string) (string, error) {
+	f, err := os.CreateTemp("", prefix+"-")
+	if err != nil {
+		return "", err
+	}
+	return CreateFileWithContent(f.Name(), fileContent)
+}
+
+// Write string to a file
+func CreateFileWithContent(fileAbsPath string, content interface{}) (string, error) {
+	var err error
+	switch content := content.(type) {
+	case string:
+		err = os.WriteFile(fileAbsPath, []byte(content), 0644) // #nosec G306
+	case []byte:
+		err = os.WriteFile(fileAbsPath, content, 0644) // #nosec G306
+	case interface{}:
+		var marshedContent []byte
+		marshedContent, err = json.Marshal(content)
+		if err != nil {
+			return fileAbsPath, err
+		}
+		err = os.WriteFile(fileAbsPath, marshedContent, 0644) // #nosec G306
+	}
+
+	if err != nil {
+		Logger.Errorf("Failed to write to file: %s", err)
+		return "", err
+	}
+	return fileAbsPath, err
 }

--- a/tests/utils/helper/tuningconfig.go
+++ b/tests/utils/helper/tuningconfig.go
@@ -1,0 +1,41 @@
+package helper
+
+import "fmt"
+
+type TuningConfigSpecRoot struct {
+	Profile   []TuningConfigSpecProfile   `json:"profile,omitempty" yaml:"profile,omitempty"`
+	Recommend []TuningConfigSpecRecommend `json:"recommend,omitempty" yaml:"recommend,omitempty"`
+}
+
+type TuningConfigSpecProfile struct {
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+	Data string `yaml:"data,omitempty" json:"data,omitempty"`
+}
+
+type TuningConfigSpecRecommend struct {
+	Priority int    `yaml:"priority,omitempty" json:"priority,omitempty"`
+	Profile  string `yaml:"profile,omitempty" json:"profile,omitempty"`
+}
+
+func NewTuningConfigSpecRootStub(tcName string, vmDirtyRatio int, priority int) TuningConfigSpecRoot {
+	return TuningConfigSpecRoot{
+		Profile: []TuningConfigSpecProfile{
+			{
+				Data: NewTuningConfigSpecProfileData(vmDirtyRatio),
+				Name: tcName + "-profile",
+			},
+		},
+		Recommend: []TuningConfigSpecRecommend{
+			{
+				Priority: priority,
+				Profile:  tcName + "-profile",
+			},
+		},
+	}
+}
+
+func NewTuningConfigSpecProfileData(vmDirtyRatio int) string {
+	return fmt.Sprintf("[main]\nsummary=Custom OpenShift profile\ninclude=openshift-node\n\n"+
+		"[sysctl]\nvm.dirty_ratio=\"%d\"\n",
+		vmDirtyRatio)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Use yaml for Tuning Config spec

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-10609

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
