### PR TITLE
OCM-00000 | chore: replace version by sha in github actions

### DIFF
--- a/.github/workflows/check-commit-format.yml
+++ b/.github/workflows/check-commit-format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Validate Commit Message(s)

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -27,15 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4.0.0
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.0
         with:
           terraform_wrapper: false
       - name: Run pre-push checks
@@ -52,15 +52,15 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4.0.0
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.0
         with:
           terraform_wrapper: false
       - name: Run the tests

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate changelog
         if: steps.check-commits.outputs.commit_count != '0'
-        uses: orhun/git-cliff-action@v4.7.1
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         id: git-cliff
         with:
           config: cliff.toml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create PR with changelog
         if: steps.check-commits.outputs.commit_count != '0'
-        uses: peter-evans/create-pull-request@v8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: changelog-${{ github.ref_name }}


### PR DESCRIPTION
<!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when the option is not applicable to your case.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary
  Pin GitHub Actions to commit SHAs instead of semantic version tags to prevent supply chain attacks via tag manipulation.

  ## Detailed Description of the Issue
  GitHub Actions referenced by semantic version tags (e.g., `v6.0.2`) can be altered if an attacker compromises a repository and force-pushes a malicious commit to an existing tag. Pinning to immutable commit SHAs with inline version comments maintains
  readability while eliminating this attack vector.

  ## Related Issues and PRs
  - Jira: N/A
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change
  <!-- Check the primary type this PR represents -->
  - [ ] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [x] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior
  GitHub Actions workflow files referenced actions using semantic version tags:
  - `actions/checkout@v6.0.2`
  - `actions/setup-go@v6.3.0` and `v6.4.0`
  - `hashicorp/setup-terraform@v4.0.0`
  - `orhun/git-cliff-action@v4.7.1` and `v4.8.0`
  - `peter-evans/create-pull-request@v8.1.1`

  ## Behavior After This Change
  Actions are pinned to immutable commit SHAs with version comments for readability:
  - `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
  - `actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0`
  - `hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.0`
  - `orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0`
  - `peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1`

  ## How to Test (Step-by-Step)
  ### Preconditions
  N/A

  ### Test Steps
  1. Trigger any workflow that uses the updated actions (e.g., push a commit, open a PR).
  2. Verify the workflow runs successfully with the pinned SHA references.
  3. Confirm workflow output matches expected behavior from the specified action versions.

  ### Expected Results
  All GitHub Actions workflows execute normally using the pinned commit SHAs.

  ## Proof of the Fix
  - Screenshots: N/A
  - Videos: N/A
  - Logs/CLI output: CI workflow runs will validate the pinned references.
  - Other artifacts: N/A

  ## Breaking Changes
  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ### Breaking Change Details / Migration Plan
  <!-- Required only when breaking changes are introduced -->

  ## Developer Verification Checklist
  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [ ] PR description clearly explains both **what** changed and **why**.
  - [ ] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] Tests were added/updated where appropriate.
  - [ ] I manually tested the change.
  - [ ] `make pre-push-checks` passes.
  - [ ] `make fmt-check` passes.
  - [ ] `make build` passes.
  - [ ] Documentation was added/updated where appropriate.
  - [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI/CD GitHub Action steps to specific commit SHAs across workflows to improve build reproducibility and supply-chain security. This updates several workflow usages previously referenced by tags to fixed commits, with no functional changes to workflow logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terraform-redhat/terraform-provider-rhcs/pull/1147)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->