### PR TITLE
OCM-17691 | fix: Make billing account ID optional to enable GovCloud HCP cluster creation

### DIFF
--- a/docs/resources/cluster_rosa_hcp.md
+++ b/docs/resources/cluster_rosa_hcp.md
@@ -51,7 +51,6 @@ resource "rhcs_cluster_rosa_hcp" "rosa_sts_cluster" {
 
 - `availability_zones` (List of String) Availability zones. This attribute specifically applies to the Worker Machine Pool and becomes irrelevant once the resource is created. Any modifications to the initial Machine Pool should be made through the Terraform imported Machine Pool resource. For more details, refer to [Worker Machine Pool in ROSA Cluster](../guides/worker-machine-pool.md)
 - `aws_account_id` (String) Identifier of the AWS account. After the creation of the resource, it is not possible to update the attribute value.
-- `aws_billing_account_id` (String) Identifier of the AWS account for billing. After the creation of the resource, it is not possible to update the attribute value.
 - `aws_subnet_ids` (List of String) AWS subnet IDs. After the creation of the resource, it is not possible to update the attribute value.
 - `cloud_region` (String) AWS region identifier, for example 'us-east-1'.
 - `name` (String) Name of the cluster. Cannot exceed 54 characters in length. After the creation of the resource, it is not possible to update the attribute value.
@@ -62,6 +61,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa_sts_cluster" {
 - `admin_credentials` (Attributes) Admin user credentials. After the creation of the resource, it is not possible to update the attribute value. (see [below for nested schema](#nestedatt--admin_credentials))
 - `aws_additional_allowed_principals` (List of String) AWS additional allowed principals.
 - `aws_additional_compute_security_group_ids` (List of String) AWS additional compute security group ids.
+- `aws_billing_account_id` (String) Identifier of the AWS account for billing. After the creation of the resource, it is not possible to update the attribute value.
 - `base_dns_domain` (String) Base DNS domain name previously reserved, e.g. '1vo8.p3.openshiftapps.com'. After the creation of the resource, it is not possible to update the attribute value.
 - `channel_group` (String) Name of the channel group where you select the OpenShift cluster version, for example 'stable'. For ROSA, only 'stable' is supported. After the creation of the resource, it is not possible to update the attribute value.
 - `compute_machine_type` (String) Identifies the machine type used by the initial worker nodes, for example `m5.xlarge`. Use the `rhcs_machine_types` data source to find the possible values. This attribute specifically applies to the Worker Machine Pool and becomes irrelevant once the resource is created. Any modifications to the initial Machine Pool should be made through the Terraform imported Machine Pool resource. For more details, refer to [Worker Machine Pool in ROSA Cluster](../guides/worker-machine-pool.md)

--- a/internal/ocm/resource/cluster.go
+++ b/internal/ocm/resource/cluster.go
@@ -181,7 +181,9 @@ func (c *Cluster) CreateAWSBuilder(clusterTopology rosaTypes.ClusterTopology,
 		if err != nil {
 			return err
 		}
-		awsBuilder.BillingAccountID(*awsBillingAccountId)
+		if awsBillingAccountId != nil {
+			awsBuilder.BillingAccountID(*awsBillingAccountId)
+		}
 	}
 
 	if awsAccountID != nil {

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -209,7 +209,7 @@ func (r *ClusterRosaHcpResource) Schema(ctx context.Context, req resource.Schema
 			},
 			"aws_billing_account_id": schema.StringAttribute{
 				Description: "Identifier of the AWS account for billing. " + common.ValueCannotBeChangedStringDescription,
-				Required:    true,
+				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^\d{12}$`), "aws billing account ID must be only digits and exactly 12 in length"),
 				},


### PR DESCRIPTION
Before this commit, HCP clusters on ROSA GovCloud couldn't be created because the
module required a value for the billing account variable, which is invalid to
supply to the OCM API when creating HCP GovCloud clusters[1]. In these cases,
the billing ID passed to the OCM `/clusters` API should be empty.

This commit makes billing account ID optional so that users can create HCP clusters
on ROSA GovCloud.

This is consistent with the server side validation OCM Cluster Service applies to
the billing ID, which are dynamic based on many criteria[2]. Instead of trying to
replicate the server side validation in the provider, this change simply makes the
field always optional and the server can perform those complex validations.

[1] https://github.com/openshift/rosa/blob/master/cmd/create/cluster/cmd.go#L1268
[2] https://github.com/openshift-online/ocm-cluster-service/blob/main/cmd/clusters-service/service/cluster_service.go