### PR TITLE
OCM-11554 | fix: empty list as default value for registry config

### DIFF
--- a/provider/common/attrvalidators/conflicts_with_not_empty.go
+++ b/provider/common/attrvalidators/conflicts_with_not_empty.go
@@ -1,0 +1,102 @@
+package attrvalidators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+var (
+	_ validator.List = ConflictsWithNotEmptyValidator{}
+)
+
+// ConflictsWithNotEmpty ensures that a list parameter is not null and not empty if incompatible with the other paths
+// specified in input
+// It differs from standard ConflictsWith which only checks if the parameter is not null
+func ConflictsWithNotEmpty(expressions ...path.Expression) validator.List {
+	return ConflictsWithNotEmptyValidator{
+		PathExpressions: expressions,
+	}
+}
+
+// ConflictsWithNotEmptyValidator is the underlying struct implementing ConflictsWithNotEmpty.
+type ConflictsWithNotEmptyValidator struct {
+	PathExpressions path.Expressions
+}
+
+type ConflictsWithNotEmptyValidatorRequest struct {
+	Config         tfsdk.Config
+	ConfigValue    attr.Value
+	Path           path.Path
+	PathExpression path.Expression
+}
+
+type ConflictsWithNotEmptyValidatorResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (v ConflictsWithNotEmptyValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v ConflictsWithNotEmptyValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Ensure that if an attribute is set, these are not set or if set empty: %q",
+		v.PathExpressions)
+}
+
+func (v ConflictsWithNotEmptyValidator) ValidateList(ctx context.Context, req validator.ListRequest,
+	res *validator.ListResponse) {
+	// If attribute configuration is null, it cannot conflict with others
+	if req.ConfigValue.IsNull() {
+		return
+	}
+
+	expressions := req.PathExpression.MergeExpressions(v.PathExpressions...)
+
+	for _, expression := range expressions {
+		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
+
+		res.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(req.Path) {
+				continue
+			}
+
+			var mpVal attr.Value
+			diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+			res.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			// Delay validation until all involved attribute have a known value
+			if mpVal.IsUnknown() {
+				return
+			}
+
+			if !mpVal.IsNull() && len(req.ConfigValue.Elements()) > 0 {
+				res.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+					req.Path,
+					fmt.Sprintf("Attribute %q cannot be specified and be not empty when %q is specified", mp,
+						req.Path),
+				))
+			}
+		}
+	}
+}

--- a/provider/common/attrvalidators/conflicts_with_not_empty_test.go
+++ b/provider/common/attrvalidators/conflicts_with_not_empty_test.go
@@ -1,0 +1,94 @@
+package attrvalidators
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Conflict with not empty validator", func() {
+
+	DescribeTable("should validate correctly",
+		func(request validator.ListRequest,
+			expectedErr bool) {
+			response := validator.ListResponse{}
+			ConflictsWithNotEmpty(path.MatchRelative().AtParent().AtName("other")).
+				ValidateList(context.Background(), request, &response)
+			if expectedErr {
+				Expect(response.Diagnostics.HasError()).To(BeTrue())
+			}
+		},
+		Entry("2 not empty lists -> error",
+			validator.ListRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				Config: buildConfig(
+					[]attr.Value{types.StringValue("test")},
+					[]attr.Value{types.StringValue("test")}),
+				ConfigValue: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
+			},
+			true,
+		),
+		Entry("only 1 not empty list -> ok",
+			validator.ListRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				Config: buildConfig(
+					[]attr.Value{types.StringValue("")},
+					[]attr.Value{types.StringValue("test")}),
+				ConfigValue: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
+			},
+			false,
+		),
+		Entry("only 1 not empty list, other null -> ok",
+			validator.ListRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				Config: buildConfig(
+					[]attr.Value{types.StringNull()},
+					[]attr.Value{types.StringValue("test")}),
+				ConfigValue: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
+			},
+			false,
+		),
+	)
+})
+
+func buildConfig(attrValue1 []attr.Value, attrValue2 []attr.Value) tfsdk.Config {
+	val, _ := types.ListValueMust(types.StringType, attrValue1).ToTerraformValue(context.Background())
+	val2, _ := types.ListValueMust(types.StringType, attrValue2).ToTerraformValue(context.Background())
+	return tfsdk.Config{
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test": schema.ListAttribute{
+					Optional:    true,
+					ElementType: types.StringType,
+				},
+				"other": schema.ListAttribute{
+					Optional:    true,
+					ElementType: types.StringType,
+				},
+			},
+		},
+		Raw: tftypes.NewValue(
+			tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"test":  tftypes.List{ElementType: tftypes.String},
+					"other": tftypes.List{ElementType: tftypes.String},
+				},
+			},
+			map[string]tftypes.Value{
+				"test":  val,
+				"other": val2,
+			},
+		),
+	}
+}

--- a/provider/common/attrvalidators/main_test.go
+++ b/provider/common/attrvalidators/main_test.go
@@ -1,0 +1,13 @@
+package attrvalidators
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
+	. "github.com/onsi/gomega"             // nolint
+)
+
+func TestAttrValidators(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Attribute validators Resource Suite")
+}

--- a/provider/common/planmodifiers/redacted_modifier_test.go
+++ b/provider/common/planmodifiers/redacted_modifier_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Registry Config resource", func() {
+var _ = Describe("Redacted Modifier", func() {
 	testSchema := schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"testattr": schema.MapAttribute{

--- a/subsystem/hcp/cluster_resource_test.go
+++ b/subsystem/hcp/cluster_resource_test.go
@@ -2246,7 +2246,8 @@ var _ = Describe("HCP Cluster", func() {
 					  "value": {
 						  "platform_allowlist": {
 								"id": "id1"
-							}
+							},
+							"allowed_registries_for_import": []
 					  }
 					},
                     {
@@ -2364,7 +2365,8 @@ var _ = Describe("HCP Cluster", func() {
 					  "value": {
 						  "platform_allowlist": {
 								"id": "id1"
-							}
+							},
+						  "allowed_registries_for_import": []
 					  }
 					},
 					{
@@ -2767,7 +2769,8 @@ var _ = Describe("HCP Cluster", func() {
 							"additional_trusted_ca": {
 							  "registry7.io": "REDACTED"
 							},
-							"registry_sources": {}
+							"registry_sources": {},
+							"allowed_registries_for_import": []
 					  	}
 					},
 					{


### PR DESCRIPTION
**What this PR does / why we need it**:
As the API is returning empty lists to clear parameters, while null values are not used, we set empty list as default, so this will cover both null values and empty lists in input, as they should behave in the same way.

Add also a custom validator for conflicts as we need to check against not empty list,while the default conflict validator checks only for null values.

Tests added and validated also locally the different cases.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Related: [OCM-11554](https://issues.redhat.com//browse/OCM-11554)

**Change type**
- [ ] New feature
- [X] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
