### PR TITLE
ROSAENG-6793 | feat: read noproxy default domains from ocm api

### DIFF
--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -1031,6 +1031,13 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 	plannedAutoNode := state.AutoNode
 	clusterReady := false
 
+	var plannedNoProxy types.String
+	if state.Proxy != nil {
+		plannedNoProxy = state.Proxy.NoProxy
+	} else {
+		plannedNoProxy = types.StringValue("")
+	}
+
 	// Save initial state:
 	err = populateRosaHcpClusterState(ctx, object, state)
 	if err != nil {
@@ -1149,6 +1156,16 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 		return
 	}
 
+	// Revise zero egress no proxy if needed
+	err = r.reviseZeroEgressNoProxy(ctx, object, state)
+	if err != nil {
+		response.Diagnostics.AddWarning(
+			"Can't revise zero egress no proxy",
+			fmt.Sprintf("Received error %v", err),
+		)
+		state.Proxy.NoProxy = plannedNoProxy
+	}
+
 	diags = response.State.Set(ctx, state)
 	response.Diagnostics.Append(diags...)
 }
@@ -1162,6 +1179,13 @@ func (r *ClusterRosaHcpResource) Read(ctx context.Context, request resource.Read
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
+	}
+
+	var priorNoProxy types.String
+	if state.Proxy != nil {
+		priorNoProxy = state.Proxy.NoProxy
+	} else {
+		priorNoProxy = types.StringValue("")
 	}
 
 	// Find the cluster:
@@ -1206,6 +1230,16 @@ func (r *ClusterRosaHcpResource) Read(ctx context.Context, request resource.Read
 			fmt.Sprintf("Received error %v", err),
 		)
 		return
+	}
+
+	// Revise zero egress no proxy if needed
+	err = r.reviseZeroEgressNoProxy(ctx, object, state)
+	if err != nil {
+		response.Diagnostics.AddWarning(
+			"Can't revise zero egress no proxy",
+			fmt.Sprintf("Received error %v", err),
+		)
+		state.Proxy.NoProxy = priorNoProxy
 	}
 
 	diags = response.State.Set(ctx, state)
@@ -1568,6 +1602,13 @@ func (r *ClusterRosaHcpResource) Update(ctx context.Context, request resource.Up
 
 	object := update.Body()
 
+	var plannedNoProxy types.String
+	if plan.Proxy != nil {
+		plannedNoProxy = plan.Proxy.NoProxy
+	} else {
+		plannedNoProxy = types.StringValue("")
+	}
+
 	// Update the state:
 	err = populateRosaHcpClusterState(ctx, object, plan)
 	if err != nil {
@@ -1588,6 +1629,16 @@ func (r *ClusterRosaHcpResource) Update(ctx context.Context, request resource.Up
 			fmt.Sprintf("Received error %v", err),
 		)
 		return
+	}
+
+	// Revise zero egress no proxy if needed
+	err = r.reviseZeroEgressNoProxy(ctx, object, plan)
+	if err != nil {
+		response.Diagnostics.AddWarning(
+			"Can't revise zero egress no proxy",
+			fmt.Sprintf("Received error %v", err),
+		)
+		plan.Proxy.NoProxy = plannedNoProxy
 	}
 
 	diags = response.State.Set(ctx, plan)
@@ -2019,8 +2070,7 @@ func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, stat
 
 		noProxy, ok := proxyObj.GetNoProxy()
 		if ok && noProxy != "" {
-			deDuplicatedNoProxy := proxy.RemoveNoProxyZeroEgressDefaultDomains(noProxy, ",")
-			state.Proxy.NoProxy = types.StringValue(deDuplicatedNoProxy)
+			state.Proxy.NoProxy = types.StringValue(noProxy)
 		}
 	} else {
 		// We cannot set the proxy to nil because the attribute state.Proxy.AdditionalTrustBundle might contain a value.
@@ -2200,6 +2250,47 @@ func (r *ClusterRosaHcpResource) waitTillClusterIsNotFoundWithTimeout(ctx contex
 	}
 
 	return false, nil
+}
+
+func (r *ClusterRosaHcpResource) reviseZeroEgressNoProxy(ctx context.Context,
+	object *cmv1.Cluster, state *ClusterRosaHcpState) error {
+	properties, ok := object.GetProperties()
+	if !ok {
+		return nil
+	}
+	zeroEgress, ok := properties["zero_egress"]
+	if !ok || zeroEgress != "true" {
+		return nil
+	}
+	proxyObj, ok := object.GetProxy()
+	if !ok {
+		return nil
+	}
+	noProxy, ok := proxyObj.GetNoProxy()
+	if !ok || noProxy == "" {
+		return nil
+	}
+	get, err := r.ClusterCollection.Cluster(object.ID()).Get().Parameter("fetch_service_inquiries", true).SendContext(ctx)
+	if err != nil {
+		return err
+	}
+	aws, ok := get.Body().GetAWS()
+	if !ok {
+		return fmt.Errorf("AWS configuration not found in cluster response")
+	}
+	zeroEgressConfig, ok := aws.GetZeroEgress()
+	if !ok {
+		return fmt.Errorf("zero egress configuration not found in cluster response")
+	}
+	defaultDomains := zeroEgressConfig.NoProxyDefaultDomains()
+	if len(defaultDomains) == 0 {
+		return nil
+	}
+	deDuplicatedNoProxy := proxy.RemoveNoProxyZeroEgressDefaultDomains(
+		noProxy, ",", defaultDomains, state.AWSAccountID.ValueString(),
+	)
+	state.Proxy.NoProxy = types.StringValue(deDuplicatedNoProxy)
+	return nil
 }
 
 func validateAutoNodeRoleARN() validator.String {

--- a/provider/proxy/utils.go
+++ b/provider/proxy/utils.go
@@ -4,37 +4,42 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 )
 
 var awsRegionRegexFmt = "(?:af|ap|ca|eu|me|sa|us)(?:-gov)?-(?:central|north|(?:north(?:east|west))|south|south(?:east|west)|east|west)-\\d+(?:[a-z]{1})?"
