### PR TITLE
OCM-17200 | ci: Fix PR CI to unblock other jobs

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -54,7 +54,7 @@ jobs:
         go-version: 1.21
 
     - name: Setup Ginkgo
-      run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.13.2
+      run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.17.1
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
Fixes `check_pull_request` GitHub action, by giving it the correct ginkgo version

This unblocks tests which rely on this action