### PR TITLE
OCM-17200 | fix: Autoscaler requires 2 applies

### DIFF
--- a/provider/autoscaler/hcp/resource_test.go
+++ b/provider/autoscaler/hcp/resource_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package hcp
 
 import (
-	"context"
-
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	. "github.com/onsi/ginkgo/v2" // nolint
 	. "github.com/onsi/gomega"    // nolint
@@ -140,74 +138,6 @@ var _ = Describe("Cluster Autoscaler", func() {
 			expectedAutoscaler, err := cmv1.NewClusterAutoscaler().Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(autoscaler).To(Equal(expectedAutoscaler))
-		})
-	})
-
-	Context("updateAutoscaler", func() {
-		It("updates all autoscaler fields (OK)", func() {
-			resource := &ClusterAutoscalerResource{}
-
-			plan := &ClusterAutoscalerState{
-				Cluster:              types.StringValue(clusterId),
-				MaxPodGracePeriod:    types.Int64Value(15),
-				PodPriorityThreshold: types.Int64Value(-15),
-				MaxNodeProvisionTime: types.StringValue("2h"),
-				ResourceLimits: &AutoscalerResourceLimits{
-					MaxNodesTotal: types.Int64Value(100),
-				},
-			}
-
-			Expect(updateState).ToNot(Equal(plan))
-
-			err := resource.updateAutoscaler(context.Background(), plan, updateState, clusterId, nil)
-			Expect(err).ToNot(HaveOccurred())
-
-			autoscaler, err := clusterAutoscalerStateToObject(plan)
-			Expect(err).ToNot(HaveOccurred())
-
-			checkOutputAgainstState(autoscaler, updateState)
-		})
-
-		It("all nulls when updating (OK)", func() {
-			resource := &ClusterAutoscalerResource{}
-
-			plan := &ClusterAutoscalerState{
-				Cluster:              types.StringValue(clusterId),
-				MaxPodGracePeriod:    types.Int64Null(),
-				PodPriorityThreshold: types.Int64Null(),
-				MaxNodeProvisionTime: types.StringNull(),
-				ResourceLimits:       nil,
-			}
-
-			err := resource.updateAutoscaler(context.Background(), plan, updateState, clusterId, nil)
-			Expect(err).ToNot(HaveOccurred())
-
-			autoscaler, err := clusterAutoscalerStateToObject(plan)
-			Expect(err).ToNot(HaveOccurred())
-
-			checkOutputAgainstState(autoscaler, plan)
-		})
-
-		It("some null, some populated, in an update (OK)", func() {
-			resource := &ClusterAutoscalerResource{}
-
-			plan := &ClusterAutoscalerState{
-				Cluster:              types.StringValue(clusterId),
-				MaxPodGracePeriod:    types.Int64Value(20),
-				PodPriorityThreshold: types.Int64Null(),
-				MaxNodeProvisionTime: types.StringValue("45m"),
-				ResourceLimits: &AutoscalerResourceLimits{
-					MaxNodesTotal: types.Int64Value(75),
-				},
-			}
-
-			err := resource.updateAutoscaler(context.Background(), plan, updateState, clusterId, nil)
-			Expect(err).ToNot(HaveOccurred())
-
-			autoscaler, err := clusterAutoscalerStateToObject(plan)
-			Expect(err).ToNot(HaveOccurred())
-
-			checkOutputAgainstState(autoscaler, plan)
 		})
 	})
 })

--- a/subsystem/hcp/cluster_autoscaler_resource_test.go
+++ b/subsystem/hcp/cluster_autoscaler_resource_test.go
@@ -107,12 +107,14 @@ var _ = Describe("Hcp Cluster Autoscaler", func() {
 					VerifyJQ(".max_pod_grace_period", float64(1)),
 					VerifyJQ(".pod_priority_threshold", float64(-10)),
 					VerifyJQ(".max_node_provision_time", "1h"),
-					VerifyJQ(".resource_limits.max_nodes_total", float64(20)),
 					RespondWithJSON(http.StatusOK, `
 						{
 							"kind": "ClusterAutoscaler",
 							"id": "123",
-							"href": "/api/clusters_mgmt/v1/clusters/123"
+							"href": "/api/clusters_mgmt/v1/clusters/123",
+							"max_pod_grace_period": 1,
+							"pod_priority_threshold": -10,
+							"max_node_provision_time": "1h"
 						}
 					`),
 				),
@@ -233,6 +235,17 @@ var _ = Describe("Hcp Cluster Autoscaler", func() {
 						}
 					`),
 				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/autoscaler"),
+					VerifyJQ(".max_node_provision_time", "2h"),
+					RespondWithJSON(http.StatusOK, `
+						{
+							"kind": "ClusterAutoscaler",
+							"href": "/api/clusters_mgmt/v1/clusters/123/autoscaler",
+							"max_node_provision_time": "2h"
+						}
+					`),
+				),
 			)
 
 			Terraform.Source(`
@@ -286,12 +299,8 @@ var _ = Describe("Hcp Cluster Autoscaler", func() {
 					`),
 				),
 				CombineHandlers(
-					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/autoscaler"),
-					RespondWithJSON(http.StatusNotFound, "{}"),
-				),
-				CombineHandlers(
-					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/123/autoscaler"),
-					RespondWithJSON(http.StatusCreated, `
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/autoscaler"),
+					RespondWithJSON(http.StatusOK, `
 						{
 							"kind": "ClusterAutoscaler",
 							"id": "123",


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:
Makes it so that the state is not a clone of the plan if the state is nil when updating autoscaler

fixes the issue with needing to run Apply twice to 'create' the autoscaler

we do not use an actual Create for this resource even in the ROSA CLI. It is a fake create which calls an update because HCP clusters already have a default autoscaler

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #[OCM-17200](https://issues.redhat.com//browse/OCM-17200)

**Change type**
- [ ] New feature
- [X] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
