### PR TITLE
OCM-14804 | feat: Allow edit for HCP global autoscaler

### DIFF
--- a/docs/resources/hcp_cluster_autoscaler.md
+++ b/docs/resources/hcp_cluster_autoscaler.md
@@ -35,6 +35,7 @@ resource "rhcs_hcp_cluster_autoscaler" "cluster_autoscaler" {
 ### Optional
 
 - `max_node_provision_time` (String) Maximum time cluster-autoscaler waits for node to be provisioned.
+- `max_nodes_total` (Number) Maximum number of nodes in the cluster.
 - `max_pod_grace_period` (Number) Gives pods graceful termination time before scaling down.
 - `pod_priority_threshold` (Number) To allow users to schedule 'best-effort' pods, which shouldn't trigger Cluster Autoscaler actions, but only run when there are spare resources available.
 - `resource_limits` (Attributes) Constraints of autoscaling resources. (see [below for nested schema](#nestedatt--resource_limits))

--- a/provider/autoscaler/hcp/state.go
+++ b/provider/autoscaler/hcp/state.go
@@ -25,6 +25,7 @@ type ClusterAutoscalerState struct {
 	MaxPodGracePeriod    types.Int64               `tfsdk:"max_pod_grace_period"`
 	PodPriorityThreshold types.Int64               `tfsdk:"pod_priority_threshold"`
 	MaxNodeProvisionTime types.String              `tfsdk:"max_node_provision_time"`
+	MaxNodesTotal        types.Int64               `tfsdk:"max_nodes_total"`
 	ResourceLimits       *AutoscalerResourceLimits `tfsdk:"resource_limits"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows editing of HCP cluster global autoscaler from TF

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #[OCM-14804](https://issues.redhat.com//browse/OCM-14804)

**Change type**
- [X] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests


Specifically, this forces Update to be called when TF attempts to create the HCP global autoscaler. It populates the state as well, so it will only run this once per cluster
