### PR TITLE
OCM-11739 | fix: add lock to guarantee only one kubelet config for classic cluster

### DIFF
--- a/provider/common/mutex.go
+++ b/provider/common/mutex.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"sync"
+)
+
+type mutexKV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+func (m *mutexKV) Lock(key string) {
+	m.get(key).Lock()
+}
+
+func (m *mutexKV) Unlock(key string) {
+	m.get(key).Unlock()
+}
+
+func NewMutexKV() *mutexKV {
+	return &mutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
+}
+
+func (m *mutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}


### PR DESCRIPTION


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:
fix https://issues.redhat.com/browse/OCM-11739
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #[OCM-11739](https://issues.redhat.com//browse/OCM-11739)

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
