### PR TITLE
OCM-10961 | fix: warning message is referring to classic on HCP clusters

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -21,12 +21,13 @@ Code contributions are done by opening a pull request (PR). Please be sure that 
 * [golang](https://go.dev/) - version 1.21.x (to build the provider plugin)
   - You also need to correctly setup a `GOPATH`, as well as adding `$GOPATH/bin` to your `$PATH`.
   - Fork and clone the repository to `$GOPATH/src/github.com/hashicorp/terraform-provider-rhcs` by the `git clone` command
-  - Create a new branch `git switch -c <brnach-name>`
+  - Create a new branch `git switch -c <branch-name>`
   - Run `go mod download` to download all the modules in the dependency graph.
   - Try building the project by running `make build`
 
 ### 3. Make your changes with a Coding Style
-Use `gofmt` in order to format your code.
+Use `gofmt` in order to format your code. You can invoke the formatting before committing with `make fmt`.
+
 Keep the code clean and readable. Functions should be concise, exit the function as early as possible.
 Best coding standards for golang can be found [here](https://go.dev/doc/effective_go).
 
@@ -38,7 +39,7 @@ We are holding three types of tests that must pass for a PR to finally be accept
 Both `unit-tests` and `subsystem`, can be run locally before submitting a PR, by running `make tests`.
 
 ### 5. Manual testing and debugging using the locally compiled RHCS Provider binary
-Manual testing should be performed before opening a PR in order to make sure there isn't any regression behavior in the provider. You can find [here an example for that](https://github.com/terraform-redhat/terraform-rhcs-rosa/tree/main/examples/rosa-classic-with-unmanaged-oidc)  
+Manual testing should be performed before opening a PR in order to make sure there isn't any regression behavior in the provider. You can find [here an example for that](https://github.com/terraform-redhat/terraform-rhcs-rosa/tree/main/examples/rosa-classic-public-with-unmanaged-oidc) 
 After compiling the RHCS provider, debugging terraform provider can be difficult. But here are a some tips to make your life easier.
 
 First, Make sure you are using your local build of the provider. `make install` will compile the project and place the binary in the local `~/.terraform/` folder.
@@ -91,8 +92,9 @@ Types other than `fix:` and `feat:` are allowed:
 
 ## Related Documentation Links
 * [RHCS rosa module](https://github.com/terraform-redhat/terraform-rhcs-rosa) - for creating ROSA clusters much more easily.
+* [RHCS rosa HCP module](https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp/) -  for creating ROSA HCP clusters much more easily.
 * [ROSA project](https://docs.openshift.com/rosa/welcome/index.html) - RedHat Openshift Service on AWS (ROSA)
-* [OpenShift Cluster Management API](https://api.openshift.com/) - Since the RHCS provider uses OpenShift API's.
+* [OpenShift Cluster Management API](https://api.openshift.com/) - Since the RHCS provider uses OpenShift APIs.
 * [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) documentation. RHCS provider is leveraging this framework heavily.
-* [Debugging Terraform](https://developer.hashicorp.com/terraform/internals/debugging) - More info aboout Terraform Logging and Debugging
+* [Debugging Terraform](https://developer.hashicorp.com/terraform/internals/debugging) - More info about Terraform Logging and Debugging
 * [Terraform Language Documentation](https://developer.hashicorp.com/terraform/language) - Information about Terraform (resources and data sources for example) can be found in the

--- a/provider/defaultingress/hcp/resource.go
+++ b/provider/defaultingress/hcp/resource.go
@@ -211,7 +211,7 @@ func (r *DefaultIngressResource) Delete(ctx context.Context, req resource.Delete
 		"Cannot delete default ingress",
 		fmt.Sprintf(
 			"Cannot delete default ingress for cluster '%s'. "+
-				"ROSA Classic clusters must have default ingress. "+
+				"ROSA HCP clusters must have default ingress. "+
 				"It is being removed from the Terraform state only. "+
 				"To resume managing default ingress, import it again. "+
 				"It will be automatically deleted when the cluster is deleted.",

--- a/provider/machinepool/hcp/machine_pool_resource.go
+++ b/provider/machinepool/hcp/machine_pool_resource.go
@@ -1065,7 +1065,7 @@ func (r *HcpMachinePoolResource) Delete(ctx context.Context, req resource.Delete
 				"Cannot delete machine pool",
 				fmt.Sprintf(
 					"Cannot delete the last machine pool for cluster '%s'. "+
-						"ROSA Classic clusters must have at least one machine pool. "+
+						"ROSA HCP clusters must have at least one machine pool. "+
 						"It is being removed from the Terraform state only. "+
 						"To resume managing this machine pool, import it again. "+
 						"It will be automatically deleted when the cluster is deleted.",

--- a/tests/tf-manifests/aws/shared-vpc-policy-and-hosted-zone/main.tf
+++ b/tests/tf-manifests/aws/shared-vpc-policy-and-hosted-zone/main.tf
@@ -8,19 +8,19 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 locals {
-  prefix              = var.domain_prefix == null ? var.cluster_name : var.domain_prefix
+  prefix = var.domain_prefix == null ? var.cluster_name : var.domain_prefix
 }
 
 module "shared_vpc_policy_and_hosted_zone" {
   source  = "terraform-redhat/rosa-classic/rhcs//modules/shared-vpc-policy-and-hosted-zone"
   version = ">=1.6.3"
 
-  cluster_name = var.cluster_name
-  hosted_zone_base_domain = "${local.prefix}.${var.dns_domain_id}"
+  cluster_name              = var.cluster_name
+  hosted_zone_base_domain   = "${local.prefix}.${var.dns_domain_id}"
   ingress_operator_role_arn = var.ingress_operator_role_arn
-  installer_role_arn = var.installer_role_arn
-  name_prefix = var.cluster_name
-  subnets = var.subnets
-  target_aws_account = var.cluster_aws_account
-  vpc_id = var.vpc_id
+  installer_role_arn        = var.installer_role_arn
+  name_prefix               = var.cluster_name
+  subnets                   = var.subnets
+  target_aws_account        = var.cluster_aws_account
+  vpc_id                    = var.vpc_id
 }


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->
warning message is referring to classic on HCP clusters

Improve also a little CONTRIBUTE.md

The tests/ file is due to a run with `terraform format`.

**What this PR does / why we need it**:
Warning message is misleading

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes [OCM-10961](https://issues.redhat.com//browse/OCM-10961)

**Change type**
- [ ] New feature
- [X] Bug fix
- [ ] Build
- [ ] CI
- [X] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
