### PR TITLE
OCM-17530 | fix: Include more detail from OCM API auth errors

### DIFF
--- a/provider/info/info_data_source.go
+++ b/provider/info/info_data_source.go
@@ -114,7 +114,7 @@ func (d *OCMInfoDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	// Get account information
 	accountResp, err := d.collection.Get().Send()
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to connect to OCM", "Please verify your OCM offline token")
+		resp.Diagnostics.AddError("Failed to connect to OCM", fmt.Sprintf("Please verify your OCM offline token. Error: %v", err))
 		return
 	}
 	obj, ok := accountResp.GetBody()


### PR DESCRIPTION
Before this commit, OCM API authentication failures were opaque to the end user because the error from the API was discarded, resulting in user-facing messages like this:

        Error: Failed to connect to OCM
        <stack trace>
        Please verify your OCM offline token.

This commit updates the error message to include the actual OCM API error so end users can more effectively diagnose the problem.
