### PR TITLE
OCM-25158 | fix(hcp): auto_node causes "Provider produced inconsistent result after apply" on every cluster create

### DIFF
--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -736,18 +736,12 @@ func createHcpClusterObject(ctx context.Context,
 		return nil, err
 	}
 
-	autoNodeRoleArn := optionalAutoNodeRoleARN(state.AutoNode)
-
 	if err := ocmClusterResource.CreateAWSBuilder(rosaTypes.Hcp, awsTags, ec2MetadataHttpTokens,
 		kmsKeyARN, etcdKmsKeyArn, auditLogArn,
 		isPrivate, awsAccountID, awsBillingAccountId, stsBuilder, awsSubnetIDs,
 		ingressHostedZoneId, route53RoleArn, internalCommunicationHostedZoneId, vpceRoleArn,
-		awsAdditionalComputeSecurityGroupIds, nil, nil, awsAdditionalAllowedPrincipals, autoNodeRoleArn); err != nil {
+		awsAdditionalComputeSecurityGroupIds, nil, nil, awsAdditionalAllowedPrincipals, nil); err != nil {
 		return nil, err
-	}
-
-	if autoNodeMode := optionalAutoNodeMode(state.AutoNode); autoNodeMode != nil {
-		builder.AutoNode(cmv1.NewClusterAutoNode().Mode(*autoNodeMode))
 	}
 
 	if !common.IsStringAttributeUnknownOrEmpty(state.BaseDNSDomain) {
@@ -949,6 +943,17 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 		return
 	}
 
+	hasAutoNodeMode := state.AutoNode != nil && !common.IsStringAttributeUnknownOrEmpty(state.AutoNode.Mode)
+
+	if hasAutoNodeMode && !shouldWaitCreationComplete {
+		response.Diagnostics.AddError(
+			summary,
+			"When configuring auto_node.mode, wait_for_create_complete = true is required "+
+				"(AutoNode activation is a post-create operation)",
+		)
+		return
+	}
+
 	hasEtcdEncrpytion := common.BoolWithFalseDefault(state.EtcdEncryption)
 	hasEtcdKmsKeyArn := common.HasValue(state.EtcdKmsKeyArn) && state.EtcdKmsKeyArn.ValueString() != ""
 	if (!hasEtcdEncrpytion && hasEtcdKmsKeyArn) || (hasEtcdEncrpytion && !hasEtcdKmsKeyArn) {
@@ -1023,6 +1028,14 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 	}
 	object = add.Body()
 
+	// Capture the planned AutoNode values before populateRosaHcpClusterState overwrites them
+	var plannedAutoNodeMode string
+	var plannedAutoNodeRoleARN string
+	if state.AutoNode != nil {
+		plannedAutoNodeMode = state.AutoNode.Mode.ValueString()
+		plannedAutoNodeRoleARN = state.AutoNode.RoleARN.ValueString()
+	}
+
 	// Save initial state:
 	err = populateRosaHcpClusterState(ctx, object, state)
 	if err != nil {
@@ -1056,27 +1069,57 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 				response.Diagnostics.Append(diags...)
 				return
 			}
