### PR TITLE
OCM-25158 | fix: AutoNode cannot be enabled on cluster creation

### DIFF
--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -736,18 +736,12 @@ func createHcpClusterObject(ctx context.Context,
 		return nil, err
 	}
 
-	autoNodeRoleArn := optionalAutoNodeRoleARN(state.AutoNode)
-
 	if err := ocmClusterResource.CreateAWSBuilder(rosaTypes.Hcp, awsTags, ec2MetadataHttpTokens,
 		kmsKeyARN, etcdKmsKeyArn, auditLogArn,
 		isPrivate, awsAccountID, awsBillingAccountId, stsBuilder, awsSubnetIDs,
 		ingressHostedZoneId, route53RoleArn, internalCommunicationHostedZoneId, vpceRoleArn,
-		awsAdditionalComputeSecurityGroupIds, nil, nil, awsAdditionalAllowedPrincipals, autoNodeRoleArn); err != nil {
+		awsAdditionalComputeSecurityGroupIds, nil, nil, awsAdditionalAllowedPrincipals, nil); err != nil {
 		return nil, err
-	}
-
-	if autoNodeMode := optionalAutoNodeMode(state.AutoNode); autoNodeMode != nil {
-		builder.AutoNode(cmv1.NewClusterAutoNode().Mode(*autoNodeMode))
 	}
 
 	if !common.IsStringAttributeUnknownOrEmpty(state.BaseDNSDomain) {
@@ -949,6 +943,17 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 		return
 	}
 
+	hasAutoNodeMode := state.AutoNode != nil && !common.IsStringAttributeUnknownOrEmpty(state.AutoNode.Mode)
+
+	if hasAutoNodeMode && !shouldWaitCreationComplete {
+		response.Diagnostics.AddError(
+			summary,
+			"When configuring auto_node.mode, wait_for_create_complete = true is required "+
+				"(AutoNode activation is a post-create operation)",
+		)
+		return
+	}
+
 	hasEtcdEncrpytion := common.BoolWithFalseDefault(state.EtcdEncryption)
 	hasEtcdKmsKeyArn := common.HasValue(state.EtcdKmsKeyArn) && state.EtcdKmsKeyArn.ValueString() != ""
 	if (!hasEtcdEncrpytion && hasEtcdKmsKeyArn) || (hasEtcdEncrpytion && !hasEtcdKmsKeyArn) {
@@ -1023,6 +1028,14 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 	}
 	object = add.Body()
 
+	// Capture the planned AutoNode values before populateRosaHcpClusterState overwrites them
+	var plannedAutoNodeMode string
+	var plannedAutoNodeRoleARN string
+	if state.AutoNode != nil {
+		plannedAutoNodeMode = state.AutoNode.Mode.ValueString()
+		plannedAutoNodeRoleARN = state.AutoNode.RoleARN.ValueString()
+	}
+
 	// Save initial state:
 	err = populateRosaHcpClusterState(ctx, object, state)
 	if err != nil {
@@ -1056,27 +1069,57 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 				response.Diagnostics.Append(diags...)
 				return
 			}
