### PR TITLE
ROSAENG-4071: fix(logging): improve error logging to include actiona…

### DIFF
--- a/provider/common/cluster_waiter.go
+++ b/provider/common/cluster_waiter.go
@@ -147,7 +147,7 @@ func pollClusterCurrentCompute(clusterId string, ctx context.Context, timeout in
 		}).
 		StartContext(pollCtx)
 	if err != nil {
-		tflog.Error(ctx, "Failed polling cluster compute")
+		tflog.Error(ctx, fmt.Sprintf("Failed polling cluster compute: %v", err))
 		return nil, err
 	}
 
@@ -176,7 +176,7 @@ func pollClusterState(clusterId string, ctx context.Context, timeout int64, clus
 		}).
 		StartContext(pollCtx)
 	if err != nil {
-		tflog.Error(ctx, "Failed polling cluster state")
+		tflog.Error(ctx, fmt.Sprintf("Failed polling cluster state: %v", err))
 		return nil, err
 	}
 

--- a/provider/ocm_policies/classic/ocm_policies_data_source.go
+++ b/provider/ocm_policies/classic/ocm_policies_data_source.go
@@ -175,7 +175,12 @@ func (s *OcmPoliciesDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	policiesResponse, err := s.awsInquiries.STSPolicies().List().Send()
 	if err != nil {
-		tflog.Error(ctx, "Failed to get policies")
+		description := fmt.Sprintf("Failed to get policies: %v", err)
+		tflog.Error(ctx, description)
+		resp.Diagnostics.AddError(
+			description,
+			"Verify your OCM credentials and connectivity to the OCM API",
+		)
 		return
 	}
 

--- a/provider/ocm_policies/hcp/ocm_policies_data_source.go
+++ b/provider/ocm_policies/hcp/ocm_policies_data_source.go
@@ -171,7 +171,12 @@ func (s *OcmPoliciesDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	policiesResponse, err := s.awsInquiries.STSPolicies().List().Send()
 	if err != nil {
-		tflog.Error(ctx, "Failed to get policies")
+		description := fmt.Sprintf("Failed to get policies: %v", err)
+		tflog.Error(ctx, description)
+		resp.Diagnostics.AddError(
+			description,
+			"Verify your OCM credentials and connectivity to the OCM API",
+		)
 		return
 	}
 


### PR DESCRIPTION
 <!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when the option is not applicable to your case.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary

  Error logging throughout the provider lacked actionable details, making troubleshooting difficult for operators. This fix adds error context to tflog.Error calls and user-facing diagnostics to data sources.

  ## Detailed Description of the Issue

  When API calls or cluster operations failed, the provider logged generic error messages without including the actual error details. For example, `tflog.Error(ctx, "Failed to get policies")` provided no information about what went wrong (network timeout, authentication failure, API
  error, etc.). Additionally, data sources logged errors internally but did not add them to `resp.Diagnostics`, causing silent failures where Terraform output showed no error while the operation failed.

  This made it difficult for users to:
  - Understand why their Terraform apply/plan failed
  - Troubleshoot OCM API connectivity or credential issues
  - Differentiate between different failure modes

  ## Related Issues and PRs

  - Jira: [ROSAENG-4071](https://issues.redhat.com/browse/ROSAENG-4071)
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change

  - [ ] feat - adds a new user-facing capability.
  - [x] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  **Cluster waiters:** Logged `"Failed polling cluster compute"` or `"Failed polling cluster state"` without including the actual error returned by the OCM SDK.

  **OCM policies data sources:** Logged `"Failed to get policies"` without error details and returned silently without adding diagnostics to Terraform output. Users saw empty state with no indication of failure.

  ## Behavior After This Change

  **Cluster waiters:** Error logs include full error context: `fmt.Sprintf("Failed polling cluster compute: %v", err)`. The error is still returned to the caller for proper handling.

  **OCM policies data sources:** Error logs include full error context and `resp.Diagnostics.AddError()` is called with both the error description and actionable guidance ("Verify your OCM credentials and connectivity to the OCM API"). Terraform now displays the error to users.

  ## How to Test (Step-by-Step)

  ### Preconditions

  - Invalid or expired OCM credentials (to trigger policy retrieval failure)
  - Or: network connectivity issues to OCM API
  - Or: cluster in a transient state (to trigger waiter polling errors)

  ### Test Steps

  1. Configure Terraform with invalid OCM credentials
  2. Run `terraform plan` or `terraform apply` with a configuration that uses `data.rhcs_policies` (classic or HCP)
  3. Observe Terraform output for error messages

  **Alternative for cluster waiter:**
  1. Trigger a cluster operation that requires polling (create/update/delete)
  2. Simulate a timeout or API error during polling
  3. Check provider logs (`TF_LOG=DEBUG`) for error details

  ### Expected Results

  - Terraform output displays: `Error: Failed to get policies: <actual error details>`
  - Error message includes actionable guidance about checking OCM credentials and connectivity
  - Provider logs (`tflog.Error`) contain the full error with `%v` formatting
  - No silent failures or empty state without error indication

  ## Proof of the Fix

  - Screenshots: N/A (error logging improvement)
  - Videos: N/A
  - Logs/CLI output: Validated with CodeRabbit review (0 findings) and rhcs-reviewer agent
  - Other artifacts:
    - Pre-commit checks: PASS
    - `make build`: PASS
    - `make fmt-check`: PASS
    - CodeRabbit review: 0 findings

  ## Breaking Changes

  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ### Breaking Change Details / Migration Plan

  N/A

  ## Developer Verification Checklist

  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [x] `make install-hooks` has been run in this clone.
  - [ ] Tests were added/updated where appropriate.
  - [x] I manually tested the change.
  - [x] `make pre-push-checks` passes.
  - [x] `make fmt-check` passes.
  - [x] `make build` passes.
  - [ ] Documentation was added/updated where appropriate.
  - [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for cluster polling and AWS policy retrieval: logs now include underlying error details and user-facing diagnostics now advise verifying credentials and API/API connectivity when operations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->