### PR TITLE
OCM-00000 | chore: add ROSAENG to commit pattern

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,8 @@ The commit message should follow this template:
 [optional FOOTER(s)]
 ```
 
+Supported JIRA ticket formats: `OCM-XXXXX` or `ROSAENG-XXXX`
+
 The commit contains the following structural types, to communicate your intent:
 
 - `fix:` a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).

--- a/cliff.toml
+++ b/cliff.toml
@@ -3,10 +3,12 @@
 #
 # Configuration for terraform-provider-rhcs
 # Commit format: [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
+# Supported tickets: OCM-XXXXX, ROSAENG-XXXX
 # Examples:
 #   OCM-12345 | feat: add new feature
 #   OCM-12345 | feat(cluster): add new feature
 #   OCM-12345 | feat!: breaking change
+#   ROSAENG-1234 | fix: resolve authentication issue
 
 [changelog]
 # Changelog header
@@ -54,6 +56,7 @@ split_commits = false
 
 # Preprocessors to transform commit messages from our format to parseable format
 # Transform: "OCM-12345 | feat(scope)!: add feature" -> "feat(scope)!: add feature"
+# Transform: "ROSAENG-1234 | feat(scope)!: add feature" -> "feat(scope)!: add feature"
 # (Must match hack/commit-msg-verify.sh: optional (scope) and ! before the colon.)
 # This allows commit_parsers to match on type while preserving the message
 commit_preprocessors = [
@@ -61,7 +64,9 @@ commit_preprocessors = [
     { pattern = '^[A-Z]+-\d+\s*\|\s*(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\([a-z0-9._-]+\))?(!)?:\s*(.+)$', replace = "$1$2$3: $4" },
     # Placeholder OCM-0… ticket (same shape)
     { pattern = '^OCM-0+\s*\|\s*(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\([a-z0-9._-]+\))?(!)?:\s*(.+)$', replace = "$1$2$3: $4" },
-    # Strip "OCM-NNNN: " prefix (e.g. "OCM-3102: Fixing a bug" -> "Fixing a bug")
+    # Placeholder ROSAENG-0… ticket (same shape)
+    { pattern = '^ROSAENG-0+\s*\|\s*(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\([a-z0-9._-]+\))?(!)?:\s*(.+)$', replace = "$1$2$3: $4" },
+    # Strip "OCM-NNNN: " or "ROSAENG-NNNN: " prefix (e.g. "OCM-3102: Fixing a bug" -> "Fixing a bug")
     { pattern = '^[A-Z]+-\d+:\s*', replace = "" },
     { pattern = '^[A-Z]+-\d+ \| \s*', replace = "" },
     # Remove Signed-off-by lines (e.g. "Signed-off-by: abc <abc@abc.com>")
@@ -118,8 +123,9 @@ filter_commits = true
 fail_on_unmatched_commit = false
 # Link parsers for external references
 link_parsers = [
-    # Parse JIRA ticket references
+    # Parse JIRA ticket references (OCM and ROSAENG)
     { pattern = "OCM-(\\d+)", href = "https://issues.redhat.com/browse/OCM-$1" },
+    { pattern = "ROSAENG-(\\d+)", href = "https://issues.redhat.com/browse/ROSAENG-$1" },
 ]
 # Use tags from current branch only
 use_branch_tags = false

--- a/hack/commit-msg-verify.sh
+++ b/hack/commit-msg-verify.sh
@@ -12,6 +12,7 @@ print_commit_message_error() {
 $message
 Expected format: JIRA-12345 | <conventional-commit>
 Example: OCM-12345 | feat(scope): add support for foo
+Example: ROSAENG-1234 | fix: resolve authentication issue
 Please check CONTRIBUTING.md for more details
 EOF
 }


### PR DESCRIPTION
<!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when the option is not applicable to your case.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary
  Add support for ROSAENG-XXXX Jira ticket format alongside existing OCM-XXXXX format in commit validation, changelog generation, and documentation.

  ## Detailed Description of the Issue
  The repository only accepted OCM-XXXXX ticket format in commit messages. With ROSAENG project tickets now in use, commits with ROSAENG-XXXX format were not documented as valid, and changelog tooling did not generate proper Jira links for these tickets.

  ## Related Issues and PRs
  - Jira: N/A
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change
  <!-- Check the primary type this PR represents -->
  - [ ] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [x] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior
  - Commit validation script error messages only showed OCM-XXXXX examples
  - `cliff.toml` changelog configuration only documented OCM ticket format
  - `cliff.toml` link parsers only generated Jira links for OCM tickets
  - CONTRIBUTING.md did not specify which ticket formats are valid

  ## Behavior After This Change
  - Commit validation accepts both OCM-XXXXX and ROSAENG-XXXX formats (existing regex pattern `[A-Z]+-[0-9]+` already supported both)
  - Error messages now show examples for both ticket formats
  - `cliff.toml` documents ROSAENG support in comments and examples
  - `cliff.toml` includes preprocessor for ROSAENG-0+ placeholder tickets
  - `cliff.toml` link parser generates Jira links for ROSAENG-XXXX tickets
  - CONTRIBUTING.md explicitly states both formats are supported

  ## How to Test (Step-by-Step)
  ### Preconditions
  - Repository clone with local hooks installed (`make install-hooks`)

  ### Test Steps
  1. Test commit message validation with OCM format: `echo "[OCM-12345](https://redhat.atlassian.net/browse/OCM-12345) | feat: test" | hack/commit-msg-verify.sh /dev/stdin`
  2. Test commit message validation with ROSAENG format: `echo "[ROSAENG-4071](https://redhat.atlassian.net/browse/ROSAENG-4071) | fix: test" | hack/commit-msg-verify.sh /dev/stdin`
  3. Verify cliff.toml preprocessors handle both formats (pattern already validates)
  4. Check documentation reflects both formats in CONTRIBUTING.md and cliff.toml

  ### Expected Results
  - Both OCM and ROSAENG ticket formats validate successfully
  - Error messages show examples for both formats
  - Changelog configuration supports both ticket types with proper Jira link generation

  ## Proof of the Fix
  - Logs/CLI output: Regex pattern `^[A-Z]+-[0-9]+` matches both OCM-XXXXX and ROSAENG-XXXX formats
  - Screenshots: N/A
  - Videos: N/A
  - Other artifacts: Changed files show updated examples and link parsers

  ## Breaking Changes
  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ### Breaking Change Details / Migration Plan
  <!-- Required only when breaking changes are introduced -->

  ## Developer Verification Checklist
  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] Tests were added/updated where appropriate.
  - [x] I manually tested the change.
  - [ ] `make pre-push-checks` passes.
  - [ ] `make fmt-check` passes.
  - [ ] `make build` passes.
  - [ ] Documentation was added/updated where appropriate.
  - [ ] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified supported ticket formats for commit messages in the contribution guide.

* **Chores**
  * Expanded tooling and configuration to recognize an additional ticket prefix in commit subjects and links.
  * Improved commit-message validation output to include an example using the new ticket format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terraform-redhat/terraform-provider-rhcs/pull/1169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->