### PR TITLE
OCM-9892 | feat: add root disk size to TF provider

### DIFF
--- a/docs/data-sources/cluster_rosa_hcp.md
+++ b/docs/data-sources/cluster_rosa_hcp.md
@@ -69,6 +69,7 @@ data "rhcs_cluster_rosa_hcp" "cluster" {
 - `version` (String) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 - `wait_for_create_complete` (Boolean) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 - `wait_for_std_compute_nodes_complete` (Boolean) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
+- `worker_disk_size` (Number) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 
 <a id="nestedatt--registry_config"></a>
 ### Nested Schema for `registry_config`

--- a/docs/data-sources/hcp_machine_pool.md
+++ b/docs/data-sources/hcp_machine_pool.md
@@ -64,6 +64,7 @@ Read-Only:
 Optional:
 
 - `additional_security_group_ids` (List of String) Additional security group ids. After the creation of the resource, it is not possible to update the attribute value.
+- `disk_size` (Number) The root disk size, in GiB.
 - `ec2_metadata_http_tokens` (String) This value determines which EC2 Instance Metadata Service mode to use for EC2 instances in the nodes.This can be set as `optional` (IMDS v1 or v2) or `required` (IMDSv2 only). This feature is available from After the creation of the resource, it is not possible to update the attribute value.
 - `tags` (Map of String) Apply user defined tags to all machine pool resources created in AWS. After the creation of the resource, it is not possible to update the attribute value.
 

--- a/docs/resources/cluster_rosa_hcp.md
+++ b/docs/resources/cluster_rosa_hcp.md
@@ -84,6 +84,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa_sts_cluster" {
 - `version` (String) Desired version of OpenShift for the cluster, for example '4.11.0'. If version is greater than the currently running version, an upgrade will be scheduled.
 - `wait_for_create_complete` (Boolean) Wait until the cluster is either in a ready state or in an error state. The waiter has a timeout of 20 minutes, with the default value set to false
 - `wait_for_std_compute_nodes_complete` (Boolean) Wait until the cluster standard compute pools are created. The waiter has a timeout of 60 minutes, with the default value set to false. This can only be provided when also waiting for create completion.
+- `worker_disk_size` (Number) Compute node root disk size, in GiB. This attribute specifically applies to the Worker Machine Pool and becomes irrelevant once the resource is created. Any modifications to the initial Machine Pool should be made through the Terraform imported Machine Pool resource. For more details, refer to [Worker Machine Pool in ROSA Cluster](../guides/worker-machine-pool.md)
 
 ### Read-Only
 

--- a/docs/resources/hcp_machine_pool.md
+++ b/docs/resources/hcp_machine_pool.md
@@ -80,6 +80,7 @@ Required:
 Optional:
 
 - `additional_security_group_ids` (List of String) Additional security group ids. After the creation of the resource, it is not possible to update the attribute value.
+- `disk_size` (Number) Root disk size, in GiB. After the creation of the resource, it is not possible to update the attribute value.
 - `ec2_metadata_http_tokens` (String) This value determines which EC2 Instance Metadata Service mode to use for EC2 instances in the nodes.This can be set as `optional` (IMDS v1 or v2) or `required` (IMDSv2 only). This feature is available from After the creation of the resource, it is not possible to update the attribute value.
 - `tags` (Map of String) Apply user defined tags to all machine pool resources created in AWS.After the creation of the resource, it is not possible to update the attribute value.
 

--- a/provider/clusterrosa/hcp/datasource.go
+++ b/provider/clusterrosa/hcp/datasource.go
@@ -256,6 +256,10 @@ func (r *ClusterRosaHcpDatasource) Schema(ctx context.Context, req datasource.Sc
 				},
 				Computed: true,
 			},