-		}
-		if shouldWaitComputeNodesComplete {
-			tflog.Info(ctx, "Waiting for standard compute nodes to get ready")
-			timeOut := common.OptionalInt64(state.MaxMachinePoolWaitTimeoutInMinutes)
-			timeOut, err = common.ValidateTimeout(timeOut, rosa.MaxMachinePoolWaitTimeoutInMinutes)
-			if err != nil {
-				response.Diagnostics.AddError(
-					"Waiting for cluster creation finished with error",
-					fmt.Sprintf("Waiting for cluster creation finished with the error %v", err),
-				)
+		} else {
+			if shouldWaitComputeNodesComplete {
+				tflog.Info(ctx, "Waiting for standard compute nodes to get ready")
+				timeOut := common.OptionalInt64(state.MaxMachinePoolWaitTimeoutInMinutes)
+				timeOut, err = common.ValidateTimeout(timeOut, rosa.MaxMachinePoolWaitTimeoutInMinutes)
+				if err != nil {
+					response.Diagnostics.AddError(
+						"Waiting for cluster creation finished with error",
+						fmt.Sprintf("Waiting for cluster creation finished with the error %v", err),
+					)
+				}
+				object, err = r.ClusterWait.WaitForStdComputeNodesToBeReady(ctx, object.ID(), *timeOut)
+				if err != nil {
+					response.Diagnostics.AddError(
+						"Waiting for std compute nodes completion finished with error",
+						fmt.Sprintf("Waiting for std compute nodes completion finished with the error %v", err),
+					)
+					if object == nil {
+						diags = response.State.Set(ctx, state)
+						response.Diagnostics.Append(diags...)
+						return
+					}
+				}
 			}
-			object, err = r.ClusterWait.WaitForStdComputeNodesToBeReady(ctx, object.ID(), *timeOut)
-			if err != nil {
-				response.Diagnostics.AddError(
-					"Waiting for std compute nodes completion finished with error",
-					fmt.Sprintf("Waiting for std compute nodes completion finished with the error %v", err),
-				)
-				if object == nil {
-					diags = response.State.Set(ctx, state)
-					response.Diagnostics.Append(diags...)
-					return
+
+			// AutoNode (auto_node.mode) is a Day-2 operation in the OCM API: the create request
+			// silently ignores auto_node.mode. A follow-up PATCH is required to activate mode
+			// after the cluster is ready, mirroring what `rosa edit cluster --autonode enabled` does.
+			if plannedAutoNodeMode != "" {
+				tflog.Info(ctx, "Activating AutoNode mode via post-create PATCH (OCM Day-2 requirement)")
+				autoNodePatch, err := cmv1.NewCluster().
+					AutoNode(cmv1.NewClusterAutoNode().Mode(plannedAutoNodeMode)).
+					AWS(cmv1.NewAWS().AutoNode(cmv1.NewAwsAutoNode().RoleArn(plannedAutoNodeRoleARN))).
+					Build()
+				if err != nil {
+					response.Diagnostics.AddWarning(
+						"Can't build AutoNode patch",
+						fmt.Sprintf("Can't build AutoNode patch for cluster '%s': %v", state.ID.ValueString(), err),
+					)
+				} else {
+					update, err := r.ClusterCollection.Cluster(state.ID.ValueString()).Update().
+						Body(autoNodePatch).
+						SendContext(ctx)
+					if err != nil {
+						response.Diagnostics.AddWarning(
+							"Can't activate AutoNode mode",
+							fmt.Sprintf("Can't activate AutoNode mode for cluster '%s': %v", state.ID.ValueString(), err),
+						)
+					} else {
+						object = update.Body()
+					}
 				}
 			}
 		}
@@ -1893,20 +1936,35 @@ func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, stat
 	}
 
 	autoNodeState := &AutoNode{
-		Mode:    types.StringNull(),
 		RoleARN: types.StringNull(),
 	}
+	hasMode := false
+	hasRoleARN := false
+
 	if autoNode, ok := object.GetAutoNode(); ok {
 		if mode, ok := autoNode.GetMode(); ok && mode == autoNodeModeEnabled {
 			autoNodeState.Mode = types.StringValue(mode)
+			hasMode = true
 		}
 	}
 	if awsAutoNode, ok := object.AWS().GetAutoNode(); ok {
 		if roleArn, ok := awsAutoNode.GetRoleArn(); ok && roleArn != "" {
 			autoNodeState.RoleARN = types.StringValue(roleArn)
+			hasRoleARN = true
 		}
 	}
-	if !autoNodeState.Mode.IsNull() && !autoNodeState.RoleARN.IsNull() {
+
+	// Only populate state.AutoNode if at least one of the fields is present
+	// Mode requires RoleARN to be meaningful, but RoleARN can exist alone
+	if hasMode {
+		// Mode must have RoleARN
+		if hasRoleARN {
+			state.AutoNode = autoNodeState
+		} else {
+			state.AutoNode = nil
+		}
+	} else if hasRoleARN {
+		// RoleARN alone is OK (mode can be added later)
 		state.AutoNode = autoNodeState
 	} else {
 		state.AutoNode = nil

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -943,12 +943,12 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 		return
 	}
 
-	hasAutoNodeMode := state.AutoNode != nil && !common.IsStringAttributeUnknownOrEmpty(state.AutoNode.Mode)
+	hasAutoNode := state.AutoNode != nil
 
-	if hasAutoNodeMode && !shouldWaitCreationComplete {
+	if hasAutoNode && !shouldWaitCreationComplete {
 		response.Diagnostics.AddError(
 			summary,
-			"When configuring auto_node.mode, wait_for_create_complete = true is required "+
+			"When configuring auto_node, wait_for_create_complete = true is required "+
 				"(AutoNode activation is a post-create operation)",
 		)
 		return
@@ -1028,13 +1028,8 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 	}
 	object = add.Body()
 
-	// Capture the planned AutoNode values before populateRosaHcpClusterState overwrites them
-	var plannedAutoNodeMode string
-	var plannedAutoNodeRoleARN string
-	if state.AutoNode != nil {
-		plannedAutoNodeMode = state.AutoNode.Mode.ValueString()
-		plannedAutoNodeRoleARN = state.AutoNode.RoleARN.ValueString()
-	}
+	plannedAutoNode := state.AutoNode
+	clusterReady := false
 
 	// Save initial state:
 	err = populateRosaHcpClusterState(ctx, object, state)
@@ -1059,6 +1054,7 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 			)
 		}
 		object, err = r.ClusterWait.WaitForClusterToBeReady(ctx, object.ID(), *timeOut)
+		clusterReady = err == nil
 		if err != nil {
 			response.Diagnostics.AddError(
 				"Waiting for cluster creation finished with error",
@@ -1069,60 +1065,31 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 				response.Diagnostics.Append(diags...)
 				return
 			}
-		} else {
-			if shouldWaitComputeNodesComplete {
-				tflog.Info(ctx, "Waiting for standard compute nodes to get ready")
-				timeOut := common.OptionalInt64(state.MaxMachinePoolWaitTimeoutInMinutes)
-				timeOut, err = common.ValidateTimeout(timeOut, rosa.MaxMachinePoolWaitTimeoutInMinutes)
-				if err != nil {
-					response.Diagnostics.AddError(
-						"Waiting for cluster creation finished with error",
-						fmt.Sprintf("Waiting for cluster creation finished with the error %v", err),
-					)
-				}
-				object, err = r.ClusterWait.WaitForStdComputeNodesToBeReady(ctx, object.ID(), *timeOut)
-				if err != nil {
-					response.Diagnostics.AddError(
-						"Waiting for std compute nodes completion finished with error",
-						fmt.Sprintf("Waiting for std compute nodes completion finished with the error %v", err),
-					)
-					if object == nil {
-						diags = response.State.Set(ctx, state)
-						response.Diagnostics.Append(diags...)
-						return
-					}
-				}
+		}
+		if shouldWaitComputeNodesComplete {
+			tflog.Info(ctx, "Waiting for standard compute nodes to get ready")
+			timeOut := common.OptionalInt64(state.MaxMachinePoolWaitTimeoutInMinutes)
+			timeOut, err = common.ValidateTimeout(timeOut, rosa.MaxMachinePoolWaitTimeoutInMinutes)
+			if err != nil {
+				response.Diagnostics.AddError(
+					"Waiting for cluster creation finished with error",
+					fmt.Sprintf("Waiting for cluster creation finished with the error %v", err),
+				)
 			}
-
-			// AutoNode (auto_node.mode) is a Day-2 operation in the OCM API: the create request
-			// silently ignores auto_node.mode. A follow-up PATCH is required to activate mode
-			// after the cluster is ready, mirroring what `rosa edit cluster --autonode enabled` does.
-			if plannedAutoNodeMode != "" {
-				tflog.Info(ctx, "Activating AutoNode mode via post-create PATCH (OCM Day-2 requirement)")
-				autoNodePatch, err := cmv1.NewCluster().
-					AutoNode(cmv1.NewClusterAutoNode().Mode(plannedAutoNodeMode)).
-					AWS(cmv1.NewAWS().AutoNode(cmv1.NewAwsAutoNode().RoleArn(plannedAutoNodeRoleARN))).
-					Build()
-				if err != nil {
-					response.Diagnostics.AddWarning(
-						"Can't build AutoNode patch",
-						fmt.Sprintf("Can't build AutoNode patch for cluster '%s': %v", state.ID.ValueString(), err),
-					)
-				} else {
-					update, err := r.ClusterCollection.Cluster(state.ID.ValueString()).Update().
-						Body(autoNodePatch).
-						SendContext(ctx)
-					if err != nil {
-						response.Diagnostics.AddWarning(
-							"Can't activate AutoNode mode",
-							fmt.Sprintf("Can't activate AutoNode mode for cluster '%s': %v", state.ID.ValueString(), err),
-						)
-					} else {
-						object = update.Body()
-					}
+			object, err = r.ClusterWait.WaitForStdComputeNodesToBeReady(ctx, object.ID(), *timeOut)
+			if err != nil {
+				response.Diagnostics.AddError(
+					"Waiting for std compute nodes completion finished with error",
+					fmt.Sprintf("Waiting for std compute nodes completion finished with the error %v", err),
+				)
+				if object == nil {
+					diags = response.State.Set(ctx, state)
+					response.Diagnostics.Append(diags...)
+					return
 				}
 			}
 		}
+
 	}
 
 	// Save the state post wait completion:
@@ -1135,6 +1102,41 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 			),
 		)
 		return
+	}
+
+	// AutoNode mode activation requires a Day-2 PATCH after the cluster is ready.
+	if plannedAutoNode != nil && clusterReady {
+		tflog.Info(ctx, "Enabling AutoNode via post-create PATCH")
+		autoNodePatch, err := cmv1.NewCluster().
+			AutoNode(cmv1.NewClusterAutoNode().Mode(autoNodeModeEnabled)).
+			AWS(cmv1.NewAWS().AutoNode(
+				cmv1.NewAwsAutoNode().RoleArn(plannedAutoNode.RoleARN.ValueString()),
+			)).
+			Build()
+		if err != nil {
+			response.Diagnostics.AddWarning(
+				"Can't enable AutoNode",
+				fmt.Sprintf(
+					"Can't build AutoNode patch for cluster '%s': %v. "+
+						"AutoNode will be re-applied on the next terraform apply.",
+					state.ID.ValueString(), err),
+			)
+		} else {
+			_, err := r.ClusterCollection.Cluster(state.ID.ValueString()).Update().
+				Body(autoNodePatch).
+				SendContext(ctx)
+			if err != nil {
+				response.Diagnostics.AddWarning(
+					"Can't enable AutoNode",
+					fmt.Sprintf(
+						"Can't enable AutoNode for cluster '%s': %v. "+
+							"AutoNode will be re-applied on the next terraform apply.",
+						state.ID.ValueString(), err),
+				)
+			}
+		}
+		// Ensure state matches the plan regardless of PATCH outcome.
+		state.AutoNode = plannedAutoNode
 	}
 
 	// Fetch log forwarder IDs
@@ -1935,39 +1937,14 @@ func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, stat
 		state.AuditLogArn = types.StringNull()
 	}
 
