### PR TITLE
OCM-24009 | fix: initialize log_forwarder_ids

### DIFF
--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -2100,6 +2100,8 @@ func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, stat
 		state.ExternalAuthProvidersEnabled = types.BoolValue(true)
 	}
 
+	state.LogForwarderIds = types.ListNull(types.StringType)
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when the option is not applicable to your case.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary

  Fixes uninitialized `log_forwarder_ids` attribute in ROSA HCP cluster state.

  ## Detailed Description of the Issue

  The `log_forwarder_ids` attribute in `populateRosaHcpClusterState` was not explicitly initialized, leaving it nil when clusters have no log forwarders configured. Terraform Plugin Framework requires
  list attributes to be initialized to either a populated list or an explicit null value to maintain type contract consistency.

Why not getting the log forwarder ids inside of populateRosaHcpClusterState?
Separation of concerns: one function maps the cluster resource body; the other performs an extra round trip for a related sub-resource. That matches how the OCM API is modeled.

  ## Related Issues and PRs

  - Jira: [OCM-24009](https://issues.redhat.com/browse/OCM-24009)
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change

  - [ ] feat - adds a new user-facing capability.
  - [x] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  - `log_forwarder_ids` was uninitialized (nil) in state when no log forwarders were configured, violating Terraform type contracts.
  - 
  ## Behavior After This Change

  - `log_forwarder_ids` is explicitly initialized to `types.ListNull(types.StringType)` ensuring proper type contract adherence.

  ## How to Test (Step-by-Step)

  ### Preconditions

  - ROSA HCP cluster without log forwarders configured

  ### Test Steps

  1. Import or create a ROSA HCP cluster without log forwarders
  2. Run `terraform plan` and verify no state drift for `log_forwarder_ids`

  ### Expected Results

  - `log_forwarder_ids` appears in state as an empty list (not absent/nil)

  ## Proof of the Fix

  - Screenshots: N/A
  - Videos: N/A
  - Logs/CLI output: N/A
  - Other artifacts: Code review of state initialization logic in `resource.go:2103` 

  ## Breaking Changes

  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ### Breaking Change Details / Migration Plan

  N/A

  ## Developer Verification Checklist

  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] Tests were added/updated where appropriate.
  - [ ] I manually tested the change.
  - [ ] `make pre-push-checks` passes.
  - [ ] `make fmt-check` passes.
  - [ ] `make build` passes.
  - [ ] Documentation was added/updated where appropriate.
  - [ ] Any risk, limitation, or follow-up work is documented.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fix**
  * Established stable default values for log forwarder configuration, preventing configuration inconsistencies during cluster state updates and improving overall reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terraform-redhat/terraform-provider-rhcs/pull/1142)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->