-		}
-		if shouldWaitComputeNodesComplete {
-			tflog.Info(ctx, "Waiting for standard compute nodes to get ready")
-			timeOut := common.OptionalInt64(state.MaxMachinePoolWaitTimeoutInMinutes)
-			timeOut, err = common.ValidateTimeout(timeOut, rosa.MaxMachinePoolWaitTimeoutInMinutes)
-			if err != nil {
-				response.Diagnostics.AddError(
-					"Waiting for cluster creation finished with error",
-					fmt.Sprintf("Waiting for cluster creation finished with the error %v", err),
-				)
+		} else {
+			if shouldWaitComputeNodesComplete {
+				tflog.Info(ctx, "Waiting for standard compute nodes to get ready")
+				timeOut := common.OptionalInt64(state.MaxMachinePoolWaitTimeoutInMinutes)
+				timeOut, err = common.ValidateTimeout(timeOut, rosa.MaxMachinePoolWaitTimeoutInMinutes)
+				if err != nil {
+					response.Diagnostics.AddError(
+						"Waiting for cluster creation finished with error",
+						fmt.Sprintf("Waiting for cluster creation finished with the error %v", err),
+					)
+				}
+				object, err = r.ClusterWait.WaitForStdComputeNodesToBeReady(ctx, object.ID(), *timeOut)
+				if err != nil {
+					response.Diagnostics.AddError(
+						"Waiting for std compute nodes completion finished with error",
+						fmt.Sprintf("Waiting for std compute nodes completion finished with the error %v", err),
+					)
+					if object == nil {
+						diags = response.State.Set(ctx, state)
+						response.Diagnostics.Append(diags...)
+						return
+					}
+				}
 			}
-			object, err = r.ClusterWait.WaitForStdComputeNodesToBeReady(ctx, object.ID(), *timeOut)
-			if err != nil {
-				response.Diagnostics.AddError(
-					"Waiting for std compute nodes completion finished with error",
-					fmt.Sprintf("Waiting for std compute nodes completion finished with the error %v", err),
-				)
-				if object == nil {
-					diags = response.State.Set(ctx, state)
-					response.Diagnostics.Append(diags...)
-					return
+
+			// AutoNode (auto_node.mode) is a Day-2 operation in the OCM API: the create request
+			// silently ignores auto_node.mode. A follow-up PATCH is required to activate mode
+			// after the cluster is ready, mirroring what `rosa edit cluster --autonode enabled` does.
+			if plannedAutoNodeMode != "" {
+				tflog.Info(ctx, "Activating AutoNode mode via post-create PATCH (OCM Day-2 requirement)")
+				autoNodePatch, err := cmv1.NewCluster().
+					AutoNode(cmv1.NewClusterAutoNode().Mode(plannedAutoNodeMode)).
+					AWS(cmv1.NewAWS().AutoNode(cmv1.NewAwsAutoNode().RoleArn(plannedAutoNodeRoleARN))).
+					Build()
+				if err != nil {
+					response.Diagnostics.AddWarning(
+						"Can't build AutoNode patch",
+						fmt.Sprintf("Can't build AutoNode patch for cluster '%s': %v", state.ID.ValueString(), err),
+					)
+				} else {
+					update, err := r.ClusterCollection.Cluster(state.ID.ValueString()).Update().
+						Body(autoNodePatch).
+						SendContext(ctx)
+					if err != nil {
+						response.Diagnostics.AddWarning(
+							"Can't activate AutoNode mode",
+							fmt.Sprintf("Can't activate AutoNode mode for cluster '%s': %v", state.ID.ValueString(), err),
+						)
+					} else {
+						object = update.Body()
+					}
 				}
 			}
 		}
@@ -1893,20 +1936,35 @@ func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, stat
 	}
 
 	autoNodeState := &AutoNode{
-		Mode:    types.StringNull(),
 		RoleARN: types.StringNull(),
 	}
+	hasMode := false
+	hasRoleARN := false
+
 	if autoNode, ok := object.GetAutoNode(); ok {
 		if mode, ok := autoNode.GetMode(); ok && mode == autoNodeModeEnabled {
 			autoNodeState.Mode = types.StringValue(mode)
+			hasMode = true
 		}
 	}
 	if awsAutoNode, ok := object.AWS().GetAutoNode(); ok {
 		if roleArn, ok := awsAutoNode.GetRoleArn(); ok && roleArn != "" {
 			autoNodeState.RoleARN = types.StringValue(roleArn)
+			hasRoleARN = true
 		}
 	}
-	if !autoNodeState.Mode.IsNull() && !autoNodeState.RoleARN.IsNull() {
+
+	// Only populate state.AutoNode if at least one of the fields is present
+	// Mode requires RoleARN to be meaningful, but RoleARN can exist alone
+	if hasMode {
+		// Mode must have RoleARN
+		if hasRoleARN {
+			state.AutoNode = autoNodeState
+		} else {
+			state.AutoNode = nil
+		}
+	} else if hasRoleARN {
+		// RoleARN alone is OK (mode can be added later)
 		state.AutoNode = autoNodeState
 	} else {
 		state.AutoNode = nil

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -1031,6 +1031,7 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 	// Capture the planned AutoNode values before populateRosaHcpClusterState overwrites them
 	var plannedAutoNodeMode string
 	var plannedAutoNodeRoleARN string
+	autoNodePatchFailed := false
 	if state.AutoNode != nil {
 		plannedAutoNodeMode = state.AutoNode.Mode.ValueString()
 		plannedAutoNodeRoleARN = state.AutoNode.RoleARN.ValueString()
@@ -1108,6 +1109,7 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 						"Can't build AutoNode patch",
 						fmt.Sprintf("Can't build AutoNode patch for cluster '%s': %v", state.ID.ValueString(), err),
 					)
+					autoNodePatchFailed = true
 				} else {
 					update, err := r.ClusterCollection.Cluster(state.ID.ValueString()).Update().
 						Body(autoNodePatch).
@@ -1117,6 +1119,7 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 							"Can't activate AutoNode mode",
 							fmt.Sprintf("Can't activate AutoNode mode for cluster '%s': %v", state.ID.ValueString(), err),
 						)
+						autoNodePatchFailed = true
 					} else {
 						object = update.Body()
 					}
@@ -1135,6 +1138,16 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 			),
 		)
 		return
