### PR TITLE
OCM-17531 | feat: Enable refresh token support in OCM API auth flow

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -70,6 +70,7 @@ type Config struct {
 	URL          types.String `tfsdk:"url"`
 	TokenURL     types.String `tfsdk:"token_url"`
 	Token        types.String `tfsdk:"token"`
+	RefreshToken types.String `tfsdk:"refresh_token"`
 	ClientID     types.String `tfsdk:"client_id"`
 	ClientSecret types.String `tfsdk:"client_secret"`
 	TrustedCAs   types.String `tfsdk:"trusted_cas"`
@@ -103,6 +104,11 @@ func (p *Provider) Schema(ctx context.Context, req tfprovider.SchemaRequest, res
 					"generated from https://console.redhat.com/openshift/token/rosa.",
 				Optional:  true,
 				Sensitive: true,
+			},
+			"refresh_token": tfpschema.StringAttribute{
+				Description: "Refresh token that is generated from `rosa login`.",
+				Optional:    true,
+				Sensitive:   true,
 			},
 			"client_id": tfpschema.StringAttribute{
 				Description: fmt.Sprintf("OpenID client identifier. The default value is '%s'.", sdk.DefaultClientID),
@@ -173,9 +179,12 @@ func (p *Provider) Configure(ctx context.Context, req tfprovider.ConfigureReques
 	if token, ok := p.getAttrValueOrConfig(config.Token, "TOKEN"); ok {
 		builder.Tokens(token)
 	}
+	if refreshToken, ok := p.getAttrValueOrConfig(config.RefreshToken, "REFRESH_TOKEN"); ok {
+		builder.Tokens(refreshToken)
+	}
 	clientID, clientIdExists := p.getAttrValueOrConfig(config.ClientID, "CLIENT_ID")
-	clientSecret, clientSecretExists := p.getAttrValueOrConfig(config.ClientSecret, "CLIENT_SECRET")
-	if clientIdExists && clientSecretExists {
+	clientSecret, _ := p.getAttrValueOrConfig(config.ClientSecret, "CLIENT_SECRET")
+	if clientIdExists {
 		builder.Client(clientID, clientSecret)
 	}
 	if trustedCAs, ok := p.getAttrValueOrConfig(config.TrustedCAs, "TRUSTED_CAS"); ok {


### PR DESCRIPTION
Before this commit, it was impossible to authenticate to OCM API endpoints which require refresh tokens, such as the GovCloud internal OCM api. This made it impossible to use the provider with ROSA GovCloud internally.

This commit adds support by:

- Exposing a new `refresh_token` provider variable which is appended to the OCM authentication builder token list

- Tweaks the client secret handling to unconditionally pass the client secret variable to the auth builder, even when empty. From the OCM SDK docs:

        // Note that some OpenID providers (Keycloak, for example) require the client identifier also for
        // the resource owner password grant. In that case use the set only the identifier, and let the
        // secret blank. For example:

  This change should thus support all workflows in a backwards compatible way.

After this change, the provider can successfully authenticate to ROSA GovCloud OCM API endpoints when appropriately configured.