### PR TITLE
OCM-22944 | docs: add agents.md and related ai agents documentation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,88 @@
+inheritance: true
+reviews:
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        - Follow Effective Go and Go Code Review Comments conventions.
+        - Verify imports and formatting are consistent with gofmt and repository rules.
+        - Check all errors are handled and wrapped with actionable context where needed.
+        - Flag variable shadowing, unnecessary nesting, and unclear naming.
+        - Prefer existing repository patterns over introducing new architecture.
+        - Ensure no secrets/tokens/credentials are hardcoded or logged.
+    - path: "provider/**/*.go"
+      instructions: |
+        - Review as Terraform Plugin Framework code (not legacy SDK patterns).
+        - Validate schema semantics for Required/Optional/Computed/Default and Sensitive flags.
+        - In Create/Update, ensure input comes from Plan; in Read, from State.
+        - Ensure response state never returns unknown values and RemoveResource is used only in Read for not-found.
+        - For nested blocks, verify required attributes are not partially populated.
+        - Prefer tflog for provider logging; avoid fmt.Print* debugging.
+        - Check import support consistency (ResourceWithImportState, ID validation) where applicable.
+    - path: "provider/clusterrosa/classic/**/*.go"
+      instructions: |
+        - Maintain classic implementation behavior and separation from HCP-specific logic.
+        - Call out parity risks where behavior should match HCP resources/data sources.
+    - path: "provider/clusterrosa/hcp/**/*.go"
+      instructions: |
+        - Maintain HCP implementation behavior and separation from classic-specific logic.
+        - Call out parity risks where behavior should match classic resources/data sources.
+    - path: "subsystem/**/*.go"
+      instructions: |
+        - Check subsystem tests follow existing patterns with TestServer handlers and Terraform runner flow.
+        - Verify behavior-changing code updates have corresponding subsystem coverage.
+    - path: "**/*_test.go"
+      instructions: |
+        - Prefer deterministic tests; avoid flaky timing/order dependencies.
+        - Match repository BDD style (Ginkgo/Gomega) and existing helper usage patterns.
+        - Ensure assertions cover behavior changes, not only happy paths.
+    - path: "Makefile"
+      instructions: |
+        - Keep targets aligned with CONTRIBUTING/README workflows (fmt, lint, build, pre-push-checks).
+        - Watch for tool version drift and duplicated version sources across go.mod, Dockerfiles, and Make variables.
+        - Confirm commands are reproducible and do not silently mutate module state in CI-critical paths.
+    - path: "**/Dockerfile"
+      instructions: |
+        - Prefer reproducible image builds; avoid mutating go.mod/go.sum during build unless that is an explicit, documented pattern.
+        - Keep Go/toolchain and install steps aligned with go.mod and Makefile (single source of truth).
+        - Flag hardcoded tool or base-image versions that will drift from the rest of the repo.
+        - No secrets, tokens, or credentials in layers, build args, or comments.
+    - path: "examples/**/*.tf"
+      instructions: |
+        - Match HashiCorp Terraform style for examples (formatting, naming, structure).
+        - Use provider/resource naming consistent with this repo (rhcs_*, realistic ROSA/OCM scenarios).
+        - No real secrets, tokens, ARNs of customer accounts, or kubeconfigs; use variables and placeholders.
+        - Call out when an example should be paired with updates under templates/ or registry docs if behavior or schema changed.
+    - path: "tests/**/*.tf"
+      instructions: |
+        - Match HashiCorp Terraform style; these files are formatted with terraform fmt like examples.
+        - No hardcoded credentials; keep test fixtures obviously non-production.
+        - Align resource blocks with provider schema and subsystem/e2e expectations.
+    - path: ".github/workflows/**/*.{yml,yaml}"
+      instructions: |
+        - Ensure workflow steps match repository make targets and verification gates (see CONTRIBUTING.md).
+        - Check pinned action versions and least-privilege permissions where possible.
+        - Flag CI changes that diverge from local pre-push checks or skip hooks unintentionally.
+        - Do not embed secrets in workflow YAML; use GitHub Actions secrets and OIDC patterns where applicable.
+        - For Go/Terraform jobs, ensure toolchain versions align with go.mod and documented prerequisites.
+    - path: "*.md"
+      instructions: |
+        - Verify documentation reflects current commands and version requirements from go.mod and Makefile.
+        - Keep wording actionable and consistent with provider terminology (ROSA, OCM, classic/HCP).
+    - path: "**/*.md"
+      instructions: |
+        - Do not duplicate checklists or command lists in AGENTS.md; refer to README.md, docs/, CONTRIBUTING.md, and .github/pull_request_template.md as the single sources of truth.
+  tools:
+    checkov:
+      enabled: true
+    golangci-lint:
+      enabled: true
+    hadolint:
+      enabled: true
+    markdownlint:
+      enabled: false
+    shellcheck:
+      enabled: true
+    tflint:
+      enabled: true
+    yamllint:
+      enabled: true