+			"worker_disk_size": schema.Int64Attribute{
+				Description: deprecatedMessage,
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -370,6 +370,10 @@ func (r *ClusterRosaHcpResource) Schema(ctx context.Context, req resource.Schema
 				Attributes:  registry_config.RegistryConfigResource(),
 				Optional:    true,
 			},
+			"worker_disk_size": schema.Int64Attribute{
+				Description: "Compute node root disk size, in GiB. " + rosaTypes.PoolMessage,
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -492,8 +496,10 @@ func createHcpClusterObject(ctx context.Context,
 		return nil, err
 	}
 
+	workerDiskSize := common.OptionalInt64(state.WorkerDiskSize)
+
 	if err := ocmClusterResource.CreateNodes(rosaTypes.Hcp, false, replicas, nil, nil,
-		computeMachineType, nil, availabilityZones, true, nil); err != nil {
+		computeMachineType, nil, availabilityZones, true, workerDiskSize); err != nil {
 		return nil, err
 	}
 
@@ -875,6 +881,7 @@ func validateNoImmutableAttChange(state, plan *ClusterRosaHcpState) diag.Diagnos
 	common.ValidateStateAndPlanEquals(state.ComputeMachineType, plan.ComputeMachineType, "compute_machine_type", &diags)
 	common.ValidateStateAndPlanEquals(state.AvailabilityZones, plan.AvailabilityZones, "availability_zones", &diags)
 	common.ValidateStateAndPlanEquals(state.Ec2MetadataHttpTokens, plan.Ec2MetadataHttpTokens, "ec2_metadata_http_tokens", &diags)
+	common.ValidateStateAndPlanEquals(state.WorkerDiskSize, plan.WorkerDiskSize, "worker_disk_size", &diags)
 
 	// cluster admin attributes
 	common.ValidateStateAndPlanEquals(state.CreateAdminUser, plan.CreateAdminUser, "create_admin_user", &diags)

--- a/provider/clusterrosa/hcp/state.go
+++ b/provider/clusterrosa/hcp/state.go
@@ -44,6 +44,7 @@ type ClusterRosaHcpState struct {
 	Replicas              types.Int64  `tfsdk:"replicas"`
 	AvailabilityZones     types.List   `tfsdk:"availability_zones"`
 	Ec2MetadataHttpTokens types.String `tfsdk:"ec2_metadata_http_tokens"`
+	WorkerDiskSize        types.Int64  `tfsdk:"worker_disk_size"`
 
 	// Version/Upgrade fields
 	Version        types.String `tfsdk:"version"`

--- a/provider/machinepool/classic/machine_pool_resource.go
+++ b/provider/machinepool/classic/machine_pool_resource.go
@@ -723,6 +723,18 @@ func (r *MachinePoolResource) doUpdate(ctx context.Context, state *MachinePoolSt
 		return diags
 	}
 
+	_, ok = common.ShouldPatchInt(state.DiskSize, plan.DiskSize)
+	if ok {
+		diags.AddError(
+			"Cannot update machine pool",
+			fmt.Sprintf(
+				"Cannot update machine pool for cluster '%s', disk size cannot be updated",
+				state.Cluster.ValueString(),
+			),
+		)
+		return diags
+	}
+
 	patchLabels, shouldPatchLabels := common.ShouldPatchMap(state.Labels, plan.Labels)
 	if shouldPatchLabels {
 		labels := map[string]string{}

--- a/provider/machinepool/hcp/aws_node_pool.go
+++ b/provider/machinepool/hcp/aws_node_pool.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -21,6 +22,7 @@ type AWSNodePool struct {
 	Tags                       types.Map    `tfsdk:"tags"`
 	AdditionalSecurityGroupIds types.List   `tfsdk:"additional_security_group_ids"`
 	Ec2MetadataHttpTokens      types.String `tfsdk:"ec2_metadata_http_tokens"`
+	DiskSize                   types.Int64  `tfsdk:"disk_size"`
 }
 
 func AwsNodePoolResource() map[string]schema.Attribute {
@@ -63,6 +65,14 @@ func AwsNodePoolResource() map[string]schema.Attribute {
 				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
+		"disk_size": schema.Int64Attribute{
+			Description: "Root disk size, in GiB. " + common.ValueCannotBeChangedStringDescription,
+			Optional:    true,
+			Computed:    true,
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
+		},
 	}
 }
 
@@ -93,6 +103,11 @@ func AwsNodePoolDatasource() map[string]dsschema.Attribute {
 				"This can be set as `optional` (IMDS v1 or v2) or `required` (IMDSv2 only). This feature is available from " + common.ValueCannotBeChangedStringDescription,
 			Optional: true,
 			Computed: true,
+		},
+		"disk_size": schema.Int64Attribute{
+			Description: "The root disk size, in GiB.",
+			Optional:    true,
+			Computed:    true,
 		},
 	}
 }


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:
- Adds the custom disk size field for creating node pools to the terraform provider, so that node pools with a custom disk size can be created through terraform
- Adds a disk size field to HCP cluster creation so that day 1 node pools w/ custom disk size can be created through terraform

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
https://issues.redhat.com/browse/OCM-9892

**Change type**
- [ x] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ x] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
