### PR TITLE
OCM-12050 | fix: warn instead of error rosa_creatorn_arn update validation

### DIFF
--- a/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
@@ -1094,11 +1094,10 @@ func (r *ClusterRosaClassicResource) Update(ctx context.Context, request resourc
 	if patchProperties {
 		propertiesElements, err := rosa.ValidatePatchProperties(ctx, state.Properties, plan.Properties)
 		if err != nil {
-			response.Diagnostics.AddError(
-				"Can't patch cluster",
-				fmt.Sprintf("Can't patch cluster with identifier: '%s', %v", state.ID.ValueString(), err),
+			response.Diagnostics.AddWarning(
+				"Shouldn't patch cluster properties",
+				fmt.Sprintf("Shouldn't patch cluster with identifier: '%s', %v", state.ID.ValueString(), err),
 			)
-			return
 		}
 		if propertiesElements != nil {
 			for k, v := range rosa.OCMProperties {

--- a/provider/clusterrosa/common/properties.go
+++ b/provider/clusterrosa/common/properties.go
@@ -20,7 +20,7 @@ func ValidatePatchProperties(ctx context.Context, state, plan types.Map) (map[st
 		}
 		if ogCreatorArn, ogOk := ogProperties[PropertyRosaCreatorArn]; ogOk {
 			if creatorArnValue != ogCreatorArn {
-				return nil, fmt.Errorf("Can't patch property '%s'", PropertyRosaCreatorArn)
+				return nil, fmt.Errorf("Shouldn't patch property '%s'", PropertyRosaCreatorArn)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

[OCM-12050](https://issues.redhat.com//browse/OCM-12050)
This validation enforces only the initial user that created the cluster can update the cluster resources, this is not ideal considering customers can use other users to update it.
For now it will be considered a warning instead and will be evaluated in a new form to be re introduced

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