--- a/.cursor/rules/go.mdc
+++ b/.cursor/rules/go.mdc
@@ -1,12 +1,12 @@
 ---
-description: Go coding standards — Effective Go, Code Review Comments, CONTRIBUTE.md.
+description: Go coding standards — Effective Go, Code Review Comments, CONTRIBUTING.md.
 globs: "**/*.go"
 alwaysApply: false
 ---
 
 # Go — Review Checklist
 
-Follow [Effective Go](https://go.dev/doc/effective_go), [Code Review Comments](https://go.dev/wiki/CodeReviewComments), and [CONTRIBUTE.md](../CONTRIBUTE.md). 
+Follow [Effective Go](https://go.dev/doc/effective_go), [Code Review Comments](https://go.dev/wiki/CodeReviewComments), and [CONTRIBUTING.md](../CONTRIBUTING.md). 
 
 ---
 
@@ -72,6 +72,6 @@ Follow [Effective Go](https://go.dev/doc/effective_go), [Code Review Comments](h
 
 ---
 
-## Project (CONTRIBUTE.md)
+## Project (CONTRIBUTING.md)
 
 - Use the Go version from `go.mod`. Run `make build`; `go mod download` after dependency changes.

--- a/.cursor/rules/terraform_tests.mdc
+++ b/.cursor/rules/terraform_tests.mdc
@@ -14,7 +14,7 @@ alwaysApply: false
 
 - **New resource or data source:** Add at least one subsystem test under `subsystem/classic/` or `subsystem/hcp/` that exercises the main flow (e.g. apply/plan/read/destroy) using the shared framework (`TestServer`, `Terraform` runner). Optionally add a test for a key error path.
 - **Behavior-changing changes:** When changing CRUD behavior, validation, or state shape, add or update subsystem tests that cover the changed behavior. Not required for docs-only or refactor-only changes.
-- Use the existing pattern: stub the API with `TestServer.AppendHandlers`, set HCL with `Terraform.Source`, run `Terraform.Apply()` (or Plan/Destroy), assert on exit code and state with `Terraform.Resource()` and Gomega matchers. See CONTRIBUTE.md and existing tests in `subsystem/` for the test layout.
+- Use the existing pattern: stub the API with `TestServer.AppendHandlers`, set HCL with `Terraform.Source`, run `Terraform.Apply()` (or Plan/Destroy), assert on exit code and state with `Terraform.Resource()` and Gomega matchers. See CONTRIBUTING.md and existing tests in `subsystem/` for the test layout.
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Commit format requirement:
 [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
 TYPE must be one of:
 feat, fix, docs, style, refactor, test, chore, build, ci, perf
-For details, see: ./CONTRIBUTE.md
+For details, see: ./CONTRIBUTING.md
 -->
 
 ## PR Summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# Agent Guide — terraform-provider-rhcs
+
+This repository contains the Terraform provider for Red Hat Cloud Services (RHCS), with primary focus on ROSA APIs exposed through OCM.
+
+This guide defines how coding agents should make decisions, implement changes, and decide when to escalate to a human reviewer.
+
+## Where rules live (avoid drift)
+
+Do **not** duplicate checklists or command lists here. Use one source per concern:
+
+| Source | Use it for |
+|--------|------------|
+| `README.md` | Project overview, prerequisites, contributor setup summary, limitations, and links to deeper docs — **read this** for context before changing behavior or docs. |
+| `docs/` | Published provider documentation (often **generated** from `templates/` and schema); do not edit generated pages by hand when the workflow requires regeneration — follow `CONTRIBUTING.md`. |
+| `examples/` | Runnable Terraform under `examples/` (resources, data sources, guides paths); use for manual checks and as references for HCL style — align with provider schema and HashiCorp Terraform style. |
+| `CONTRIBUTING.md` | Commands, hooks, tests, formatting, release — **procedural authority**. |
+| `.github/pull_request_template.md` | What to fill in on a PR and the **Developer Verification Checklist** — **submission checklist**. |
+| `.cursor/rules/` | Code style and Terraform Plugin Framework guardrails. |
+| **`AGENTS.md` (this file)** | ROSA/OCM boundaries, escalation triggers, and **high-level** implementation flow — not step-by-step commands. |
+
+Thin entrypoints `CLAUDE.md` and `GEMINI.md` should only point here to avoid drift.
+
+**Precedence:** If anything here conflicts with `CONTRIBUTING.md` or `.cursor/rules/`, follow `CONTRIBUTING.md` first, then `.cursor/rules/`.
+
+**Before opening a PR:** Complete the checklist in `.github/pull_request_template.md`.
+
+## HashiCorp Terraform Skills
+
+Upstream skills: https://github.com/hashicorp/agent-skills/tree/main/terraform
+
+Recommended for this provider: `terraform-provider-development`, `terraform-test`, `terraform-style-guide` (open each skill’s `SKILL.md`). Treat `CONTRIBUTING.md` and `.cursor/rules/` as overriding generic skill text when they disagree.
+
+## Product boundaries (ROSA + OCM)
+
+- Do not implement provider support for capabilities that are not available in ROSA.
+- Validate feature availability against ROSA documentation and the official OCM API behavior before implementing resource or data source code.
+- When unsure whether support is ROSA HCP vs Classic (or both), stop and verify before implementation.
+
+Reference sources:
+
+- ROSA docs: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/
+- OCM API model (API specification): https://github.com/openshift-online/ocm-api-model
+
+## Expectations for agent-produced changes
+
+These are **review and design expectations**. They are not all enforced by automation; contributors and reviewers still apply them. Concrete commands and gates are in `CONTRIBUTING.md` (for example hooks, `make pre-push-checks`, coverage rules).
+
+- Do not hardcode secrets, API keys, tokens, kubeconfigs, AWS credentials, or customer identifiers in code, tests, docs, examples, or logs.
+- Do not document bypassing local hooks or verification gates.
+- Do not ship silent breaking changes: call out impact and migration in the PR (see **Breaking Changes** in the PR template).
+- Do not edit generated provider docs by hand when the workflow requires regeneration; edit sources and regenerate per `CONTRIBUTING.md`.
+- Prefer existing patterns in this repo over new architecture or naming.
+- Keep error messages actionable and consistent with project standards.
+
+## Common implementation flows
+
+### Add or change a resource
+
+1. Confirm capability exists in ROSA and OCM API.
+2. Inspect analogous resource implementations in `provider/` and follow schema/state/CRUD conventions.
+3. Add or update schema and state structs using existing package patterns.
+4. Implement create/read/update/delete behavior and diagnostics.
+5. Add/update unit tests in `provider/.../*_test.go`.
+6. Add/update subsystem coverage under `subsystem/` for behavior changes.
+7. Update docs source (`templates/` and schema descriptions), regenerate docs, and verify generated files.
+
+### Add or change a data source
+
+1. Confirm capability exists and is queryable through OCM APIs used by the provider.
+2. Follow existing data source patterns for schema, read behavior, and diagnostics.
+3. Validate shape and computed attributes against analogous data sources.
+4. Add/update unit tests and subsystem tests for the primary query flow.
+5. Regenerate and validate docs for the new/changed data source.
+
+## Breaking change policy
+
+Treat any change below as potentially breaking unless proven otherwise:
+
+- Attribute rename/removal/type change.
+- Required vs optional/computed contract changes.
+- Behavioral changes in plan/apply that alter existing successful configurations.
+- Import/state format changes.
+- Provider-wide dependency changes that can impact runtime, generated docs, authentication, or API compatibility.
+
+When a breaking change is necessary, use the PR template’s **Breaking Changes** section and migration fields, add tests that show the impact, update docs/examples, and request human review as required by `CONTRIBUTING.md`.
+
+## Human-in-the-loop triggers
+
+Stop and request explicit human review before merge when any of the following occurs:
+
+- Dependency bump for provider-wide tooling/runtime with possible broad impact, including:
+  - `terraform-plugin-docs`
+  - AWS SDK modules (for example `aws-sdk-go-v2`)
+  - Terraform Plugin Framework/core dependencies
+- Schema or state model changes affecting existing resources/data sources.
+- New feature appears unsupported or ambiguous in ROSA docs or OCM API.
+- Security-sensitive behavior changes (auth, token handling, trust bundles, proxy behavior, logging of request/response data).
+- CI failures suggest cross-repo or infrastructure issues rather than isolated code defects.
+
+## Use existing patterns first
+
+Before introducing new structure, identify and reuse:
+
+- Similar resource/data source package layouts.
+- Existing CRUD and diagnostics patterns.
+- Existing subsystem test wiring and assertions.
+- Existing docs template style and generated docs workflow.
+
+If no suitable pattern exists, document why in the PR description.
+
+To see how a similar change was done, search **merged** pull requests in this repository for the relevant `provider/` or `subsystem/` paths instead of relying on a single historical PR link.
+
+## Practical review heuristics for agents
+
+- Prefer small, reviewable commits scoped to one behavior change.
+- Keep PR descriptions concrete with reproducible validation steps (align with the template’s **How to Test**).
+- Avoid speculative refactors while implementing functional changes.
+- If a change touches both Classic and HCP behavior, call out parity or intentional divergence explicitly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Agent Entrypoint
+
+See `AGENTS.md` for all agent workflow rules and repository guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ It was targeted to developers who wish to help improve the provider, and does no
 Please read this document and follow this guide to ensure your contribution will be accepted as fast as possible.
 
 ## Contributing Code Guidelines
-To begin with, we appreciate your enthusiasm for contributing to RHCS Provider. 
+To begin with, we appreciate your enthusiasm for contributing to RHCS Provider.
 If you have any questions or uncertainties, feel free to reach out for help.
 
 ### 1. Report an issue
@@ -58,7 +58,7 @@ The hooks perform:
 - check runs are fail-fast: execution stops at the first failing step
 
 ### 4. Test your changes and use the CI (Pre Merge)
-We are holding three types of tests that must pass for a PR to finally be accepted and merged: 
+We are holding three types of tests that must pass for a PR to finally be accepted and merged:
 * `unit-tests` - for testing a small unit of resource or data source functionality [here is an example of cluster_rosa_classic unit-tests](provider/clusterrosa/classic/cluster_rosa_classic_resource_test.go)
 * `subsystem test` - write a test that describing what you will fix and locate it in the [subsystem test directory](subsystem).
 * `end-to-end tests` - those tests simulate a real resources and run in official OpenShift CI platform.
@@ -76,7 +76,7 @@ make pre-push-checks   # exact non-mutating verification used by the pre-push ho
 Changed-files coverage is enforced through `make coverage-changed-files` using `gocovdiff` with an 80% threshold for changed Go files under `provider/` and `internal/`.
 
 ### 5. Manual testing and debugging using the locally compiled RHCS Provider binary
-Manual testing should be performed before opening a PR in order to make sure there isn't any regression behavior in the provider. You can find [here an example for that](https://github.com/terraform-redhat/terraform-rhcs-rosa/tree/main/examples/rosa-classic-public-with-unmanaged-oidc) 
+Manual testing should be performed before opening a PR to ensure there isn't any regression behavior in the provider. You can find [here an example for that](https://github.com/terraform-redhat/terraform-rhcs-rosa/tree/main/examples/rosa-classic-public-with-unmanaged-oidc)
 After compiling the RHCS provider, debugging terraform provider can be difficult. But here are a some tips to make your life easier.
 
 First, Make sure you are using your local build of the provider. `make install` will compile the project and place the binary in the local `~/.terraform/` folder.
@@ -91,11 +91,11 @@ terraform {
   }
 }
 ```
-Use the `tflog` for println debugging: 
+Use the `tflog` for println debugging:
 ```go
     tflog.Debug(ctx, msg)
 ```
-Set environment variable `TF_LOG` to one of the log levels (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`). This will result in a more verbose output that can help you identify issues. 
+Set environment variable `TF_LOG` to one of the log levels (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`). This will result in a more verbose output that can help you identify issues.
 
 ### 6. Commit Messages
 
@@ -154,4 +154,4 @@ git-cliff v1.7.2..v1.7.3 --prepend CHANGELOG.md
 * [OpenShift Cluster Management API](https://api.openshift.com/) - Since the RHCS provider uses OpenShift APIs.
 * [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) documentation. RHCS provider is leveraging this framework heavily.
 * [Debugging Terraform](https://developer.hashicorp.com/terraform/internals/debugging) - More info about Terraform Logging and Debugging
-* [Terraform Language Documentation](https://developer.hashicorp.com/terraform/language) - Information about Terraform (resources and data sources for example) can be found in the
+* [Terraform Language Documentation](https://developer.hashicorp.com/terraform/language) - Information about Terraform resources and data sources.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# Gemini Agent Entrypoint
+
+See `AGENTS.md` for all agent workflow rules and repository guidance.

--- a/README.md
+++ b/README.md
@@ -129,5 +129,5 @@ You can also use specific commit images by substituting `latest` for the desired
 Binary image only runs on AMD64 architectures up to now.
 
 ### Developing the Provider
-Detailed documentation for developing and contributing to RHCS provider can be found in our [contribution guide](CONTRIBUTE.md).
+Detailed documentation for developing and contributing to RHCS provider can be found in our [contribution guide](CONTRIBUTING.md).
  

--- a/hack/commit-msg-verify.sh
+++ b/hack/commit-msg-verify.sh
@@ -12,7 +12,7 @@ print_commit_message_error() {
 $message
 Expected format: JIRA-12345 | <conventional-commit>
 Example: OCM-12345 | feat(scope): add support for foo
-Please check CONTRIBUTE.md for more details
+Please check CONTRIBUTING.md for more details
 EOF
 }
 


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary

Adds `AGENTS.md` plus thin `CLAUDE.md` / `GEMINI.md` entrypoints for coding-agent workflows; renames `CONTRIBUTE.md` to `CONTRIBUTING.md` and updates references across the repo; introduces CodeRabbit path instructions; bumps Konflux Tekton task bundle digests and lowers Renovate `prConcurrentLimit`.

## Detailed Description of the Issue

Contributors and automation tools referenced a misspelled `CONTRIBUTE.md` filename and lacked a single, repo-specific guide for AI agents (boundaries, doc precedence, ROSA/OCM expectations). Separately, Konflux catalog image digests needed refreshing, and Renovate concurrency was reduced to limit open automated PR volume.

## Related Issues and PRs
- Jira: [OCM-22944](https://issues.redhat.com/browse/OCM-22944)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: `AGENTS.md`, `CONTRIBUTING.md`

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [x] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- Contribution instructions lived under `CONTRIBUTE.md`; several files pointed at that path.
- No dedicated in-repo agent guide; Konflux tasks used older bundle SHAs; Renovate could open up to 10 concurrent PRs.

## Behavior After This Change

- Canonical contributing doc is `CONTRIBUTING.md`; hooks, README, PR template, and Cursor rules reference it.
- `AGENTS.md` documents agent rules, documentation precedence, ROSA/OCM boundaries, and links to ROSA docs and the `ocm-api-model` API specification; `CLAUDE.md` / `GEMINI.md` defer to `AGENTS.md`.
- `.coderabbit.yaml` adds path-specific review instructions for Go, provider packages, tests, workflows, and Markdown.
- `.tekton/terraform-provider-rhcs-push.yaml` uses updated `deprecated-image-check` and `clamav-scan` bundle digests; `renovate.json` sets `prConcurrentLimit` to `2`.

## How to Test (Step-by-Step)
### Preconditions

- None beyond a clean checkout of this branch.

### Test Steps

1. Confirm `CONTRIBUTING.md` exists and `CONTRIBUTE.md` is gone; open README and PR template links to the guide.
2. Skim `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` for broken relative references.
3. Optionally run `make pre-push-checks` to align with the updated contributor checklist.

### Expected Results

- All updated paths resolve; agent entrypoints point at `AGENTS.md`; CI/Konflux YAML remains valid YAML.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: N/A
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A — provider schema and runtime behavior are unchanged. Anyone with bookmarks or external docs linking to `CONTRIBUTE.md` should update those links to `CONTRIBUTING.md`.

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make pre-push-checks` passes.
- [ ] `make fmt-check` passes.
- [ ] `make build` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.