### PR TITLE
OCM-22297 | ci: Fixing id:72514,id:72478, upgrade tests, disabling IMDS tests for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ unit-test-coverage: $(GINKGO)
 
 
 .PHONY: test tests
-test tests: unit-test subsystem-test
+test tests: unit-test subsystem-test e2e-unit-test
 
 .PHONY: fmt_go
 fmt_go: $(GCI)
@@ -187,6 +187,13 @@ docs:
 .PHONY: tools
 tools:
 	@$(MAKE) --no-print-directory $(GCI) $(GINKGO) $(MOCKGEN) $(GOLANGCI_LINT)
+
+.PHONY: e2e-unit-test
+e2e-unit-test: $(GINKGO)
+	$(GINKGO) run \
+		--succinct \
+		-ldflags="$(ldflags)" \
+		-r tests/utils/...
 
 .PHONY: e2e_sanity_test
 e2e_sanity_test: $(GINKGO) install

--- a/tests/e2e/cluster_edit_test.go
+++ b/tests/e2e/cluster_edit_test.go
@@ -401,8 +401,8 @@ var _ = Describe("Edit cluster", ci.Day2, func() {
 			currentVersion := clusterResp.Body().Version().RawID()
 
 			By("Get new channel group")
-			otherChannelGroup := constants.VersionNightlyChannel
-			if profileHandler.Profile().GetChannelGroup() == constants.VersionNightlyChannel {
+			otherChannelGroup := constants.VersionFastChannel
+			if profileHandler.Profile().GetChannelGroup() == constants.VersionFastChannel {
 				otherChannelGroup = constants.VersionCandidateChannel
 			}
 
@@ -419,10 +419,6 @@ var _ = Describe("Edit cluster", ci.Day2, func() {
 			}
 
 			By("Edit channel_group")
-			otherChannelGroup = constants.VersionStableChannel
-			if profileHandler.Profile().GetChannelGroup() == constants.VersionStableChannel {
-				otherChannelGroup = constants.VersionEusChannel
-			}
 			validateClusterArg(func(args *exec.ClusterArgs) {
 				args.ChannelGroup = helper.StringPointer(otherChannelGroup)
 			}, func(output string, err error) {

--- a/tests/e2e/cluster_upgrade_test.go
+++ b/tests/e2e/cluster_upgrade_test.go
@@ -25,12 +25,14 @@ var _ = Describe("Upgrade", func() {
 	defer GinkgoRecover()
 
 	var (
-		targetV        string
-		clusterID      string
-		profileHandler profilehandler.ProfileHandler
-		profile        profilehandler.ProfileSpec
-		clusterArgs    *exec.ClusterArgs
-		clusterService exec.ClusterService
+		targetV           string
+		availableUpgrades []string
+		clusterID         string
+		profileHandler    profilehandler.ProfileHandler
+		profile           profilehandler.ProfileSpec
+		clusterArgs       *exec.ClusterArgs
+		clusterService    exec.ClusterService
+		channelGroup      string
 	)
 
 	BeforeEach(func() {
@@ -47,235 +49,164 @@ var _ = Describe("Upgrade", func() {
 		Expect(err).ToNot(HaveOccurred())
 		clusterArgs, err = clusterService.ReadTFVars()
 		Expect(err).ToNot(HaveOccurred())
+
+		clusterResp, err := cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
+		Expect(err).ToNot(HaveOccurred())
+		availableUpgrades, err = cms.GetVersionUpgrades(cms.RHCSConnection, clusterResp.Body().Version().ID())
+		Expect(err).ToNot(HaveOccurred())
+
+		channelGroup = clusterResp.Body().Version().ChannelGroup()
 	})
 
-	Context("ROSA STS cluster", func() {
-		BeforeEach(func() {
-			if profile.IsHCP() {
-				Skip("Test can run only on Classic cluster")
+	It("on Z-stream - [id:63153] [id:72474]", ci.Upgrade,
+		func() {
+			if profile.GetVersion() != constants.VersionZStream {
+				Skip("The test is configured only for Z-stream upgrade")
+			}
+			clusterResp, err := cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
+				constants.Z, availableUpgrades)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Validate invalid OCP version - downgrade")
+			currentVersion := string(clusterResp.Body().Version().RawID())
+			splittedVersion := strings.Split(currentVersion, ".")
+			zStreamV, err := strconv.Atoi(splittedVersion[2])
+			Expect(err).ToNot(HaveOccurred())
+
+			downgradedVersion := fmt.Sprintf("%s.%s.%s", splittedVersion[0], splittedVersion[1], fmt.Sprint(zStreamV-1))
+
+			imageVersionsList := cms.EnabledVersions(cms.RHCSConnection, channelGroup, profile.GetMajorVersion(), true)
+			versionsList := cms.GetRawVersionList(imageVersionsList)
+			if slices.Contains(versionsList, downgradedVersion) {
+				clusterArgs.OpenshiftVersion = helper.StringPointer(downgradedVersion)
+				_, err = clusterService.Apply(clusterArgs)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("cluster version is already above the\nrequested version"))
+
+			}
+
+			By("Run the cluster update")
+			clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
+			_, err = clusterService.Apply(clusterArgs)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Wait the upgrade finished")
+			if profile.GetClusterType().HCP {
+				err = openshift.WaitHCPClusterUpgradeFinished(cms.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred(), "Cluster %s failed with the error %v", clusterID, err)
+			} else {
+				err = openshift.WaitClassicClusterUpgradeFinished(cms.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred(), "Cluster %s failed with the error %v", clusterID, err)
+			}
+
+			By("Wait for 10 minutes to be sure the version is synced in clusterdeployment")
+			time.Sleep(10 * time.Minute)
+
+			By("Check the cluster status and OCP version")
+			clusterResp, err = cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
+			Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
+
+			if config.IsWaitForOperators() && !profile.IsPrivate() {
+				// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
+				timeout := 60
+				err = openshift.WaitForOperatorsToBeReady(cms.RHCSConnection, clusterID, timeout)
+				Expect(err).ToNot(HaveOccurred())
 			}
 		})
 
-		It("on Z-stream - [id:63153]", ci.Upgrade,
-			func() {
-				if profile.GetVersion() != constants.VersionZStream {
-					Skip("The test is configured only for Z-stream upgrade")
-				}
-				clusterResp, err := cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred())
-				targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
-					constants.Z, clusterResp.Body().Version().AvailableUpgrades())
-				Expect(err).ToNot(HaveOccurred())
+	It("on Y-stream - [id:63152] [id:72475]", ci.Upgrade,
+		func() {
+			if profile.GetVersion() != constants.VersionYStream {
+				Skip("The test is configured only for Y-stream upgrade")
+			}
 
-				By("Validate invalid OCP version - downgrade")
-				currentVersion := string(clusterResp.Body().Version().RawID())
-				splittedVersion := strings.Split(currentVersion, ".")
-				zStreamV, err := strconv.Atoi(splittedVersion[2])
-				Expect(err).ToNot(HaveOccurred())
+			By("Get cluster info")
+			clusterResp, err := cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
+				constants.Y, availableUpgrades)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(targetV).ToNot(Equal(""))
 
-				downgradedVersion := fmt.Sprintf("%s.%s.%s", splittedVersion[0], splittedVersion[1], fmt.Sprint(zStreamV-1))
+			By("Upgrade account-roles")
+			majorVersion := helper.GetMajorVersion(targetV)
+			Expect(majorVersion).ToNot(Equal(""))
+			_, err = profileHandler.Prepare().PrepareAccountRoles(token, clusterResp.Body().Name(), profile.GetUnifiedAccRolesPath(), majorVersion, channelGroup, "")
+			Expect(err).ToNot(HaveOccurred())
 
-				imageVersionsList := cms.EnabledVersions(cms.RHCSConnection, profile.GetChannelGroup(), profile.GetMajorVersion(), true)
-				versionsList := cms.GetRawVersionList(imageVersionsList)
-				if slices.Contains(versionsList, downgradedVersion) {
-					clusterArgs.OpenshiftVersion = helper.StringPointer(downgradedVersion)
-					_, err = clusterService.Apply(clusterArgs)
-					Expect(err).To(HaveOccurred())
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("cluster version is already above the\nrequested version"))
+			By("Validate invalid OCP version field - downgrade")
+			currentVersion := string(clusterResp.Body().Version().RawID())
+			splittedVersion := strings.Split(currentVersion, ".")
+			yStreamV, err := strconv.Atoi(splittedVersion[1])
+			Expect(err).ToNot(HaveOccurred())
 
-				}
-
-				By("Run the cluster update")
-				clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
+			downgradedVersion := fmt.Sprintf("%s.%s.%s", splittedVersion[0], fmt.Sprint(yStreamV-1), splittedVersion[2])
+			imageVersionsList := cms.EnabledVersions(cms.RHCSConnection, channelGroup, profile.GetMajorVersion(), true)
+			versionsList := cms.GetRawVersionList(imageVersionsList)
+			if slices.Contains(versionsList, downgradedVersion) {
+				clusterArgs.OpenshiftVersion = helper.StringPointer(downgradedVersion)
 				_, err = clusterService.Apply(clusterArgs)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("cluster version is already above the\nrequested version"))
+
+			}
+
+			// Blocked by OCM-7641
+			// By("Validate  the cluster Upgrade upgrade_acknowledge field")
+			// clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
+			// _, err = clusterService.Apply(clusterArgs)
+			// Expect(err).To(HaveOccurred())
+			// Expect(err.Error()).To(ContainSubstring("Missing required acknowledgements to schedule upgrade"))
+
+			By("Change the cluster channel")
+			targetChannel := fmt.Sprintf("%s-%s", channelGroup, majorVersion)
+			Logger.Infof("Setting channel for cluster '%s' to '%s'", clusterID, targetChannel)
+			err = cms.ChangeClusterChannel(cms.RHCSConnection, clusterID, targetChannel)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Wait for the cluster channel to update")
+			Eventually(func() []string {
+				clusterDetails, err := cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
 				Expect(err).ToNot(HaveOccurred())
+				Logger.Infof("Found these available upgrades: %s", strings.Join(clusterDetails.Body().Version().AvailableUpgrades(), ","))
+				return clusterDetails.Body().Version().AvailableUpgrades()
+			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 1).Should(ContainElement(targetV))
 
-				By("Wait the upgrade finished")
-				err = openshift.WaitClassicClusterUpgradeFinished(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred(), "Cluster upgrade %s failed with the error %v", clusterID, err)
+			Logger.Infof("Starting cluster upgrade to version '%s' on channel '%s'", targetV, targetChannel)
 
-				By("Wait for 10 minutes to be sure the version is synced in clusterdeployment")
-				time.Sleep(10 * time.Minute)
+			By("Apply the cluster Upgrade")
+			clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
+			clusterArgs.UpgradeAcknowledgementsFor = helper.StringPointer(majorVersion)
+			_, err = clusterService.Apply(clusterArgs)
+			Expect(err).ToNot(HaveOccurred())
 
-				By("Check the cluster status and OCP version")
-				clusterResp, err = cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
-				Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
-
-				if config.IsWaitForOperators() && !profile.IsPrivate() {
-					// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
-					timeout := 60
-					err = openshift.WaitForOperatorsToBeReady(cms.RHCSConnection, clusterID, timeout)
-					Expect(err).ToNot(HaveOccurred())
-				}
-			})
-
-		It("on Y-stream - [id:63152]", ci.Upgrade,
-			func() {
-				if profile.GetVersion() != constants.VersionYStream {
-					Skip("The test is configured only for Y-stream upgrade")
-				}
-
-				clusterResp, err := cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred())
-				targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
-					constants.Y, clusterResp.Body().Version().AvailableUpgrades())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(targetV).ToNot(Equal(""))
-
-				By("Upgrade account-roles")
-				majorVersion := helper.GetMajorVersion(targetV)
-				Expect(majorVersion).ToNot(Equal(""))
-				_, err = profileHandler.Prepare().PrepareAccountRoles(token, clusterResp.Body().Name(), profile.GetUnifiedAccRolesPath(), majorVersion, profile.GetChannelGroup(), "")
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Validate invalid OCP version field - downgrade")
-				currentVersion := string(clusterResp.Body().Version().RawID())
-				splittedVersion := strings.Split(currentVersion, ".")
-				yStreamV, err := strconv.Atoi(splittedVersion[1])
-				Expect(err).ToNot(HaveOccurred())
-
-				downgradedVersion := fmt.Sprintf("%s.%s.%s", splittedVersion[0], fmt.Sprint(yStreamV-1), splittedVersion[2])
-				imageVersionsList := cms.EnabledVersions(cms.RHCSConnection, profile.GetChannelGroup(), profile.GetMajorVersion(), true)
-				versionsList := cms.GetRawVersionList(imageVersionsList)
-				if slices.Contains(versionsList, downgradedVersion) {
-					clusterArgs.OpenshiftVersion = helper.StringPointer(downgradedVersion)
-					_, err = clusterService.Apply(clusterArgs)
-					Expect(err).To(HaveOccurred())
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("cluster version is already above the\nrequested version"))
-
-				}
-
-				// Blocked by OCM-7641
-				// By("Validate  the cluster Upgrade upgrade_acknowledge field")
-				// clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
-				// _, err = clusterService.Apply(clusterArgs)
-				// Expect(err).To(HaveOccurred())
-				// Expect(err.Error()).To(ContainSubstring("Missing required acknowledgements to schedule upgrade"))
-
-				By("Apply the cluster Upgrade")
-				clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
-				clusterArgs.UpgradeAcknowledgementsFor = helper.StringPointer(majorVersion)
-				_, err = clusterService.Apply(clusterArgs)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Wait the upgrade finished")
+			By("Wait the upgrade finished")
+			if profile.GetClusterType().HCP {
+				err = openshift.WaitHCPClusterUpgradeFinished(cms.RHCSConnection, clusterID)
+				Expect(err).ToNot(HaveOccurred(), "Cluster %s failed with the error %v", clusterID, err)
+			} else {
 				err = openshift.WaitClassicClusterUpgradeFinished(cms.RHCSConnection, clusterID)
 				Expect(err).ToNot(HaveOccurred(), "Cluster %s failed with the error %v", clusterID, err)
+			}
 
-				By("Wait for 10 minutes to be sure the version is synced in clusterdeployment")
-				time.Sleep(10 * time.Minute)
+			By("Wait for 10 minutes to be sure the version is synced in clusterdeployment")
+			time.Sleep(10 * time.Minute)
 
-				By("Check the cluster status and OCP version")
-				clusterResp, err = cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
+			By("Check the cluster status and OCP version")
+			clusterResp, err = cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
+			Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
+
+			if config.IsWaitForOperators() && !profile.IsPrivate() {
+				// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
+				timeout := 60
+				err = openshift.WaitForOperatorsToBeReady(cms.RHCSConnection, clusterID, timeout)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
-				Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
-
-				if config.IsWaitForOperators() && !profile.IsPrivate() {
-					// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
-					timeout := 60
-					err = openshift.WaitForOperatorsToBeReady(cms.RHCSConnection, clusterID, timeout)
-					Expect(err).ToNot(HaveOccurred())
-				}
-			})
-	})
-
-	Context("ROSA HCP cluster", func() {
-		BeforeEach(func() {
-			if !profile.IsHCP() {
-				Skip("Test can run only on Hosted cluster")
 			}
 		})
-
-		It("ROSA HCP cluster on Z-stream - [id:72474]", ci.Upgrade,
-			func() {
-				if profile.GetVersion() != constants.VersionZStream {
-					Skip("The test is configured only for Z-stream upgrade")
-				}
-
-				By("Retrieve cluster information and upgrade version")
-				clusterResp, err := cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred())
-				targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
-					constants.Z, clusterResp.Body().Version().AvailableUpgrades())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(targetV).ToNot(BeEmpty())
-
-				Logger.Infof("Gonna upgrade to version %s", targetV)
-
-				By("Run the cluster update")
-				clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
-				_, err = clusterService.Apply(clusterArgs)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Wait the upgrade finished")
-				err = openshift.WaitHCPClusterUpgradeFinished(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred(), "Cluster upgrade %s failed with the error %v", clusterID, err)
-
-				By("Check the cluster status and OCP version")
-				clusterResp, err = cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
-				Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
-
-				if config.IsWaitForOperators() && !profile.IsPrivate() {
-					// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
-					timeout := 60
-					err = openshift.WaitForOperatorsToBeReady(cms.RHCSConnection, clusterID, timeout)
-					Expect(err).ToNot(HaveOccurred())
-				}
-			})
-
-		It("ROSA HCP cluster on Y-stream - [id:72475]", ci.Upgrade,
-			func() {
-				if profile.GetVersion() != constants.VersionYStream {
-					Skip("The test is configured only for Y-stream upgrade")
-				}
-
-				By("Retrieve cluster information and upgrade version")
-				clusterResp, err := cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred())
-				targetV, err = cms.GetVersionUpgradeTarget(clusterResp.Body().Version().RawID(),
-					constants.Y, clusterResp.Body().Version().AvailableUpgrades())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(targetV).ToNot(BeEmpty())
-				majorVersion := helper.GetMajorVersion(targetV)
-				Expect(majorVersion).ToNot(BeEmpty())
-
-				Logger.Infof("Gonna upgrade to version %s", targetV)
-
-				clusterArgs.OpenshiftVersion = helper.StringPointer(targetV)
-				// Blocked by OCM-7641
-				// By("Validate the cluster Upgrade upgrade_acknowledge field")
-				// err = clusterService.Apply(clusterArgs)
-				// Expect(err).To(HaveOccurred())
-				// Expect(err.Error()).To(ContainSubstring("Missing required acknowledgements to schedule upgrade"))
-
-				By("Apply the cluster Upgrade")
-				clusterArgs.UpgradeAcknowledgementsFor = helper.StringPointer(majorVersion)
-				_, err = clusterService.Apply(clusterArgs)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Wait the upgrade finished")
-				err = openshift.WaitHCPClusterUpgradeFinished(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred(), "Cluster %s failed with the error %v", clusterID, err)
-
-				By("Check the cluster status and OCP version")
-				clusterResp, err = cms.RetrieveClusterDetail(cms.RHCSConnection, clusterID)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(clusterResp.Body().State())).To(Equal(constants.Ready))
-				Expect(string(clusterResp.Body().Version().RawID())).To(Equal(targetV))
-
-				if config.IsWaitForOperators() && !profile.IsPrivate() {
-					// WaitClusterOperatorsToReadyStatus will wait for cluster operators ready
-					timeout := 60
-					err = openshift.WaitForOperatorsToBeReady(cms.RHCSConnection, clusterID, timeout)
-					Expect(err).ToNot(HaveOccurred())
-				}
-			})
-	})
 })

--- a/tests/e2e/hcp_image_mirror_test.go
+++ b/tests/e2e/hcp_image_mirror_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/profilehandler"
 )
 
