### PR TITLE
OCM-15886 | fix: Change validateUpgrade versionId to CurrentVersion

### DIFF
--- a/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
@@ -1252,7 +1252,7 @@ func (r *ClusterRosaClassicResource) validateUpgrade(ctx context.Context, state,
 	if common.HasValue(state.ChannelGroup) {
 		channelGroup = state.ChannelGroup.ValueString()
 	}
-	versionId := ocmUtils.CreateVersionId(state.Version.ValueString(), channelGroup)
+	versionId := ocmUtils.CreateVersionId(state.CurrentVersion.ValueString(), channelGroup)
 	availableVersions, err := upgrade.GetAvailableUpgradeVersions(ctx, r.VersionCollection, versionId)
 	if err != nil {
 		return fmt.Errorf("failed to get available upgrades: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes create/cluster in some situations where the `state`'s version was invalid, now using the `state`'s CurrentVersion

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #[OCM-15886](https://issues.redhat.com//browse/OCM-15886) #924 

**Change type**
- [ ] New feature
- [X] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
