### PR TITLE
feat: add CloudWatch audit log forwarding support for ROSA HCP clusters

### DIFF
--- a/internal/ocm/resource/cluster.go
+++ b/internal/ocm/resource/cluster.go
@@ -146,7 +146,8 @@ func (c *Cluster) CreateAWSBuilder(clusterTopology rosaTypes.ClusterTopology,
 	additionalComputeSecurityGroupIds []string,
 	additionalInfraSecurityGroupIds []string,
 	additionalControlPlaneSecurityGroupIds []string,
-	additionalAllowedPrincipals []string) error {
+	additionalAllowedPrincipals []string,
+	auditLogArn *string) error {
 
 	if clusterTopology == rosaTypes.Hcp && awsSubnetIDs == nil {
 		return errors.New("Hosted Control Plane clusters must have a pre-configure VPC. Make sure to specify the subnet ids.")
@@ -237,6 +238,15 @@ func (c *Cluster) CreateAWSBuilder(clusterTopology rosaTypes.ClusterTopology,
 
 	if additionalAllowedPrincipals != nil {
 		awsBuilder.AdditionalAllowedPrincipals(additionalAllowedPrincipals...)
+	}
+
+	// CloudWatch audit log forwarding
+	// audit_log is nested under AWS configuration (aws.audit_log.role_arn)
+	// Reference: OCM API spec - AWS.audit_log.role_arn
+	if auditLogArn != nil && *auditLogArn != "" {
+		auditLogBuilder := cmv1.NewAuditLog()
+		auditLogBuilder.RoleArn(*auditLogArn)
+		awsBuilder.AuditLog(auditLogBuilder)
 	}
 
 	c.clusterBuilder.AWS(awsBuilder)

--- a/internal/ocm/resource/cluster_test.go
+++ b/internal/ocm/resource/cluster_test.go
@@ -203,17 +203,17 @@ var _ = Describe("Cluster", func() {
 	})
 	Context("CreateAWSBuilder validation", func() {
 		It("PrivateLink true subnets IDs empty - failure", func() {
-			err := cluster.CreateAWSBuilder(rosaTypes.Classic, nil, nil, nil, nil, true, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			err := cluster.CreateAWSBuilder(rosaTypes.Classic, nil, nil, nil, nil, true, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Clusters with PrivateLink must have a pre-configured VPC. Make sure to specify the subnet ids."))
 		})
 		It("PrivateLink false invalid kmsKeyARN - failure", func() {
-			err := cluster.CreateAWSBuilder(rosaTypes.Classic, nil, nil, pointer("test"), nil, false, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			err := cluster.CreateAWSBuilder(rosaTypes.Classic, nil, nil, pointer("test"), nil, false, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal(fmt.Sprintf("expected the kms-key-arn: %s to match %s", "test", kmsArnRegexpValidator.KmsArnRE)))
 		})
 		It("PrivateLink false empty kmsKeyARN - success", func() {
-			err := cluster.CreateAWSBuilder(rosaTypes.Classic, nil, nil, nil, nil, false, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			err := cluster.CreateAWSBuilder(rosaTypes.Classic, nil, nil, nil, nil, false, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -228,7 +228,7 @@ var _ = Describe("Cluster", func() {
 		})
 		It("PrivateLink false invalid Ec2MetadataHttpTokens - success", func() {
 			// TODO Need to add validation for Ec2MetadataHttpTokens
-			err := cluster.CreateAWSBuilder(rosaTypes.Classic, nil, pointer("test"), nil, nil, false, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			err := cluster.CreateAWSBuilder(rosaTypes.Classic, nil, pointer("test"), nil, nil, false, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -257,7 +257,7 @@ var _ = Describe("Cluster", func() {
 			err := cluster.CreateAWSBuilder(rosaTypes.Classic, map[string]string{"key1": "val1"},
 				pointer(string(cmv1.Ec2MetadataHttpTokensRequired)),
 				pointer(validKmsKey), nil, true, pointer(accountID), nil,
-				sts, subnets, nil, nil, nil, nil, nil, nil, nil, nil)
+				sts, subnets, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -299,7 +299,7 @@ var _ = Describe("Cluster", func() {
 			err := cluster.CreateAWSBuilder(rosaTypes.Classic, map[string]string{"key1": "val1"},
 				pointer(string(cmv1.Ec2MetadataHttpTokensRequired)),
 				pointer(validKmsKey), nil, true, pointer(accountID), nil,
-				sts, subnets, &privateHZId, &privateHZRoleArn, nil, nil, nil, nil, nil, nil)
+				sts, subnets, &privateHZId, &privateHZRoleArn, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			ocmCluster, err := cluster.Build()
 			Expect(err).NotTo(HaveOccurred())
@@ -324,7 +324,7 @@ var _ = Describe("Cluster", func() {
 			err := cluster.CreateAWSBuilder(rosaTypes.Classic, map[string]string{"key1": "val1"},
 				pointer(string(cmv1.Ec2MetadataHttpTokensRequired)),
 				pointer(validKmsKey), nil, true, pointer(accountID), nil,
-				sts, subnets, &privateHZId, &privateHZRoleArn, nil, nil, nil, nil, nil, nil)
+				sts, subnets, &privateHZId, &privateHZRoleArn, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 		})
 		It("PrivateHostedZone set missing STS - fail", func() {
@@ -336,7 +336,7 @@ var _ = Describe("Cluster", func() {
 			err := cluster.CreateAWSBuilder(rosaTypes.Classic, map[string]string{"key1": "val1"},
 				pointer(string(cmv1.Ec2MetadataHttpTokensRequired)),
 				pointer(validKmsKey), nil, true, pointer(accountID), nil,
-				nil, subnets, &privateHZId, &privateHZRoleArn, nil, nil, nil, nil, nil, nil)
+				nil, subnets, &privateHZId, &privateHZRoleArn, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 		})
 		It("PrivateHostedZone set missing subnet ids - fail", func() {
@@ -355,7 +355,7 @@ var _ = Describe("Cluster", func() {
 			err := cluster.CreateAWSBuilder(rosaTypes.Classic, map[string]string{"key1": "val1"},
 				pointer(string(cmv1.Ec2MetadataHttpTokensRequired)),
 				pointer(validKmsKey), nil, true, pointer(accountID), nil,
-				sts, nil, &privateHZId, &privateHZRoleArn, nil, nil, nil, nil, nil, nil)
+				sts, nil, &privateHZId, &privateHZRoleArn, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
@@ -660,7 +660,7 @@ func createClassicClusterObject(ctx context.Context,
 		isPrivateLink, awsAccountID, nil, stsBuilder, awsSubnetIDs,
 		privateHostedZoneID, privateHostedZoneRoleARN, nil, nil,
 		awsAdditionalComputeSecurityGroupIds, awsAdditionalInfraSecurityGroupIds,
-		awsAdditionalControlPlaneSecurityGroupIds, nil); err != nil {
+		awsAdditionalControlPlaneSecurityGroupIds, nil, nil); err != nil {
 		return nil, err
 	}
 

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -420,6 +420,18 @@ func (r *ClusterRosaHcpResource) Schema(ctx context.Context, req resource.Schema
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"audit_log_arn": schema.StringAttribute{
+				Description: "ARN of the IAM role for CloudWatch audit log forwarding. " +
+					"The role must have a trust policy allowing the OpenShift logging service account " +
+					"(system:serviceaccount:openshift-logging:cluster-logging) to assume it via OIDC.",
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^arn:aws:iam::\d{12}:role/[\w+=,.@-]+$`),
+						"audit_log_arn must be a valid IAM role ARN",
+					),
+				},
+			},
 		},
 	}
 }
@@ -598,11 +610,14 @@ func createHcpClusterObject(ctx context.Context,
 		return nil, err
 	}
 
+	auditLogArn := common.OptionalString(state.AuditLogArn)
+
 	if err := ocmClusterResource.CreateAWSBuilder(rosaTypes.Hcp, awsTags, ec2MetadataHttpTokens,
 		kmsKeyARN, etcdKmsKeyArn,
 		isPrivate, awsAccountID, awsBillingAccountId, stsBuilder, awsSubnetIDs,
 		ingressHostedZoneId, route53RoleArn, internalCommunicationHostedZoneId, vpceRoleArn,
-		awsAdditionalComputeSecurityGroupIds, nil, nil, awsAdditionalAllowedPrincipals); err != nil {
+		awsAdditionalComputeSecurityGroupIds, nil, nil, awsAdditionalAllowedPrincipals,
+		auditLogArn); err != nil {
 		return nil, err
 	}
 
@@ -717,6 +732,8 @@ func createHcpClusterObject(ctx context.Context,
 		externalAuthConfigBuilder := cmv1.NewExternalAuthConfig().Enabled(true)
 		builder.ExternalAuthConfig(externalAuthConfigBuilder)
 	}
+
+	// CloudWatch audit log forwarding is now handled in CreateAWSBuilder
 
 	object, err := builder.Build()
 	return object, err
@@ -1176,6 +1193,24 @@ func (r *ClusterRosaHcpResource) Update(ctx context.Context, request resource.Up
 		clusterBuilder.AWS(awsBuilder)
 	}
 
+	// CloudWatch audit log forwarding
+	// audit_log is nested under AWS configuration (aws.audit_log.role_arn)
+	// Reference: OCM API spec - AWS.audit_log.role_arn
+	if newAuditLogArn, shouldPatch := common.ShouldPatchString(state.AuditLogArn, plan.AuditLogArn); shouldPatch {
+		auditLogAwsBuilder := cmv1.NewAWS()
+		if newAuditLogArn != "" {
+			auditLogBuilder := cmv1.NewAuditLog()
+			auditLogBuilder.RoleArn(newAuditLogArn)
+			auditLogAwsBuilder.AuditLog(auditLogBuilder)
+		} else {
+			// To remove audit log, set it to empty
+			auditLogBuilder := cmv1.NewAuditLog()
+			auditLogBuilder.RoleArn("")
+			auditLogAwsBuilder.AuditLog(auditLogBuilder)
+		}
+		clusterBuilder.AWS(auditLogAwsBuilder)
+	}
+
 	clusterSpec, err := clusterBuilder.Build()
 	if err != nil {
 		response.Diagnostics.AddError(
@@ -1596,6 +1631,24 @@ func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, stat
 			return err
 		}
 		state.AWSSubnetIDs = awsSubnetIds
+	}
+
+	// CloudWatch audit log ARN
+	// audit_log is nested under AWS configuration (aws.audit_log.role_arn)
+	// Reference: OCM API spec - AWS.audit_log.role_arn
+	if awsObj, ok := object.GetAWS(); ok {
+		if auditLog, ok := awsObj.GetAuditLog(); ok {
+			auditLogArn, ok := auditLog.GetRoleArn()
+			if ok && auditLogArn != "" {
+				state.AuditLogArn = types.StringValue(auditLogArn)
+			} else {
+				state.AuditLogArn = types.StringNull()
+			}
+		} else {
+			state.AuditLogArn = types.StringNull()
+		}
+	} else {
+		state.AuditLogArn = types.StringNull()
 	}
 
 	hasProxy := true

--- a/provider/clusterrosa/hcp/state.go
+++ b/provider/clusterrosa/hcp/state.go
@@ -77,4 +77,7 @@ type ClusterRosaHcpState struct {
 
 	// External authentication fields
 	ExternalAuthProvidersEnabled types.Bool `tfsdk:"external_auth_providers_enabled"`
+
+	// CloudWatch audit logging fields
+	AuditLogArn types.String `tfsdk:"audit_log_arn"`
 }


### PR DESCRIPTION
Add support for configuring CloudWatch audit log forwarding via the audit_log_arn attribute in the rhcs_cluster_rosa_hcp resource.

Changes:
- Added audit_log_arn schema attribute with IAM role ARN validation
- Added AuditLogArn field to ClusterRosaHcpState
- Updated CreateAWSBuilder to accept and configure audit log ARN
- Implemented create, update, and read operations for audit log ARN
- Updated test calls to include auditLogArn parameter

The audit_log_arn attribute:
- Accepts a valid IAM role ARN (validated via regex)
- Configures CloudWatch audit log forwarding via OCM API
- Supports create, update, and delete operations
- Maps to aws.audit_log.role_arn in the OCM API structure

Implementation follows OCM API specification where audit log is nested under AWS configuration (aws.audit_log.role_arn), not a separate CloudWatch object.

Uses OCM SDK methods:
- cmv1.NewAuditLog() - Create audit log builder
- AuditLogBuilder.RoleArn(string) - Set role ARN
- AWSBuilder.AuditLog(*AuditLogBuilder) - Attach to AWS builder
- AWS.GetAuditLog() - Read audit log from cluster
- AuditLog.GetRoleArn() - Get role ARN

This enables Terraform users to configure CloudWatch audit log forwarding without requiring external scripts or rosa CLI.
