### PR TITLE
OCM-17688 | test: Change e2e test dockerfile go version to 1.23.9

### DIFF
--- a/build/ci-tf-e2e.Dockerfile
+++ b/build/ci-tf-e2e.Dockerfile
@@ -10,7 +10,7 @@ RUN yum install -y wget &&\
     chmod +x /usr/local/bin/ocm
 
 # go
-RUN curl -Ls https://go.dev/dl/go1.21.5.linux-amd64.tar.gz |tar -C /usr/local -xzf -
+RUN curl -Ls https://go.dev/dl/go1.23.9.linux-amd64.tar.gz |tar -C /usr/local -xzf -
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH=/usr/local/go
 ENV TEST_OFFLINE_TOKEN=""
@@ -23,7 +23,7 @@ RUN yum install -y yum-utils && \
     yum -y install terraform python3 python3-pip make jq httpd-tools git &&\
     pip3 install PyYAML jinja2 &&\
     go env -w GO111MODULE=on &&\
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.13.2 &&\
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.17.1 &&\
     go install go.uber.org/mock/mockgen@v0.3.0 &&\
     cd terraform-provider-rhcs && go mod tidy && go mod vendor && make install &&\
     chmod -R 777 $GOPATH &&\


### PR DESCRIPTION
Updates `go` version in the e2e tests Dockerfile. This should fix the pipeline errors related to incorrect Go version being used