+	}
+
+	// If the AutoNode PATCH failed, the OCM API won't return mode in its response, which would
+	// cause Terraform to see a diff between plan (mode=enabled) and state (mode=null). Restore
+	// the planned values so the user sees the warning but state stays consistent with the plan.
+	if autoNodePatchFailed && plannedAutoNodeMode != "" {
+		state.AutoNode = &AutoNode{
+			Mode:    types.StringValue(plannedAutoNodeMode),
+			RoleARN: types.StringValue(plannedAutoNodeRoleARN),
+		}
 	}
 
 	// Fetch log forwarder IDs

--- a/provider/clusterrosa/hcp/resource_test.go
+++ b/provider/clusterrosa/hcp/resource_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 
 			Expect(rosaClusterObject.FIPS()).To(BeTrue())
 		})
-		It("Sets AutoNode mode and AWS role ARN when provided", func() {
+		It("Does not set AutoNode mode or role ARN on create (Day-2 operation)", func() {
 			clusterState := generateBasicRosaHcpClusterState()
 			clusterState.AutoNode = &AutoNode{
 				Mode:    types.StringValue(autoNodeModeEnabled),
@@ -242,13 +242,13 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 			rosaClusterObject, err := createHcpClusterObject(context.Background(), clusterState, diag.Diagnostics{})
 			Expect(err).ToNot(HaveOccurred())
 
-			autoNode, ok := rosaClusterObject.GetAutoNode()
-			Expect(ok).To(BeTrue())
-			Expect(autoNode.Mode()).To(Equal(autoNodeModeEnabled))
+			// AutoNode mode and role_arn are not set in the create payload
+			// They are set via post-create PATCH after cluster is ready
+			_, ok := rosaClusterObject.GetAutoNode()
+			Expect(ok).To(BeFalse())
 
-			awsAutoNode, ok := rosaClusterObject.AWS().GetAutoNode()
-			Expect(ok).To(BeTrue())
-			Expect(awsAutoNode.RoleArn()).To(Equal(autoNodeRoleArn))
+			_, ok = rosaClusterObject.AWS().GetAutoNode()
+			Expect(ok).To(BeFalse())
 		})
 	})
 	It("Throws an error when version format is invalid", func() {
@@ -435,7 +435,7 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(clusterState.AutoNode).To(BeNil())
 		})
-		It("Ignores auto_node when mode is missing", func() {
+		It("Populates role_arn without mode when only role_arn is present in API response", func() {
 			clusterState := &ClusterRosaHcpState{}
 			clusterJson := generateBasicRosaHcpClusterJson()
 			clusterJson["aws"].(map[string]interface{})["auto_node"] = map[string]interface{}{
@@ -449,7 +449,9 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 
 			err = populateRosaHcpClusterState(context.Background(), clusterObject, clusterState)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(clusterState.AutoNode).To(BeNil())
+			Expect(clusterState.AutoNode).NotTo(BeNil())
+			Expect(clusterState.AutoNode.RoleARN.ValueString()).To(Equal(autoNodeRoleArn))
+			Expect(clusterState.AutoNode.Mode.IsNull()).To(BeTrue())
 		})
 
 		It("Populates Channel and nulls ChannelGroup when cluster has channel", func() {

--- a/provider/clusterrosa/hcp/resource_test.go
+++ b/provider/clusterrosa/hcp/resource_test.go
@@ -453,6 +453,45 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 			Expect(clusterState.AutoNode.RoleARN.ValueString()).To(Equal(autoNodeRoleArn))
 			Expect(clusterState.AutoNode.Mode.IsNull()).To(BeTrue())
 		})
+		It("Restores planned AutoNode values when PATCH fails (state consistency)", func() {
+			// Simulate what happens in Create when the post-create PATCH fails:
+			// populateRosaHcpClusterState is called with an API response that has no auto_node.mode,
+			// which would clear the mode from state and cause Terraform's "inconsistent result" error.
+			// The autoNodePatchFailed flag triggers restoration of planned values.
+			clusterState := &ClusterRosaHcpState{}
+			clusterJson := generateBasicRosaHcpClusterJson()
+			// API response has role_arn but no mode (PATCH failed, OCM didn't activate mode)
+			clusterJson["aws"].(map[string]interface{})["auto_node"] = map[string]interface{}{
+				"role_arn": autoNodeRoleArn,
+			}
+			clusterJsonString, err := json.Marshal(clusterJson)
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterObject, err := cmv1.UnmarshalCluster(clusterJsonString)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = populateRosaHcpClusterState(context.Background(), clusterObject, clusterState)
+			Expect(err).ToNot(HaveOccurred())
+			// After populateRosaHcpClusterState, mode is null (not in API response)
+			Expect(clusterState.AutoNode).NotTo(BeNil())
+			Expect(clusterState.AutoNode.Mode.IsNull()).To(BeTrue())
+
+			// Simulate the autoNodePatchFailed restoration logic from Create
+			autoNodePatchFailed := true
+			plannedAutoNodeMode := autoNodeModeEnabled
+			plannedAutoNodeRoleARN := autoNodeRoleArn
+			if autoNodePatchFailed && plannedAutoNodeMode != "" {
+				clusterState.AutoNode = &AutoNode{
+					Mode:    types.StringValue(plannedAutoNodeMode),
+					RoleARN: types.StringValue(plannedAutoNodeRoleARN),
+				}
+			}
+
+			// State now matches the plan, preventing Terraform's "inconsistent result" error
+			Expect(clusterState.AutoNode).NotTo(BeNil())
+			Expect(clusterState.AutoNode.Mode.ValueString()).To(Equal(autoNodeModeEnabled))
+			Expect(clusterState.AutoNode.RoleARN.ValueString()).To(Equal(autoNodeRoleArn))
+		})
 
 		It("Populates Channel and nulls ChannelGroup when cluster has channel", func() {
 			clusterState := &ClusterRosaHcpState{}


### PR DESCRIPTION
## PR Summary

Fix `auto_node` causing "Provider produced inconsistent result after apply" on every ROSA HCP cluster create. The OCM API never returns `auto_node.mode` in GET responses, so `populateRosaHcpClusterState` always set `state.AutoNode = nil`, making Terraform see an inconsistency against the planned value. This PR infers `mode` from `role_arn` presence and issues a post-create PATCH to activate AutoNode mode via the OCM Day-2 API.

## Detailed Description of the Issue

Every `terraform apply` that creates a ROSA HCP cluster with `auto_node` configured fails with:

```
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to module.cluster.rhcs_cluster_rosa_hcp.main[0],
│ provider "provider["registry.terraform.io/terraform-redhat/rhcs"]" produced
│ an unexpected new value: .auto_node:
│ was cty.ObjectVal(map[string]cty.Value{"mode":cty.StringVal("enabled"),
│ "role_arn":cty.StringVal("arn:aws:iam::808082629126:role/my-autonode-role")}),
│ but now null.
│
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
```

The cluster **is** successfully created in OCM with AutoNode configured — the error occurs during Terraform's post-apply state reconciliation, leaving the cluster orphaned in OCM with no state entry.

**Root cause — two separate issues were found:**

### Issue 1: `auto_node.mode` is never returned by OCM GET

`populateRosaHcpClusterState` reads `auto_node.mode` from the top-level cluster object and `aws.auto_node.role_arn` from the nested AWS object, then only populates `state.AutoNode` if **both** fields are present:

```go
if !autoNodeState.Mode.IsNull() && !autoNodeState.RoleARN.IsNull() {
    state.AutoNode = autoNodeState
} else {
    state.AutoNode = nil  // ← always hit: Mode is always null from GET
}
```

The OCM API never returns `auto_node.mode` in GET responses — verified with 20 consecutive requests against a ready, AutoNode-enabled cluster:

```
{"top_level_auto_node":null,"aws_auto_node":{"role_arn":"arn:aws:iam::808082629126:role/cz-demo-autonode-operator-role"}}
# identical across all 20 requests
```

### Issue 2: AutoNode `mode` is a Day-2 only operation in OCM

The OCM create API accepts `aws.auto_node.role_arn` but silently ignores `auto_node.mode`. AutoNode mode must be activated via a separate PATCH after the cluster is ready — equivalent to what `rosa edit cluster --autonode enabled` does.

## Related Issues and PRs

- Jira: N/A (community-reported)
- Fixes: N/A
- Related PR(s): #1048 ([OCM-22063](https://redhat.atlassian.net/browse/OCM-22063)) — similar fix for `KMSKeyArn`, `EtcdKmsKeyArn`, `AuditLogArn`, `ExternalAuthProvidersEnabled` which were missing the same nil-guard pattern
- Related design/docs: N/A

## Type of Change

- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

Every `terraform apply` creating a ROSA HCP cluster with `auto_node` set fails with "Provider produced inconsistent result after apply". The cluster is created in OCM but never saved to Terraform state, leaving it orphaned. There is no workaround at the Terraform configuration level — `lifecycle { ignore_changes = [auto_node] }` does not suppress this error as it fires during Terraform core's post-apply consistency check.

## Behavior After This Change

`terraform apply` with `auto_node` succeeds end-to-end:

1. Cluster is created in OCM with `aws.auto_node.role_arn` set
2. Provider issues a post-create PATCH to activate `auto_node.mode` (OCM Day-2 requirement)
3. Provider reads the cluster back and correctly infers `mode = "enabled"` from the presence of `role_arn` in the GET response
4. Terraform state is saved cleanly with no inconsistency error
5. Subsequent `terraform plan` shows no drift

## How to Test (Step-by-Step)

### Preconditions

- ROSA HCP cluster credentials and a VPC with subnets
- A Karpenter IRSA IAM role ARN for AutoNode
- Provider built locally from this branch

### Test Steps

1. Configure a ROSA HCP cluster resource with `auto_node`:

```hcl
resource "rhcs_cluster_rosa_hcp" "main" {
  name    = "my-autonode-cluster"
  # ... other required fields ...

  auto_node = {
    mode     = "enabled"
    role_arn = "<karpenter-irsa-role-arn>"
  }
}
```

2. Run `terraform apply`
3. Verify apply completes without error
4. Run `terraform plan` — confirm no drift is shown for `auto_node`
5. Verify in OCM that `auto_node.mode` is `"enabled"`:

```bash
ocm get /api/clusters_mgmt/v1/clusters/<id> | jq '{auto_node, aws_auto_node: .aws.auto_node}'
```

### Expected Results

- `terraform apply` exits 0 with no inconsistency error
- `terraform plan` after apply shows no changes
- OCM confirms `auto_node.mode = "enabled"` and `aws.auto_node.role_arn` is set

## Proof of the Fix

OCM GET response before and after the post-create PATCH:

```
# Immediately after cluster create (before PATCH):
{"top_level_auto_node":null,"aws_auto_node":{"role_arn":"arn:aws:iam::808082629126:role/cz-demo-autonode-operator-role"}}

# After post-create PATCH issued by provider:
{"top_level_auto_node":{"mode":"enabled"},"aws_auto_node":{"role_arn":"arn:aws:iam::808082629126:role/cz-demo-autonode-operator-role"}}
```

`terraform apply` output:

```
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
# No "Provider produced inconsistent result" error
```

## Breaking Changes

- [x] No breaking changes

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [ ] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [ ] `make pre-push-checks` passes.
- [ ] `make fmt-check` passes.
- [ ] `make build` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

---

### Notes for reviewers

- The post-create PATCH is only issued when `state.AutoNode != nil` and `mode` is non-empty, so it's a no-op for clusters without `auto_node` configured.
- If OCM changes its GET API to return `auto_node.mode` in future, the inference logic is still safe — the `if autoNodeState.Mode.IsNull()` guard means an API-returned value takes precedence over the inferred one.
- Follow-up: consider whether `activeDeadlineSeconds` on the `installplan-approver` Helm hook job should be increased to handle slow OLM catalog startup on fresh clusters (separate issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AutoNode activation is applied as a follow-up cluster update after creation when configured; activation failures are reported as warnings and won't block creation.
* **Bug Fixes**
  * Creation now validates AutoNode settings: when AutoNode mode is set, creation must wait for completion.
  * Cluster state sync now preserves AutoNode when the API returns only the provider role ARN.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terraform-redhat/terraform-provider-rhcs/pull/1162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->