### PR TITLE
OCM-11804 | ci: Avoid to use hashicorp/aws 5.71.0

### DIFF
--- a/examples/create_account_roles/main.tf
+++ b/examples/create_account_roles/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.1.0"

--- a/examples/create_rosa_sts_cluster/classic_sts/cluster/main.tf
+++ b/examples/create_rosa_sts_cluster/classic_sts/cluster/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.1.0"

--- a/examples/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
+++ b/examples/create_rosa_sts_cluster/oidc_configuration/cluster_with_managed_oidc_config/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.1.0"

--- a/examples/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
+++ b/examples/create_rosa_sts_cluster/oidc_configuration/cluster_with_unmanaged_oidc_config/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.1.0"

--- a/examples/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
+++ b/examples/create_rosa_sts_cluster/oidc_configuration/oidc_provider/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.1.0"

--- a/tests/tf-manifests/aws/account-roles/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-classic/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.6.3"

--- a/tests/tf-manifests/aws/account-roles/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-hcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.6.3"

--- a/tests/tf-manifests/aws/kms/main.tf
+++ b/tests/tf-manifests/aws/kms/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
   }
 }

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-classic/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.6.3"

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-hcp/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.6.3"

--- a/tests/tf-manifests/aws/proxy/main.tf
+++ b/tests/tf-manifests/aws/proxy/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
   }
 }

--- a/tests/tf-manifests/aws/security-groups/main.tf
+++ b/tests/tf-manifests/aws/security-groups/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
   }
 }

--- a/tests/tf-manifests/aws/vpc-tags/main.tf
+++ b/tests/tf-manifests/aws/vpc-tags/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
   }
 }

--- a/tests/tf-manifests/aws/vpc/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/vpc/rosa-classic/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
   }
 }

--- a/tests/tf-manifests/aws/vpc/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/vpc/rosa-hcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
   }
 }

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.0.1"

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20.0"
+      version = ">= 4.20.0, != 5.71.0"
     }
     rhcs = {
       version = ">= 1.0.1"


### PR DESCRIPTION
Due to https://github.com/hashicorp/terraform-provider-aws/issues/39676

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCM-11804

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