-var awsAccountIdRegexFmt = "\\d{12}"
-var zeroEgressDefaultDomainFmts = []*regexp.Regexp{
-	regexp.MustCompile(fmt.Sprintf("^s3\\.dualstack\\.%s\\.amazonaws\\.com$", awsRegionRegexFmt)),
-	regexp.MustCompile(fmt.Sprintf("^\\.s3\\.%s\\.amazonaws\\.com$", awsRegionRegexFmt)),
-	regexp.MustCompile(fmt.Sprintf("^sts\\.%s\\.amazonaws\\.com$", awsRegionRegexFmt)),
-	regexp.MustCompile(fmt.Sprintf("^api\\.ecr\\.%s\\.amazonaws\\.com$", awsRegionRegexFmt)),
-	//nolint:lll
-	regexp.MustCompile(fmt.Sprintf("^\\.?%s\\.dkr\\.ecr\\.%s\\.amazonaws\\.com$", awsAccountIdRegexFmt, awsRegionRegexFmt)),
-	regexp.MustCompile(fmt.Sprintf("^\\.dkr\\.ecr\\.%s\\.amazonaws\\.com$", awsRegionRegexFmt)),
-}
 
-func RemoveNoProxyZeroEgressDefaultDomains(input string, separator string) string {
-	splits := strings.Split(input, separator)
-	result := []string{}
-	for _, split := range splits {
-		var matched bool
-		for _, format := range zeroEgressDefaultDomainFmts {
-			matched = format.Match([]byte(split))
-			if matched {
-				break
-			}
-		}
-		if !matched {
-			result = append(result, split)
-		}
+func RemoveNoProxyZeroEgressDefaultDomains(
+	input string, separator string, defaultDomains []string, awsAccountID string,
+) string {
+	domains := strings.Split(input, separator)
+	defaultDomainsMap := make(map[string]string)
+	for _, item := range defaultDomains {
+		defaultDomainsMap[item] = ""
 	}
-	return strings.Join(result, ",")
+
+	var deprecatedEcrRegex *regexp.Regexp
+	if awsAccountID != "" {
+		deprecatedEcrRegex = regexp.MustCompile(fmt.Sprintf(
+			"^\\.?%s\\.dkr\\.ecr\\.%s\\.amazonaws\\.com$",
+			regexp.QuoteMeta(awsAccountID),
+			awsRegionRegexFmt,
+		))
+	}
+
+	domains = slices.DeleteFunc(domains, func(item string) bool {
+		// Check exact match first
+		if _, exists := defaultDomainsMap[item]; exists {
+			return true
+		}
+		// Check deprecated zero egress default domains for backward compatibility
+		if deprecatedEcrRegex != nil && deprecatedEcrRegex.MatchString(item) {
+			return true
+		}
+		return false
+	})
+	return strings.Join(domains, separator)
 }
 
 func Contains[T comparable](slice []T, element T) bool {

--- a/provider/proxy/utils_test.go
+++ b/provider/proxy/utils_test.go
@@ -14,44 +14,138 @@ func TestResource(t *testing.T) {
 
 var _ = Describe("RemoveNoProxyZeroEgressDefaultDomains", func() {
 	It("removes original zero egress default domains", func() {
+		defaultDomains := []string{
+			"s3.dualstack.ap-southeast-4.amazonaws.com",
+			"sts.ap-southeast-4.amazonaws.com",
+			"012345678912.dkr.ecr.ap-southeast-4.amazonaws.com",
+		}
 		Expect(RemoveNoProxyZeroEgressDefaultDomains(
 			//nolint:lll
 			"s3.dualstack.ap-southeast-4.amazonaws.com,sts.ap-southeast-4.amazonaws.com,012345678912.dkr.ecr.ap-southeast-4.amazonaws.com",
-			",")).To(Equal(""))
+			",", defaultDomains, "012345678912")).To(Equal(""))
 	})
 
 	It("removes new zero egress default domains", func() {
+		defaultDomains := []string{
+			".s3.us-east-1.amazonaws.com",
+			"api.ecr.us-east-1.amazonaws.com",
+			".dkr.ecr.us-east-1.amazonaws.com",
+		}
 		Expect(RemoveNoProxyZeroEgressDefaultDomains(
 			//nolint:lll
 			".s3.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com",
-			",")).To(Equal(""))
+			",", defaultDomains, "")).To(Equal(""))
 	})
 
 	It("removes all five zero egress default domains", func() {
+		defaultDomains := []string{
+			"s3.dualstack.us-east-1.amazonaws.com",
+			".s3.us-east-1.amazonaws.com",
+			"sts.us-east-1.amazonaws.com",
+			"api.ecr.us-east-1.amazonaws.com",
+			".dkr.ecr.us-east-1.amazonaws.com",
+		}
 		Expect(RemoveNoProxyZeroEgressDefaultDomains(
 			//nolint:lll
 			"s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com",
-			",")).To(Equal(""))
+			",", defaultDomains, "")).To(Equal(""))
 	})
 
 	It("preserves user-specified no_proxy entries", func() {
+		defaultDomains := []string{
+			"s3.dualstack.us-east-1.amazonaws.com",
+			".s3.us-east-1.amazonaws.com",
+			"sts.us-east-1.amazonaws.com",
+			"api.ecr.us-east-1.amazonaws.com",
+			".dkr.ecr.us-east-1.amazonaws.com",
+		}
 		Expect(RemoveNoProxyZeroEgressDefaultDomains(
 			//nolint:lll
 			"test.example.com,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com",
-			",")).To(Equal("test.example.com"))
+			",", defaultDomains, "")).To(Equal("test.example.com"))
 	})
 
 	It("removes duplicated zero egress default domains", func() {
+		defaultDomains := []string{
+			"s3.dualstack.ap-southeast-4.amazonaws.com",
+			"sts.ap-southeast-4.amazonaws.com",
+			"012345678912.dkr.ecr.ap-southeast-4.amazonaws.com",
+		}
 		Expect(RemoveNoProxyZeroEgressDefaultDomains(
 			//nolint:lll
 			"s3.dualstack.ap-southeast-4.amazonaws.com,sts.ap-southeast-4.amazonaws.com,012345678912.dkr.ecr.ap-southeast-4.amazonaws.com,s3.dualstack.ap-southeast-4.amazonaws.com,sts.ap-southeast-4.amazonaws.com,012345678912.dkr.ecr.ap-southeast-4.amazonaws.com",
-			",")).To(Equal(""))
+			",", defaultDomains, "012345678912")).To(Equal(""))
 	})
 
 	It("handles govcloud regions", func() {
+		defaultDomains := []string{
+			"s3.dualstack.us-gov-west-1.amazonaws.com",
+			".s3.us-gov-west-1.amazonaws.com",
+			"sts.us-gov-west-1.amazonaws.com",
+			"api.ecr.us-gov-west-1.amazonaws.com",
+			".dkr.ecr.us-gov-west-1.amazonaws.com",
+		}
 		Expect(RemoveNoProxyZeroEgressDefaultDomains(
 			//nolint:lll
 			"s3.dualstack.us-gov-west-1.amazonaws.com,.s3.us-gov-west-1.amazonaws.com,sts.us-gov-west-1.amazonaws.com,api.ecr.us-gov-west-1.amazonaws.com,.dkr.ecr.us-gov-west-1.amazonaws.com",
-			",")).To(Equal(""))
+			",", defaultDomains, "")).To(Equal(""))
+	})
+
+	// Backward compatibility tests for SREP-3100 ECR format change
+	It("filters old ECR format when API returns new format (backward compatibility)", func() {
+		// Simulates: cluster created before SREP-3100 with account-prefixed ECR domain
+		// API returns new format (.dkr.ecr...), but cluster has old format (account.dkr.ecr...)
+		defaultDomains := []string{
+			".dkr.ecr.us-east-1.amazonaws.com", // API returns new format
+		}
+		result := RemoveNoProxyZeroEgressDefaultDomains(
+			"123456789012.dkr.ecr.us-east-1.amazonaws.com", // Cluster has old format
+			",", defaultDomains, "123456789012")
+		Expect(result).To(Equal("")) // Old format should be filtered by regex
+	})
+
+	It("filters old ECR format with user domains (backward compatibility)", func() {
+		defaultDomains := []string{
+			"s3.dualstack.us-east-1.amazonaws.com",
+			".dkr.ecr.us-east-1.amazonaws.com", // New format from API
+		}
+		result := RemoveNoProxyZeroEgressDefaultDomains(
+			//nolint:lll
+			"custom.domain,s3.dualstack.us-east-1.amazonaws.com,123456789012.dkr.ecr.us-east-1.amazonaws.com,another.custom.com",
+			",", defaultDomains, "123456789012")
+		Expect(result).To(Equal("custom.domain,another.custom.com"))
+	})
+
+	It("filters both old and new ECR formats", func() {
+		defaultDomains := []string{
+			".dkr.ecr.us-east-1.amazonaws.com",
+		}
+		result := RemoveNoProxyZeroEgressDefaultDomains(
+			//nolint:lll
+			"custom.domain,123456789012.dkr.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com",
+			",", defaultDomains, "123456789012")
+		Expect(result).To(Equal("custom.domain"))
+	})
+
+	It("filters old ECR format across different regions", func() {
+		defaultDomains := []string{
+			".dkr.ecr.ap-southeast-4.amazonaws.com",
+		}
+		result := RemoveNoProxyZeroEgressDefaultDomains(
+			"987654321098.dkr.ecr.ap-southeast-4.amazonaws.com",
+			",", defaultDomains, "987654321098")
+		Expect(result).To(Equal(""))
+	})
+
+	It("does not filter ECR format with different AWS account ID", func() {
+		// Simulates: User has a different AWS account's ECR domain in their no_proxy
+		// Should NOT be filtered because account ID doesn't match
+		defaultDomains := []string{
+			".dkr.ecr.us-east-1.amazonaws.com",
+		}
+		result := RemoveNoProxyZeroEgressDefaultDomains(
+			"999888777666.dkr.ecr.us-east-1.amazonaws.com", // Different account
+			",", defaultDomains, "123456789012") // Cluster's account
+		Expect(result).To(Equal("999888777666.dkr.ecr.us-east-1.amazonaws.com")) // Should NOT be filtered
 	})
 })

