### PR TITLE
OCM-15301 | ci: Add build-image-index task

### DIFF
--- a/.tekton/terraform-provider-rhcs-push.yaml
+++ b/.tekton/terraform-provider-rhcs-push.yaml
@@ -367,6 +367,35 @@ spec:
           - name: kind
             value: task
         resolver: bundles
+    - name: build-image-index
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: ALWAYS_BUILD_INDEX
+          value: $(params.build-image-index)
+        - name: IMAGES
+          value:
+            - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      runAfter:
+        - build-container
+      taskRef:
+        params:
+          - name: name
+            value: build-image-index
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
     - name: sast-unicode-check
       runAfter:
         - build-container


### PR DESCRIPTION
Adds `build-image-index` task to Konflux pipeline to unblock release