-var _ = Describe("HCP ImageMirror", ci.Day2, func() {
+// This whole test suite seems very flakey, disabling it for now
+// OCM-22745 is to track the work to re-enable these tests
+var _ = Describe("HCP ImageMirror", ci.Day2, ci.Exclude, func() {
 	defer GinkgoRecover()
 	var (
 		imageMirrorService exec.ImageMirrorService

--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -1030,14 +1030,6 @@ var _ = Describe("HCP MachinePool", ci.Day2, ci.FeatureMachinepool, func() {
 				args.Replicas = nil
 			}, "enabling autoscaling, should set value for maxReplicas")
 
-			By("Try to create a nodepool with autoscaling enabled and min_replicas=0")
-			validateMPArgAgainstErrorSubstrings(mpName, func(args *exec.MachinePoolArgs) {
-				args.AutoscalingEnabled = helper.BoolPointer(true)
-				args.Replicas = nil
-				args.MinReplicas = helper.IntPointer(0)
-				args.MaxReplicas = helper.IntPointer(3)
-			}, "'autoscaling.min_replica' must be greater than zero")
-
 			By("Try to create a nodepool with both replicas and autoscaling enabled")
 			validateMPArgAgainstErrorSubstrings(mpName, func(args *exec.MachinePoolArgs) {
 				args.AutoscalingEnabled = helper.BoolPointer(true)

--- a/tests/utils/cms/main_test.go
+++ b/tests/utils/cms/main_test.go
@@ -1,0 +1,46 @@
+package cms
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
+	. "github.com/onsi/gomega"             // nolint
+	"github.com/onsi/gomega/format"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+
+	. "github.com/terraform-redhat/terraform-provider-rhcs/subsystem/framework"
+)
+
+var connection *sdk.Connection
+var ctx context.Context
+
+func TestResource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CMS Helper Suite")
+}
+
+var _ = BeforeEach(func() {
+	format.MaxLength = 0 // set gomega format MaxLength to 0 to see all the diff when fails
+	// Create the server:
+	var ca string
+	TestServer, ca = MakeTCPTLSServer()
+	// Create an access token:
+	token := MakeTokenString("Bearer", 10*time.Minute)
+
+	ctx = context.Background()
+
+	var err error
+	connection, err = sdk.NewConnectionBuilder().URL(TestServer.URL()).TrustedCAFile(ca).Tokens(token).BuildContext(ctx)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterEach(func() {
+	// Close the server:
+	TestServer.Close()
+
+	// Close the connection:
+	connection.Close()
+})

--- a/tests/utils/cms/versions.go
+++ b/tests/utils/cms/versions.go
@@ -467,6 +467,33 @@ func GetVersionsWithUpgradesToVersion(connection *client.Connection, targetVersi
 	return imageVersionList, err
 }
 
+// It will return a list of versions which have an upgrade path from the current version
+func GetVersionUpgrades(client *client.Connection, originalVersion string) (upgrades []string, err error) {
+	res, err := client.ClustersMgmt().V1().Versions().Version(originalVersion).Get().Send()
+	if err != nil {
+		return nil, err
+	}
+	return res.Body().AvailableUpgrades(), nil
+}
+
+// ChangeClusterChannel updates the channel of a cluster. The newChannel should follow the
+// Y-stream format: "<channel_group>-<major>.<minor>" (e.g. "stable-4.19", "eus-4.16").
+// Returns an error if the cluster update fails or the API returns a non-200 status.
+func ChangeClusterChannel(client *client.Connection, clusterID string, newChannel string) (err error) {
+	cluster, err := v1.NewCluster().Channel(newChannel).Build()
+	if err != nil {
+		return err
+	}
+	res, err := client.ClustersMgmt().V1().Clusters().Cluster(clusterID).Update().Body(cluster).Send()
+	if err != nil {
+		return err
+	}
+	if res.Status() != 200 {
+		return res.Error()
+	}
+	return nil
+}
+
 // It will return a list of versions which have available upgrades in both y and z Streams
 func GetVersionUpgradeTarget(orginalVersion string, stream string, availableUpgrades []string) (targetV string, err error) {
 	semVersion, semVersionError := semver.NewVersion(orginalVersion)

--- a/tests/utils/cms/versions_test.go
+++ b/tests/utils/cms/versions_test.go
@@ -1,0 +1,182 @@
+package cms
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"                      // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+
+	. "github.com/terraform-redhat/terraform-provider-rhcs/subsystem/framework"
+)
+
+var _ = Describe("CMS Versions Helper", func() {
+	Context("GetVersionUpgrades works well", func() {
+		It("version with upgrades", func() {
+			version := "openshift-v4.19.0"
+			By("Prepare the server")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, fmt.Sprintf("/api/clusters_mgmt/v1/versions/%s", version)),
+					RespondWithJSON(http.StatusOK, `{
+					  "kind":"Version",
+					  "id":"openshift-v4.19.0",
+					  "href":"/api/clusters_mgmt/v1/versions/openshift-v4.19.0",
+					  "raw_id":"4.19.0",
+					  "enabled":true,
+					  "channel_group":"stable",
+					  "available_upgrades": [
+					    "4.19.1",
+					    "4.19.2",
+					    "4.19.3"
+					  ],
+					  "available_channels": [
+					    "eus-4.20",
+					    "stable-4.19",
+					    "stable-4.20"
+					  ]
+					}`),
+				),
+			)
+
+			By("Get the available upgrades")
+			versions, err := GetVersionUpgrades(connection, version)
+
+			By("Check the available upgrades")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).ToNot(BeEmpty())
+			Expect(versions).To(Equal([]string{"4.19.1", "4.19.2", "4.19.3"}))
+		})
+
+		It("version without upgrades", func() {
+			version := "openshift-v4.19.0"
+			By("Prepare the server")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, fmt.Sprintf("/api/clusters_mgmt/v1/versions/%s", version)),
+					RespondWithJSON(http.StatusOK, `{
+					  "kind":"Version",
+					  "id":"openshift-v4.19.0",
+					  "href":"/api/clusters_mgmt/v1/versions/openshift-v4.19.0",
+					  "raw_id":"4.19.0",
+					  "enabled":true,
+					  "channel_group":"stable",
+					  "available_upgrades": [],
+					  "available_channels": [
+					    "eus-4.20",
+					    "stable-4.19",
+					    "stable-4.20"
+					  ]
+					}`),
+				),
+			)
+
+			By("Get the available upgrades")
+			versions, err := GetVersionUpgrades(connection, version)
+
+			By("Check the available upgrades")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versions).To(BeEmpty())
+		})
+
+		It("invalid version", func() {
+			version := "4.19.0"
+			By("Prepare the server")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, fmt.Sprintf("/api/clusters_mgmt/v1/versions/%s", version)),
+					RespondWithJSON(http.StatusNotFound, `{
+					  "kind":"Error",
+					  "id":"404",
+					  "href":"/api/clusters_mgmt/v1/errors/404",
+					  "code":"CLUSTERS-MGMT-404",
+					  "reason":"Version '4.19.0' not found",
+					  "operation_id":"2fd9f62e-75b0-4d31-a66a-d253add6f31b",
+					  "timestamp":"2026-03-10T16:45:13.333975472Z"
+					}`),
+				),
+			)
+
+			By("Get the available upgrades")
+			versions, err := GetVersionUpgrades(connection, version)
+
+			By("Check the available upgrades")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Version '4.19.0' not found"))
+			Expect(versions).To(BeEmpty())
+		})
+	})
+
+	Context("ChangeClusterChannel", func() {
+		It("can change cluster channel", func() {
+			By("Prepare the server")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
+					VerifyJQ(".channel", "stable-4.19"),
+					RespondWithJSON(http.StatusOK, `{
+						"kind": "Cluster",
+						"id": "123",
+						"href": "/api/clusters_mgmt/v1/clusters/123",
+						"name": "cluster",
+						"state": "ready",
+						"channel": "stable-4.19"
+					}`),
+				),
+			)
+
+			By("Change the channel")
+			err := ChangeClusterChannel(connection, "123", "stable-4.19")
+			By("Check that it succeeded")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("invalid channel", func() {
+			By("Prepare the server")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
+					VerifyJQ(".channel", "invalid"),
+					RespondWithJSON(http.StatusBadRequest, `{
+					  "kind":"Error",
+					  "id":"400",
+					  "href":"/api/clusters_mgmt/v1/errors/400",
+					  "code":"CLUSTERS-MGMT-400",
+					  "reason":"Invalid channel format: 'invalid'. Channel must follow Y-stream format (e.g., stable-4.16, eus-4.16)",
+					  "operation_id":"2e685ee0-1237-4767-9558-eae87246da35",
+					  "timestamp":"2026-03-17T19:29:04.029369755Z"
+					}`),
+				),
+			)
+			By("Change the channel")
+			err := ChangeClusterChannel(connection, "123", "invalid")
+			By("Check that it failed")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("invalid cluster ID", func() {
+			By("Prepare the server")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
+					VerifyJQ(".channel", "stable-4.19"),
+					RespondWithJSON(http.StatusNotFound, `{
+					  "kind":"Error",
+					  "id":"404",
+					  "href":"/api/clusters_mgmt/v1/errors/404",
+					  "code":"CLUSTERS-MGMT-404",
+					  "reason":"Cluster '123' not found",
+					  "operation_id":"d8c32fec-345c-4ac6-b8f5-b092cd573229",
+					  "timestamp":"2026-03-17T19:33:45.173193619Z"
+					}`),
+				),
+			)
+			By("Change the channel")
+			err := ChangeClusterChannel(connection, "123", "stable-4.19")
+			By("Check that it failed")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
  The commit subject needs to conform to the following format:
  [JIRA-TICKET] | [TYPE]: <MESSAGE>
  Where:
     JIRA_TICKET is jira ticket ID (for example OCM-xxx)
     TYPE must be one of the options (case sensitive):
          feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For more info see [Commit Messages Format Guide](../CONTRIBUTE.md)
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
-->

**What this PR does / why we need it**: This is fixing a few CI failures that have been coming up lately
- `id:72514` - assumed that you can't create a node pool with autoscaling enabled and `min_replicas` set to `0`, but that actually seems to work fine
- `id:72478` - tried to change the channel group to `eus`, but that channel group only has even numbered y-stream versions. I switched it to try to use either the `fast` or `candidate` channel groups as those both seem to have the same versions as `stable` (which is required for the edit to succeed)
- A lot of the tests under `tests/e2e/hcp_image_mirror_test.go` have been very flaky since they've been introduced. Until we have time to re-write those tests I'm excluding the entire test suite to minimize the number of false negatives we get
- The upgrades tests needed updating to set the `channel` property on the cluster before listing the y-stream upgrades due to a recent API change. I also noticed that we had separate test cases for HCP clusters vs classic clusters, but they only seemed to really differ by a single line, so I combined the 4 test cases down to 2 test cases (y-stream vs z-stream) for now
  - I've tested that both z-stream and y-stream upgrades work well for HCP clusters
  - I've tested y-stream upgrades for classic clusters, but ran into an issue where it doesn't work on the first apply, but does work on the second apply. I think there may be either a provider bug or an API bug where the `upgrade_acknowledgements_for` field isn't actually working properly. I'm still trying to narrow down the issue, but I don't think it's related to my testing code changes at all as this was a known issue before as well. I tested z-stream upgrades for classic clusters, and didn't see any issues
  - I also had to update the `ocm-sdk-go` library version to be able to set the new `channel` property

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (OCM-xxxx)*:
Fixes #[OCM-22297](https://issues.redhat.com/browse/OCM-22297)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Build
- [x] CI
- [ ] Documentation
- [ ] Performance
- [ ] Refactor
- [ ] Style
- [ ] Unit tests
- [ ] Subsystem tests

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.

**Local logs:**
- [id:72478](https://github.com/user-attachments/files/25423227/72478-log.txt)
- [id:72514](https://github.com/user-attachments/files/25423229/72514-log.txt)
- [HCP y-stream upgrade](https://github.com/user-attachments/files/25423230/hcp-up-y-log.txt)
- [HCP z-stream upgrade](https://github.com/user-attachments/files/25423231/hcp-up-z-log.txt)
- [Classic y-stream upgrade](https://github.com/user-attachments/files/25493367/sts-up-y-log.txt)
- [Classic z-stream upgrade](https://github.com/user-attachments/files/25493369/sts-up-z-log.txt)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored cluster upgrade and edit test suites for improved organization and reduced duplication
  * Added new testing utilities for version management and cluster channel updates
  * Disabled HCP ImageMirror test suite due to known flakiness
  * Removed outdated autoscaling validation test case

<!-- end of auto-generated comment: release notes by coderabbit.ai -->