--- a/subsystem/hcp/cluster_resource_test.go
+++ b/subsystem/hcp/cluster_resource_test.go
@@ -4350,7 +4350,7 @@ var _ = Describe("HCP Cluster", func() {
 						"path": "/proxy",
 						"value": {
 							"https_proxy" : "https://proxy2.com",
-							"no_proxy" : "test,s3.dualstack.ap-southeast-4.amazonaws.com,s3.dualstack.ap-southeast-4.amazonaws.com"
+							"no_proxy" : "test"
 						}
 						},
 						{
@@ -4534,6 +4534,677 @@ var _ = Describe("HCP Cluster", func() {
 				}`)
 				runOutput = Terraform.Apply()
 				Expect(runOutput.ExitCode).To(BeZero())
+			})
+
+			It("Filters zero-egress default domains from no_proxy during create", func() {
+				// Prepare the server:
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+						RespondWithJSON(http.StatusOK, versionListPage),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+						VerifyJQ(`.name`, "my-cluster"),
+						VerifyJQ(`.cloud_provider.id`, "aws"),
+						VerifyJQ(`.region.id`, "us-west-1"),
+						VerifyJQ(`.product.id`, "rosa"),
+						VerifyJQ(`.properties.zero_egress`, "true"),
+						VerifyJQ(`.proxy.no_proxy`, "test.example.com"),
+						RespondWithPatchedJSON(http.StatusCreated, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "test.example.com"
+							}
+						}]`),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route, "fetch_service_inquiries=true"),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								},
+								"zero_egress": {
+									"no_proxy_default_domains": [
+										"s3.dualstack.us-east-1.amazonaws.com",
+										".s3.us-east-1.amazonaws.com",
+										"sts.us-east-1.amazonaws.com",
+										"api.ecr.us-east-1.amazonaws.com",
+										".dkr.ecr.us-east-1.amazonaws.com"
+									]
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "test.example.com,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com"
+							}
+						}]`),
+					),
+				)
+
+				// Run the apply command - user only specifies their custom domain
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					properties = {
+						rosa_creator_arn = "arn:aws:iam::123456789012:user/dummy",
+						zero_egress = "true"
+					}
+					proxy = {
+						no_proxy = "test.example.com"
+					}
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+				}`)
+				runOutput := Terraform.Apply()
+				Expect(runOutput.ExitCode).To(BeZero())
+				resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster")
+				// Verify that the state correctly filters out default domains
+				// even when the API returns them appended
+				Expect(resource).To(MatchJQ(`.attributes.proxy.no_proxy`, "test.example.com"))
+			})
+
+			It("Filters zero-egress default domains from no_proxy during read (refresh)", func() {
+				// Prepare the server for initial creation:
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+						RespondWithJSON(http.StatusOK, versionListPage),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+						RespondWithPatchedJSON(http.StatusCreated, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "custom.domain,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com"
+							}
+						}]`),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route, "fetch_service_inquiries=true"),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								},
+								"zero_egress": {
+									"no_proxy_default_domains": [
+										"s3.dualstack.us-east-1.amazonaws.com",
+										".s3.us-east-1.amazonaws.com",
+										"sts.us-east-1.amazonaws.com",
+										"api.ecr.us-east-1.amazonaws.com",
+										".dkr.ecr.us-east-1.amazonaws.com"
+									]
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "custom.domain,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com"
+							}
+						}]`),
+					),
+				)
+
+				// Initial creation
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					properties = {
+						rosa_creator_arn = "arn:aws:iam::123456789012:user/dummy",
+						zero_egress = "true"
+					}
+					proxy = {
+						no_proxy = "custom.domain"
+					}
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+				}`)
+				runOutput := Terraform.Apply()
+				Expect(runOutput.ExitCode).To(BeZero())
+
+				// Now test the Read path (refresh) - mock the GET with fetch_service_inquiries
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "custom.domain,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com"
+							}
+						}]`),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route, "fetch_service_inquiries=true"),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								},
+								"zero_egress": {
+									"no_proxy_default_domains": [
+										"s3.dualstack.us-east-1.amazonaws.com",
+										".s3.us-east-1.amazonaws.com",
+										"sts.us-east-1.amazonaws.com",
+										"api.ecr.us-east-1.amazonaws.com",
+										".dkr.ecr.us-east-1.amazonaws.com"
+									]
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "custom.domain,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com"
+							}
+						}]`),
+					),
+				)
+
+				// Trigger refresh by running apply again (no changes expected)
+				runOutput = Terraform.Apply()
+				Expect(runOutput.ExitCode).To(BeZero())
+
+				resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster")
+				// Verify Read path also filters default domains correctly
+				Expect(resource).To(MatchJQ(`.attributes.proxy.no_proxy`, "custom.domain"))
+			})
+
+			It("Filters zero-egress default domains from no_proxy during update", func() {
+				// Prepare the server for initial creation:
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+						RespondWithJSON(http.StatusOK, versionListPage),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+						VerifyJQ(`.name`, "my-cluster"),
+						VerifyJQ(`.cloud_provider.id`, "aws"),
+						VerifyJQ(`.region.id`, "us-west-1"),
+						VerifyJQ(`.product.id`, "rosa"),
+						VerifyJQ(`.properties.zero_egress`, "true"),
+						VerifyJQ(`.proxy.no_proxy`, "test.example.com"),
+						RespondWithPatchedJSON(http.StatusCreated, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "test.example.com"
+							}
+						}]`),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route, "fetch_service_inquiries=true"),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								},
+								"zero_egress": {
+									"no_proxy_default_domains": [
+										"s3.dualstack.us-east-1.amazonaws.com",
+										".s3.us-east-1.amazonaws.com",
+										"sts.us-east-1.amazonaws.com",
+										"api.ecr.us-east-1.amazonaws.com",
+										".dkr.ecr.us-east-1.amazonaws.com"
+									]
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "test.example.com,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com"
+							}
+						}]`),
+					),
+				)
+
+				// Initial creation
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					properties = {
+						rosa_creator_arn = "arn:aws:iam::123456789012:user/dummy",
+						zero_egress = "true"
+					}
+					proxy = {
+						no_proxy = "test.example.com"
+					}
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+				}`)
+				runOutput := Terraform.Apply()
+				Expect(runOutput.ExitCode).To(BeZero())
+
+				// Prepare server for update - user updates no_proxy to add another custom domain
+				TestServer.AppendHandlers(
+					// First GET to refresh state before update
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "test.example.com,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com"
+							}
+						}]`),
+					),
+					// Second GET to read state for comparison with plan
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "test.example.com,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com"
+							}
+						}]`),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodPatch, cluster123Route),
+						// Verify PATCH sends only user-specified domains (default domains filtered out)
+						VerifyJQ(`.proxy.no_proxy`, "test.example.com,another.custom.com"),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "test.example.com,another.custom.com"
+							}
+						}]`),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route, "fetch_service_inquiries=true"),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								},
+								"zero_egress": {
+									"no_proxy_default_domains": [
+										"s3.dualstack.us-east-1.amazonaws.com",
+										".s3.us-east-1.amazonaws.com",
+										"sts.us-east-1.amazonaws.com",
+										"api.ecr.us-east-1.amazonaws.com",
+										".dkr.ecr.us-east-1.amazonaws.com"
+									]
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+								"zero_egress": "true"
+							}
+						},
+						{
+							"op": "add",
+							"path": "/proxy",
+							"value": {
+								"no_proxy" : "test.example.com,another.custom.com,s3.dualstack.us-east-1.amazonaws.com,.s3.us-east-1.amazonaws.com,sts.us-east-1.amazonaws.com,api.ecr.us-east-1.amazonaws.com,.dkr.ecr.us-east-1.amazonaws.com"
+							}
+						}]`),
+					),
+				)
+
+				// Update no_proxy to add another custom domain
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					properties = {
+						rosa_creator_arn = "arn:aws:iam::123456789012:user/dummy",
+						zero_egress = "true"
+					}
+					proxy = {
+						no_proxy = "test.example.com,another.custom.com"
+					}
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+				}`)
+				runOutput = Terraform.Apply()
+				Expect(runOutput.ExitCode).To(BeZero())
+
+				resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster")
+				// Verify Update path filters default domains and state reflects only user domains
+				Expect(resource).To(MatchJQ(`.attributes.proxy.no_proxy`, "test.example.com,another.custom.com"))
 			})
 		})
 


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary
<!-- brief text of 1 or 2 lines with the most important changes and outcomes -->

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->
Current in production env, for zero egress enabled clusters, client can query the default domains in noproxy thru OCM API. This PR removes the hardcoded domain templates in TF provider, changes to read the default domain list from OCM API.

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [ROSAENG-6793](https://redhat.atlassian.net/browse/ROSAENG-6793)
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [x] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. Create a hcp cluster with zero egress enabled. Related blocks in the main.tf as below
```
resource "rhcs_cluster_rosa_hcp" "rosa_sts_hcp_cluster" {
...
...
  properties = {
    rosa_creator_arn = data.aws_caller_identity.current.arn,
    zero_egress = "true"
  }
  proxy = {
    http_proxy = "http://test.com",
    no_proxy = "127.0.0.1"
  }
}
```
2. Run command `terraform apply` 
3.

### Expected Results
<!-- What should happen after running the steps above -->
the `terraform apply` command should complete successfully

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [ ] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [ ] PR description clearly explains both **what** changed and **why**.
- [ ] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make pre-push-checks` passes.
- [ ] `make fmt-check` passes.
- [ ] `make build` passes.
- [ ] Documentation was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy handling for zero-egress clusters: user-defined proxy exclusion entries are preserved while automatic default domains are removed during create, update, and refresh/read flows; API-returned proxy values are stored raw and de-duplication is applied before state is persisted. Helper failures now emit warnings without overwriting existing proxy settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->