### PR TITLE
Implement no-cni for HCP clusters

### DIFF
--- a/provider/clusterrosa/hcp/datasource.go
+++ b/provider/clusterrosa/hcp/datasource.go
@@ -191,6 +191,10 @@ func (r *ClusterRosaHcpDatasource) Schema(ctx context.Context, req datasource.Sc
 				Description: "Length of the prefix of the subnet assigned to each node. " + common.ValueCannotBeChangedStringDescription,
 				Computed:    true,
 			},
+			"no_cni": schema.BoolAttribute{
+				Description: "Disable CNI creation to let users bring their own CNI. " + common.ValueCannotBeChangedStringDescription,
+				Computed:    true,
+			},
 			"channel_group": schema.StringAttribute{
 				Description: deprecatedMessage,
 				Computed:    true,

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -287,6 +287,14 @@ func (r *ClusterRosaHcpResource) Schema(ctx context.Context, req resource.Schema
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
+			"no_cni": schema.BoolAttribute{
+				Description: "Disable CNI creation to let users bring their own CNI. " + common.ValueCannotBeChangedStringDescription,
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"channel_group": schema.StringAttribute{
 				Description: "Name of the channel group where you select the OpenShift cluster version, for example 'stable'. " +
 					"For ROSA, only 'stable' is supported. " + common.ValueCannotBeChangedStringDescription,
@@ -621,6 +629,9 @@ func createHcpClusterObject(ctx context.Context,
 	if common.HasValue(state.HostPrefix) {
 		network.HostPrefix(int(state.HostPrefix.ValueInt64()))
 	}
+	if common.BoolWithFalseDefault(state.NoCNI) {
+		network.Type("Other")
+	}
 	if !network.Empty() {
 		builder.Network(network)
 	}
@@ -949,6 +960,7 @@ func validateNoImmutableAttChange(state, plan *ClusterRosaHcpState) diag.Diagnos
 	common.ValidateStateAndPlanEquals(state.ServiceCIDR, plan.ServiceCIDR, "service_cidr", &diags)
 	common.ValidateStateAndPlanEquals(state.PodCIDR, plan.PodCIDR, "pod_cidr", &diags)
 	common.ValidateStateAndPlanEquals(state.HostPrefix, plan.HostPrefix, "host_prefix", &diags)
+	common.ValidateStateAndPlanEquals(state.NoCNI, plan.Private, "no_cni", &diags)
 	common.ValidateStateAndPlanEquals(state.ChannelGroup, plan.ChannelGroup, "channel_group", &diags)
 
 	// STS field validations
@@ -1601,6 +1613,12 @@ func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, stat
 		state.HostPrefix = types.Int64Value(int64(hostPrefix))
 	} else {
 		state.HostPrefix = types.Int64Null()
+	}
+	networkType, ok := object.Network().GetType()
+	if ok && networkType == "Other" {
+		state.NoCNI = types.BoolValue(true)
+	} else {
+		state.NoCNI = types.BoolNull()
 	}
 	channel_group, ok := object.Version().GetChannelGroup()
 	if ok {

--- a/provider/clusterrosa/hcp/state.go
+++ b/provider/clusterrosa/hcp/state.go
@@ -40,6 +40,7 @@ type ClusterRosaHcpState struct {
 	MachineCIDR types.String `tfsdk:"machine_cidr"`
 	ServiceCIDR types.String `tfsdk:"service_cidr"`
 	HostPrefix  types.Int64  `tfsdk:"host_prefix"`
+	NoCNI       types.Bool   `tfsdk:"no_cni"`
 	Proxy       *proxy.Proxy `tfsdk:"proxy"`
 
 	// Standard machine pools fields


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:

Makes it possible to configure a HCP cluster without a CNI, like with `rosa cluster create --no-cni`

Implementing it like the `rosa` CLI does it: https://github.com/openshift/rosa/blob/4f425f6d857bb7b1ddb7af8fc69a25d25ce8fae3/pkg/ocm/clusters.go#L939

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #885

**Change type**
- [X] New feature
- [ ] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
