### PR TITLE
OCM-00000 | ci: update task-build-image-index

### DIFF
--- a/.tekton/terraform-provider-rhcs-push.yaml
+++ b/.tekton/terraform-provider-rhcs-push.yaml
@@ -258,7 +258,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:c7b0f7e1f743040d99a3532abbdfddc9484f80fd559a75171c97499c3eb5d163
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:5b51ebe8076412bea2703249c0e92472e240d2a44d90b8768dfe076e918c4391
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
<!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when the option is not applicable to your case.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary

  Update `task-build-image-index:0.2` digest in the Tekton push pipeline to the latest upstream release.

log: `Untrusted version of PipelineTask "build-image-index" (Task "build-image-index") was included in build chain comprised of: build-image-index. Please upgrade the task version to: sha256:5b51ebe8076412bea2703249c0e92472e240d2a44d90b8768dfe076e918c4391`

  ## Detailed Description of the Issue

  The `task-build-image-index` Tekton catalog task pinned in `.tekton/terraform-provider-rhcs-push.yaml` referenced an outdated image digest. This bumps the digest to the current release to pick up any upstream fixes or improvements.

  ## Related Issues and PRs

  - Jira: N/A
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change

  - [ ] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [x] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  Tekton push pipeline used `task-build-image-index:0.2@sha256:c7b0f7e1f743040d99a3532abbdfddc9484f80fd559a75171c97499c3eb5d163`.

  ## Behavior After This Change

  Tekton push pipeline uses `task-build-image-index:0.2@sha256:5b51ebe8076412bea2703249c0e92472e240d2a44d90b8768dfe076e918c4391`.

  ## How to Test (Step-by-Step)

  N/A

  ### Preconditions

  N/A

  ### Test Steps

  1. Merge and observe that the push pipeline completes successfully.

  ### Expected Results

  Pipeline run completes without errors using the updated task image.

  ## Proof of the Fix

  N/A

  ## Breaking Changes

  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ### Breaking Change Details / Migration Plan

  N/A

  ## Developer Verification Checklist

  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] Tests were added/updated where appropriate.
  - [ ] I manually tested the change.
  - [ ] `make pre-push-checks` passes.
  - [ ] `make fmt-check` passes.
  - [ ] `make build` passes.
  - [ ] Documentation was added/updated where appropriate.
  - [ ] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration with a maintenance upgrade to the image index build task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->