### PR TITLE
OCM-11614 | test: Update the ami name for proxy launching due to the …

### DIFF
--- a/tests/tf-manifests/aws/proxy/main.tf
+++ b/tests/tf-manifests/aws/proxy/main.tf
@@ -12,7 +12,7 @@ provider "aws" {
 }
 
 locals {
-  proxy_image_name = "al2023-ami-2023.5.20240708.0-kernel-6.1-x86_64"
+  proxy_image_name = "al2023-ami-2023.5.20241001.1-kernel-6.1-x86_64"
 }
 
 data "aws_ami" "proxy_img" {


### PR DESCRIPTION
…change on AWS

**What this PR does / why we need it**:
AWS has released a new image and deprecated the old one

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-11614

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
