### PR TITLE
OCM-21630 | fix: Wait after acking before upgrading

### DIFF
--- a/tests/e2e/cluster_upgrade_test.go
+++ b/tests/e2e/cluster_upgrade_test.go
@@ -155,9 +155,14 @@ var _ = Describe("Upgrade", func() {
 				// Expect(err).To(HaveOccurred())
 				// Expect(err.Error()).To(ContainSubstring("Missing required acknowledgements to schedule upgrade"))
 
+				By("Acknowledge and wait for clusterdeployment to sync, takes ~60 seconds")
+				clusterArgs.UpgradeAcknowledgementsFor = helper.StringPointer(majorVersion)
+				_, err = clusterService.Apply(clusterArgs)
+				Expect(err).ToNot(HaveOccurred())
+				time.Sleep(2 * time.Minute)
+
 				By("Apply the cluster Upgrade")
 				clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
-				clusterArgs.UpgradeAcknowledgementsFor = helper.StringPointer(majorVersion)
 				_, err = clusterService.Apply(clusterArgs)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -94,7 +94,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   domain_prefix                                   = var.domain_prefix
   private_hosted_zone                             = var.private_hosted_zone
   lifecycle {
-    ignore_changes = [availability_zones]
+    ignore_changes = [availability_zones, sts]
   }
   wait_for_create_complete   = var.wait_for_cluster
   disable_waiting_in_destroy = var.disable_waiting_in_destroy

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
@@ -76,7 +76,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa_hcp_cluster" {
   destroy_timeout              = 60
   upgrade_acknowledgements_for = var.upgrade_acknowledgements_for
   lifecycle {
-    ignore_changes = [availability_zones]
+    ignore_changes = [availability_zones, sts]
   }
   aws_additional_compute_security_group_ids       = var.additional_compute_security_groups
   wait_for_create_complete                        = var.wait_for_cluster


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**:

Fixes an e2e test issue where the ack for OCP 4.20 was not updated in the cluster deployment before an upgrade was attempted in most cases, causing flakey E2E test failures

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #[OCM-21630](https://issues.redhat.com//browse/OCM-21630)

**Change type**
- [ ] New feature
- [X] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [X] Subsystem tests

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
