### PR TITLE
OCM-18335 | fix: machinepool EC version upgrades

### DIFF
--- a/provider/machinepool/hcp/machine_pool_resource.go
+++ b/provider/machinepool/hcp/machine_pool_resource.go
@@ -1340,6 +1340,8 @@ func populateState(ctx context.Context, object *cmv1.NodePool, state *HcpMachine
 		version, ok := object.Version().GetID()
 		// If we're using a non-default channel group, it will have been appended to
 		// the version ID. Remove it before saving state.
+		channelGroup, _ := cluster.Version().GetChannelGroup()
+		version = strings.TrimSuffix(version, fmt.Sprintf("-%s", channelGroup))
 		version = strings.TrimPrefix(version, rosa.VersionPrefix)
 		if ok {
 			state.CurrentVersion = types.StringValue(version)


### PR DESCRIPTION
**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Build
- [ ] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.

# Details

This PR fixes a bug where HCP machine pool upgrades between early candidate (EC) versions would fail with the error "cluster version is already above the requested version", even when upgrading to a newer version (e.g., from `4.20.0-ec.5` to `4.20.0-ec.6`).

---

## Fixed Behavior

1. Upgrade a machine pool from one EC version to a newer EC version:

    ```hcl
    resource "rhcs_hcp_machine_pool" "mps" {
      # ...
      version = "4.20.0-ec.6"  # Upgrading from 4.20.0-ec.5
    }
    ```

2. Now correctly identifies that `4.20.0-ec.6` is newer than `4.20.0-ec.5` and schedules the upgrade:

    ```
    rhcs_hcp_machine_pool.mps[0]: Modifying... [id=np-72513-uu]
    rhcs_hcp_machine_pool.mps[0]: Modifications complete
    ```

---

## Previous Behavior

Before this fix, upgrading between EC versions would fail because the channel group suffix (e.g., `-candidate`) was not being trimmed from the version ID stored in state:

```bash
terraform apply
```

Output:
```
Error: Can't upgrade machine pool

  with rhcs_hcp_machine_pool.mps[0],
  on main.tf line 28, in resource "rhcs_hcp_machine_pool" "mps":
  28: resource "rhcs_hcp_machine_pool" "mps" {

Can't upgrade machine pool version with identifier: `np-72513-uu`, cluster
version is already above the requested version
```

The root cause was that the state stored `4.20.0-ec.5-candidate` instead of `4.20.0-ec.5`, causing the version comparison to incorrectly determine that `ec.5-candidate` > `ec.6` (lexicographically).

---

# Ticket

Closes [OCM-18335](https://issues.redhat.com/browse/OCM-18335)