### PR TITLE
OCM-18882 | fix: Update CapRes ID only on creation

### DIFF
--- a/provider/machinepool/hcp/machine_pool_resource.go
+++ b/provider/machinepool/hcp/machine_pool_resource.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -706,6 +707,15 @@ func (r *HcpMachinePoolResource) doUpdate(ctx context.Context, state *HcpMachine
 		diags.AddError(
 			"Can't upgrade machine pool",
 			fmt.Sprintf("Can't upgrade machine pool version with identifier: `%s`, %v", state.ID.ValueString(), err),
+		)
+		return diags
+	}
+
+	if !state.AWSNodePool.CapacityReservationId.IsNull() && reflect.DeepEqual(state.AWSNodePool.CapacityReservationId, plan.AWSNodePool.CapacityReservationId) {
+		diags.AddError(
+			"Can't update machine pool",
+			fmt.Sprintf("Capacity Reservation ID cannot be modified after it's creation (old value: '%s', "+
+				"new value: '%s')", state.AWSNodePool.CapacityReservationId, plan.AWSNodePool.CapacityReservationId),
 		)
 		return diags
 	}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:
Makes it so that you cannot update CapacityReservationID, and you must delete and create a new resource to change it. In this case, a new nodepool

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #[OCM-18882](https://issues.redhat.com//browse/OCM-18882)

**Change type**
- [ ] New feature
- [X] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
