### PR TITLE
OCM-18810 | ci: One more fix for konflux release (rpms-signature-scan)

### DIFF
--- a/.tekton/terraform-provider-rhcs-push.yaml
+++ b/.tekton/terraform-provider-rhcs-push.yaml
@@ -368,7 +368,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:c943625383f1cb95f9fd99506d13a5a12b9c91e7796ea14e228093f9d4995d10
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:3d9fbf2c0a732f736b050c293380b63c8c72ab38d0ef79fcf9d1b7d8fcd25efb
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Updates the `rpms-signature-scan` task SHA to the latest to fix konflux