-	autoNodeState := &AutoNode{
-		RoleARN: types.StringNull(),
-	}
-	hasMode := false
-	hasRoleARN := false
-
-	if autoNode, ok := object.GetAutoNode(); ok {
-		if mode, ok := autoNode.GetMode(); ok && mode == autoNodeModeEnabled {
-			autoNodeState.Mode = types.StringValue(mode)
-			hasMode = true
-		}
-	}
+	state.AutoNode = nil
 	if awsAutoNode, ok := object.AWS().GetAutoNode(); ok {
 		if roleArn, ok := awsAutoNode.GetRoleArn(); ok && roleArn != "" {
-			autoNodeState.RoleARN = types.StringValue(roleArn)
-			hasRoleARN = true
+			state.AutoNode = &AutoNode{
+				Mode:    types.StringValue(autoNodeModeEnabled),
+				RoleARN: types.StringValue(roleArn),
+			}
 		}
-	}
-
-	// Only populate state.AutoNode if at least one of the fields is present
-	// Mode requires RoleARN to be meaningful, but RoleARN can exist alone
-	if hasMode {
-		// Mode must have RoleARN
-		if hasRoleARN {
-			state.AutoNode = autoNodeState
-		} else {
-			state.AutoNode = nil
-		}
-	} else if hasRoleARN {
-		// RoleARN alone is OK (mode can be added later)
-		state.AutoNode = autoNodeState
-	} else {
-		state.AutoNode = nil
 	}
 
 	httpTokensState, ok := object.AWS().GetEc2MetadataHttpTokens()
@@ -2265,22 +2242,6 @@ func validateAutoNodeRoleARN() validator.String {
 			}
 		},
 	)
-}
-
-func optionalAutoNodeMode(autoNode *AutoNode) *string {
-	if autoNode == nil || common.IsStringAttributeUnknownOrEmpty(autoNode.Mode) {
-		return nil
-	}
-
-	return autoNode.Mode.ValueStringPointer()
-}
-
-func optionalAutoNodeRoleARN(autoNode *AutoNode) *string {
-	if autoNode == nil || common.IsStringAttributeUnknownOrEmpty(autoNode.RoleARN) {
-		return nil
-	}
-
-	return autoNode.RoleARN.ValueStringPointer()
 }
 
 func getAutoNodeMode(autoNode *AutoNode) types.String {

--- a/provider/clusterrosa/hcp/resource_test.go
+++ b/provider/clusterrosa/hcp/resource_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 
 			Expect(rosaClusterObject.FIPS()).To(BeTrue())
 		})
-		It("Sets AutoNode mode and AWS role ARN when provided", func() {
+		It("Does not set AutoNode mode or role ARN on create (Day-2 operation)", func() {
 			clusterState := generateBasicRosaHcpClusterState()
 			clusterState.AutoNode = &AutoNode{
 				Mode:    types.StringValue(autoNodeModeEnabled),
@@ -242,13 +242,13 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 			rosaClusterObject, err := createHcpClusterObject(context.Background(), clusterState, diag.Diagnostics{})
 			Expect(err).ToNot(HaveOccurred())
 
-			autoNode, ok := rosaClusterObject.GetAutoNode()
-			Expect(ok).To(BeTrue())
-			Expect(autoNode.Mode()).To(Equal(autoNodeModeEnabled))
+			// AutoNode mode and role_arn are not set in the create payload
+			// They are set via post-create PATCH after cluster is ready
+			_, ok := rosaClusterObject.GetAutoNode()
+			Expect(ok).To(BeFalse())
 
-			awsAutoNode, ok := rosaClusterObject.AWS().GetAutoNode()
-			Expect(ok).To(BeTrue())
-			Expect(awsAutoNode.RoleArn()).To(Equal(autoNodeRoleArn))
+			_, ok = rosaClusterObject.AWS().GetAutoNode()
+			Expect(ok).To(BeFalse())
 		})
 	})
 	It("Throws an error when version format is invalid", func() {
@@ -435,7 +435,7 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(clusterState.AutoNode).To(BeNil())
 		})
-		It("Ignores auto_node when mode is missing", func() {
+		It("Populates role_arn without mode when only role_arn is present in API response", func() {
 			clusterState := &ClusterRosaHcpState{}
 			clusterJson := generateBasicRosaHcpClusterJson()
 			clusterJson["aws"].(map[string]interface{})["auto_node"] = map[string]interface{}{
@@ -449,7 +449,9 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 
 			err = populateRosaHcpClusterState(context.Background(), clusterObject, clusterState)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(clusterState.AutoNode).To(BeNil())
+			Expect(clusterState.AutoNode).NotTo(BeNil())
+			Expect(clusterState.AutoNode.RoleARN.ValueString()).To(Equal(autoNodeRoleArn))
+			Expect(clusterState.AutoNode.Mode.IsNull()).To(BeTrue())
 		})
 
 		It("Populates Channel and nulls ChannelGroup when cluster has channel", func() {

--- a/provider/clusterrosa/hcp/resource_test.go
+++ b/provider/clusterrosa/hcp/resource_test.go
@@ -320,6 +320,7 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 			Expect(clusterState.Sts.OIDCEndpointURL.ValueString()).To(Equal(oidcEndpointUrl))
 			Expect(clusterState.Sts.RoleARN.ValueString()).To(Equal(roleArn))
 			Expect(clusterState.Ec2MetadataHttpTokens.ValueString()).To(Equal(httpTokens))
+			Expect(clusterState.AutoNode).To(BeNil())
 		})
 		It("Check trimming of oidc url with https perfix", func() {
 			clusterState := &ClusterRosaHcpState{}
@@ -435,23 +436,32 @@ var _ = Describe("Rosa HCP Sts cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(clusterState.AutoNode).To(BeNil())
 		})
-		It("Populates role_arn without mode when only role_arn is present in API response", func() {
+		It("Preserves planned AutoNode when API response lacks AutoNode data", func() {
 			clusterState := &ClusterRosaHcpState{}
 			clusterJson := generateBasicRosaHcpClusterJson()
-			clusterJson["aws"].(map[string]interface{})["auto_node"] = map[string]interface{}{
-				"role_arn": autoNodeRoleArn,
-			}
 			clusterJsonString, err := json.Marshal(clusterJson)
 			Expect(err).ToNot(HaveOccurred())
 
 			clusterObject, err := cmv1.UnmarshalCluster(clusterJsonString)
 			Expect(err).ToNot(HaveOccurred())
 
+			plannedAutoNode := &AutoNode{
+				Mode:    types.StringValue(autoNodeModeEnabled),
+				RoleARN: types.StringValue(autoNodeRoleArn),
+			}
+
 			err = populateRosaHcpClusterState(context.Background(), clusterObject, clusterState)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(clusterState.AutoNode).To(BeNil())
+
+			// Simulate state preservation logic from Create
+			if plannedAutoNode != nil && clusterState.AutoNode == nil {
+				clusterState.AutoNode = plannedAutoNode
+			}
+
 			Expect(clusterState.AutoNode).NotTo(BeNil())
+			Expect(clusterState.AutoNode.Mode.ValueString()).To(Equal(autoNodeModeEnabled))
 			Expect(clusterState.AutoNode.RoleARN.ValueString()).To(Equal(autoNodeRoleArn))
-			Expect(clusterState.AutoNode.Mode.IsNull()).To(BeTrue())
 		})
 
 		It("Populates Channel and nulls ChannelGroup when cluster has channel", func() {


### PR DESCRIPTION
## PR Summary

This builds on the work in #1162 . Simplifies things a little given my understanding of the CS API.

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [OCM-25158]([OCM-25158](https://redhat.atlassian.net/browse/OCM-25158))
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [X] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1.
2.
3.

### Expected Results
<!-- What should happen after running the steps above -->

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [ ] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [ ] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [ ] PR description clearly explains both **what** changed and **why**.
- [ ] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make pre-push-checks` passes.
- [ ] `make fmt-check` passes.
- [ ] `make build` passes.
- [ ] Documentation was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AutoNode validation: AutoNode can only be configured when `wait_for_create_complete` is set to true.

* **Refactor**
  * AutoNode configuration is now applied after cluster creation as a post-creation operation.
  * Enhanced AutoNode state detection mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terraform-redhat/terraform-provider-rhcs/pull/1170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->