### PR TITLE
ROSAENG-9174 | feat(hcp): add component_routes support to HCP default ingress resource

### DIFF
--- a/docs/resources/hcp_default_ingress.md
+++ b/docs/resources/hcp_default_ingress.md
@@ -27,8 +27,21 @@ resource "rhcs_hcp_default_ingress" "default_ingress" {
 - `cluster` (String) Identifier of the cluster. After the creation of the resource, it is not possible to update the attribute value.
 - `listening_method` (String) Listening Method for apps ingress. Options are external,internal.
 
+### Optional
+
+- `component_routes` (Map of Object) Component route parameters for console and downloads. OAuth is not supported on HCP clusters. (see [below for nested schema](#nestedatt--component_routes))
+
 ### Read-Only
 
 - `id` (String) Unique identifier of the ingress.
+
+<a id="nestedatt--component_routes"></a>
+### Nested Schema for `component_routes`
+
+Optional:
+
+- `hostname` (String)
+- `tls_secret_ref` (String)
+
 
 

--- a/provider/defaultingress/classic/resource.go
+++ b/provider/defaultingress/classic/resource.go
@@ -448,7 +448,7 @@ func (r *DefaultIngressResource) updateIngress(ctx context.Context, state, plan 
 			componentRoutes := defaultingress.ResetComponentRoutes()
 			for k, v := range plan.ComponentRoutes.Elements() {
 				componentRouteBuilder := cmv1.NewComponentRoute()
-				hostname, tlsSecretRef := defaultingress.ExpandComponentRoute(ctx, v.(types.Object), diags)
+				hostname, tlsSecretRef := defaultingress.ExpandComponentRoute(ctx, v.(types.Object), &diags)
 				componentRouteBuilder.Hostname(hostname)
 				componentRouteBuilder.TlsSecretRef(tlsSecretRef)
 				componentRoutes[k] = componentRouteBuilder
@@ -533,7 +533,7 @@ func validateDefaultIngress(ctx context.Context, state *DefaultIngress, diags di
 			tflog.Error(ctx, msg)
 			return errors.New(msg)
 		}
-		hostname, tlsSecretRef := defaultingress.ExpandComponentRoute(ctx, v.(types.Object), diags)
+		hostname, tlsSecretRef := defaultingress.ExpandComponentRoute(ctx, v.(types.Object), &diags)
 		if hostname == "" && tlsSecretRef == "" {
 			msg := "component route fields shouldn't both be empty, " +
 				"if you would like to reset a specific component route please remove the key instead"

--- a/provider/defaultingress/component_routes.go
+++ b/provider/defaultingress/component_routes.go
@@ -37,7 +37,7 @@ func FlattenComponentRoute(hostname, tlsSecretRef string) types.Object {
 }
 
 func ExpandComponentRoute(ctx context.Context,
-	object types.Object, diags diag.Diagnostics) (string, string) {
+	object types.Object, diags *diag.Diagnostics) (string, string) {
 	if object.IsNull() {
 		return "", ""
 	}

--- a/provider/defaultingress/hcp/resource.go
+++ b/provider/defaultingress/hcp/resource.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -18,15 +20,70 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common/attrvalidators"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/defaultingress"
 )
 
 var validListeningMethods = []string{string(cmv1.ListeningMethodExternal), string(cmv1.ListeningMethodInternal)}
+
+var requiredHcpComponentRouteKeys = []string{"console", "downloads"}
+
+func validateComponentRoutes(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	elements := req.ConfigValue.Elements()
+	if len(elements) == 0 {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Empty component routes",
+			"component_routes must not be empty. Provide at least one route (console or downloads), or remove the attribute entirely.",
+		)
+		return
+	}
+	for key := range elements {
+		valid := false
+		for _, k := range requiredHcpComponentRouteKeys {
+			if key == k {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid component route key",
+				fmt.Sprintf("'%s' is not a valid component route key. Valid keys are: console, downloads", key),
+			)
+		}
+	}
+	for key, val := range elements {
+		obj, ok := val.(types.Object)
+		if !ok {
+			continue
+		}
+		var route defaultingress.ComponentRoute
+		d := obj.As(ctx, &route, basetypes.ObjectAsOptions{})
+		if d.HasError() {
+			continue
+		}
+		hostname := route.Hostname.ValueString()
+		tlsSecret := route.TlsSecretRef.ValueString()
+		if (hostname == "" && tlsSecret != "") || (hostname != "" && tlsSecret == "") {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Incomplete component route",
+				fmt.Sprintf("'%s' must have both hostname and tls_secret_ref, or both empty", key),
+			)
+		}
+	}
+}
 
 type DefaultIngressResource struct {
 	collection  *cmv1.ClustersClient
@@ -71,6 +128,20 @@ func (r *DefaultIngressResource) Schema(ctx context.Context, req resource.Schema
 				Required:   true,
 				Validators: []validator.String{attrvalidators.EnumValueValidator(validListeningMethods)},
 			},
+			"component_routes": schema.MapAttribute{
+				Description: "Component route parameters for console and downloads. " +
+					"OAuth is not supported on HCP clusters.",
+				ElementType: basetypes.ObjectType{
+					AttrTypes: defaultingress.ComponentRouteAttributeTypes,
+				},
+				Optional: true,
+				Validators: []validator.Map{
+					attrvalidators.NewMapValidator(
+						"component_routes must contain exactly 'console' and 'downloads' keys",
+						validateComponentRoutes,
+					),
+				},
+			},
 		},
 	}
 	return
@@ -113,7 +184,7 @@ func (r *DefaultIngressResource) Create(ctx context.Context, req resource.Create
 		)
 		return
 	}
-	err = r.updateIngress(ctx, nil, plan, plan.Cluster.ValueString(), r.collection)
+	err = r.updateIngress(ctx, nil, plan, plan.Cluster.ValueString(), r.collection, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed building cluster default ingress",
@@ -175,24 +246,20 @@ func (r *DefaultIngressResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// assert cluster attribute wasn't changed:
-	common.ValidateStateAndPlanEquals(state.Cluster, plan.Cluster, "cluster", &diags)
+	common.ValidateStateAndPlanEquals(state.Cluster, plan.Cluster, "cluster", &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	err := r.updateIngress(ctx, state, plan, plan.Cluster.ValueString(), r.collection)
+	err := r.updateIngress(ctx, state, plan, plan.Cluster.ValueString(), r.collection, &resp.Diagnostics)
 	if err != nil {
-		diags.AddError(
+		resp.Diagnostics.AddError(
 			"Failed to update default ingress",
 			fmt.Sprintf(
 				"Cannot update default ingress for "+
 					"cluster '%s': %v", state.Cluster.ValueString(), err,
 			),
 		)
-	}
-
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -276,11 +343,30 @@ func (r *DefaultIngressResource) populateState(ingress *cmv1.Ingress, state *Def
 	state.Id = types.StringValue(ingress.ID())
 	state.ListeningMethod = types.StringValue(string(ingress.Listening()))
 
+	componentRoutes, ok := ingress.GetComponentRoutes()
+	if ok && len(componentRoutes) > 0 {
+		elements := map[string]attr.Value{}
+		for k, v := range componentRoutes {
+			elements[k] = defaultingress.FlattenComponentRoute(v.Hostname(), v.TlsSecretRef())
+		}
+		mapValue, diags := types.MapValue(types.ObjectType{
+			AttrTypes: defaultingress.ComponentRouteAttributeTypes,
+		}, elements)
+		if diags != nil && diags.HasError() {
+			return fmt.Errorf("failed to convert component routes to MapType: %v", diags.Errors()[0].Detail())
+		}
+		state.ComponentRoutes = mapValue
+	} else {
+		state.ComponentRoutes = types.MapNull(types.ObjectType{
+			AttrTypes: defaultingress.ComponentRouteAttributeTypes,
+		})
+	}
+
 	return nil
 }
 
 func (r *DefaultIngressResource) updateIngress(ctx context.Context, state, plan *DefaultIngress,
-	clusterId string, clusterCollection *cmv1.ClustersClient) error {
+	clusterId string, clusterCollection *cmv1.ClustersClient, diags *diag.Diagnostics) error {
 
 	if state == nil {
 		state = &DefaultIngress{Cluster: plan.Cluster}
@@ -299,7 +385,7 @@ func (r *DefaultIngressResource) updateIngress(ctx context.Context, state, plan 
 			plan = &DefaultIngress{}
 		}
 
-		ingressBuilder := getDefaultIngressBuilder(ctx, state, plan)
+		ingressBuilder := getDefaultIngressBuilder(ctx, state, plan, diags)
 
 		ingress, err := ingressBuilder.Build()
 		if err != nil {
@@ -320,10 +406,34 @@ func (r *DefaultIngressResource) updateIngress(ctx context.Context, state, plan 
 	return nil
 }
 
-func getDefaultIngressBuilder(ctx context.Context, state, plan *DefaultIngress) *cmv1.IngressBuilder {
+func getDefaultIngressBuilder(
+	ctx context.Context, state, plan *DefaultIngress, diags *diag.Diagnostics,
+) *cmv1.IngressBuilder {
 	ingressBuilder := cmv1.NewIngress()
 	if !common.IsStringAttributeUnknownOrEmpty(plan.ListeningMethod) && state.ListeningMethod != plan.ListeningMethod {
 		ingressBuilder.Listening(cmv1.ListeningMethod(plan.ListeningMethod.ValueString()))
+	}
+	if !state.ComponentRoutes.Equal(plan.ComponentRoutes) {
+		componentRoutes := map[string]*cmv1.ComponentRouteBuilder{}
+		if !plan.ComponentRoutes.IsNull() {
+			for k, v := range plan.ComponentRoutes.Elements() {
+				componentRouteBuilder := cmv1.NewComponentRoute()
+				hostname, tlsSecretRef := defaultingress.ExpandComponentRoute(ctx, v.(types.Object), diags)
+				componentRouteBuilder.Hostname(hostname)
+				componentRouteBuilder.TlsSecretRef(tlsSecretRef)
+				componentRoutes[k] = componentRouteBuilder
+			}
+			for k := range state.ComponentRoutes.Elements() {
+				if _, exists := componentRoutes[k]; !exists {
+					componentRoutes[k] = cmv1.NewComponentRoute().Hostname("").TlsSecretRef("")
+				}
+			}
+		} else {
+			for k := range state.ComponentRoutes.Elements() {
+				componentRoutes[k] = cmv1.NewComponentRoute().Hostname("").TlsSecretRef("")
+			}
+		}
+		ingressBuilder.ComponentRoutes(componentRoutes)
 	}
 	return ingressBuilder
 }

--- a/provider/defaultingress/hcp/resource.go
+++ b/provider/defaultingress/hcp/resource.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -18,15 +20,81 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common/attrvalidators"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/defaultingress"
 )
 
 var validListeningMethods = []string{string(cmv1.ListeningMethodExternal), string(cmv1.ListeningMethodInternal)}
+
+var validHcpComponentRouteKeys = []string{"console", "downloads"}
+
+func resetHcpComponentRoutes() map[string]*cmv1.ComponentRouteBuilder {
+	componentRoutes := make(map[string]*cmv1.ComponentRouteBuilder, len(validHcpComponentRouteKeys))
+	for _, key := range validHcpComponentRouteKeys {
+		componentRoutes[key] = cmv1.NewComponentRoute().
+			Hostname("").
+			TlsSecretRef("")
+	}
+	return componentRoutes
+}
+
+func validateComponentRoutes(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	elements := req.ConfigValue.Elements()
+	if len(elements) == 0 {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Empty component routes",
+			"component_routes must not be empty. "+
+				"Provide at least one route (console or downloads), or remove the attribute entirely.",
+		)
+		return
+	}
+	for key := range elements {
+		valid := false
+		for _, k := range validHcpComponentRouteKeys {
+			if key == k {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid component route key",
+				fmt.Sprintf("'%s' is not a valid component route key. Valid keys are: console, downloads", key),
+			)
+		}
+	}
+	for key, val := range elements {
+		obj, ok := val.(types.Object)
+		if !ok {
+			continue
+		}
+		var route defaultingress.ComponentRoute
+		d := obj.As(ctx, &route, basetypes.ObjectAsOptions{})
+		if d.HasError() {
+			continue
+		}
+		hostname := route.Hostname.ValueString()
+		tlsSecret := route.TlsSecretRef.ValueString()
+		if (hostname == "" && tlsSecret != "") || (hostname != "" && tlsSecret == "") {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Incomplete component route",
+				fmt.Sprintf("'%s' must have both hostname and tls_secret_ref, or both empty", key),
+			)
+		}
+	}
+}
 
 type DefaultIngressResource struct {
 	collection  *cmv1.ClustersClient
@@ -71,6 +139,20 @@ func (r *DefaultIngressResource) Schema(ctx context.Context, req resource.Schema
 				Required:   true,
 				Validators: []validator.String{attrvalidators.EnumValueValidator(validListeningMethods)},
 			},
+			"component_routes": schema.MapAttribute{
+				Description: "Component route parameters for console and downloads. " +
+					"OAuth is not supported on HCP clusters.",
+				ElementType: basetypes.ObjectType{
+					AttrTypes: defaultingress.ComponentRouteAttributeTypes,
+				},
+				Optional: true,
+				Validators: []validator.Map{
+					attrvalidators.NewMapValidator(
+						"component_routes supports 'console' and 'downloads' keys",
+						validateComponentRoutes,
+					),
+				},
+			},
 		},
 	}
 	return
@@ -113,7 +195,7 @@ func (r *DefaultIngressResource) Create(ctx context.Context, req resource.Create
 		)
 		return
 	}
-	err = r.updateIngress(ctx, nil, plan, plan.Cluster.ValueString(), r.collection)
+	err = r.updateIngress(ctx, nil, plan, plan.Cluster.ValueString(), r.collection, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed building cluster default ingress",
@@ -175,24 +257,20 @@ func (r *DefaultIngressResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// assert cluster attribute wasn't changed:
-	common.ValidateStateAndPlanEquals(state.Cluster, plan.Cluster, "cluster", &diags)
+	common.ValidateStateAndPlanEquals(state.Cluster, plan.Cluster, "cluster", &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	err := r.updateIngress(ctx, state, plan, plan.Cluster.ValueString(), r.collection)
+	err := r.updateIngress(ctx, state, plan, plan.Cluster.ValueString(), r.collection, &resp.Diagnostics)
 	if err != nil {
-		diags.AddError(
+		resp.Diagnostics.AddError(
 			"Failed to update default ingress",
 			fmt.Sprintf(
 				"Cannot update default ingress for "+
 					"cluster '%s': %v", state.Cluster.ValueString(), err,
 			),
 		)
-	}
-
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -276,11 +354,30 @@ func (r *DefaultIngressResource) populateState(ingress *cmv1.Ingress, state *Def
 	state.Id = types.StringValue(ingress.ID())
 	state.ListeningMethod = types.StringValue(string(ingress.Listening()))
 
+	componentRoutes, ok := ingress.GetComponentRoutes()
+	if ok && len(componentRoutes) > 0 {
+		elements := map[string]attr.Value{}
+		for k, v := range componentRoutes {
+			elements[k] = defaultingress.FlattenComponentRoute(v.Hostname(), v.TlsSecretRef())
+		}
+		mapValue, diags := types.MapValue(types.ObjectType{
+			AttrTypes: defaultingress.ComponentRouteAttributeTypes,
+		}, elements)
+		if diags != nil && diags.HasError() {
+			return fmt.Errorf("failed to convert component routes to MapType: %v", diags.Errors()[0].Detail())
+		}
+		state.ComponentRoutes = mapValue
+	} else {
+		state.ComponentRoutes = types.MapNull(types.ObjectType{
+			AttrTypes: defaultingress.ComponentRouteAttributeTypes,
+		})
+	}
+
 	return nil
 }
 
 func (r *DefaultIngressResource) updateIngress(ctx context.Context, state, plan *DefaultIngress,
-	clusterId string, clusterCollection *cmv1.ClustersClient) error {
+	clusterId string, clusterCollection *cmv1.ClustersClient, diags *diag.Diagnostics) error {
 
 	if state == nil {
 		state = &DefaultIngress{Cluster: plan.Cluster}
@@ -299,7 +396,7 @@ func (r *DefaultIngressResource) updateIngress(ctx context.Context, state, plan 
 			plan = &DefaultIngress{}
 		}
 
-		ingressBuilder := getDefaultIngressBuilder(ctx, state, plan)
+		ingressBuilder := getDefaultIngressBuilder(ctx, state, plan, diags)
 
 		ingress, err := ingressBuilder.Build()
 		if err != nil {
@@ -320,10 +417,23 @@ func (r *DefaultIngressResource) updateIngress(ctx context.Context, state, plan 
 	return nil
 }
 
-func getDefaultIngressBuilder(ctx context.Context, state, plan *DefaultIngress) *cmv1.IngressBuilder {
+func getDefaultIngressBuilder(
+	ctx context.Context, state, plan *DefaultIngress, diags *diag.Diagnostics,
+) *cmv1.IngressBuilder {
 	ingressBuilder := cmv1.NewIngress()
 	if !common.IsStringAttributeUnknownOrEmpty(plan.ListeningMethod) && state.ListeningMethod != plan.ListeningMethod {
 		ingressBuilder.Listening(cmv1.ListeningMethod(plan.ListeningMethod.ValueString()))
+	}
+	if !state.ComponentRoutes.Equal(plan.ComponentRoutes) {
+		componentRoutes := resetHcpComponentRoutes()
+		for k, v := range plan.ComponentRoutes.Elements() {
+			componentRouteBuilder := cmv1.NewComponentRoute()
+			hostname, tlsSecretRef := defaultingress.ExpandComponentRoute(ctx, v.(types.Object), diags)
+			componentRouteBuilder.Hostname(hostname)
+			componentRouteBuilder.TlsSecretRef(tlsSecretRef)
+			componentRoutes[k] = componentRouteBuilder
+		}
+		ingressBuilder.ComponentRoutes(componentRoutes)
 	}
 	return ingressBuilder
 }

--- a/provider/defaultingress/hcp/state.go
+++ b/provider/defaultingress/hcp/state.go
@@ -9,4 +9,5 @@ type DefaultIngress struct {
 	Id              types.String `tfsdk:"id"`
 	Cluster         types.String `tfsdk:"cluster"`
 	ListeningMethod types.String `tfsdk:"listening_method"`
+	ComponentRoutes types.Map    `tfsdk:"component_routes"`
 }

--- a/subsystem/hcp/default_ingress_resource_test.go
+++ b/subsystem/hcp/default_ingress_resource_test.go
@@ -116,6 +116,220 @@ var _ = Describe("rhcs_cluster_rosa_hcp - default ingress", func() {
 		Expect(runOutput.ExitCode).To(BeZero())
 	})
 
+	It("When component_routes with console and downloads are set it should update successfully", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, clusterReady),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses"),
+				RespondWithJSON(http.StatusOK, defaultDay1Template),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				VerifyJQ(".component_routes.console.hostname", "console.custom.example.com"),
+				VerifyJQ(".component_routes.console.tls_secret_ref", "console-tls-secret"),
+				VerifyJQ(".component_routes.downloads.hostname", "downloads.custom.example.com"),
+				VerifyJQ(".component_routes.downloads.tls_secret_ref", "downloads-tls-secret"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						},
+						"downloads": {
+							"hostname": "downloads.custom.example.com",
+							"tls_secret_ref": "downloads-tls-secret"
+						}
+					}
+				}`),
+			),
+		)
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+				component_routes = {
+					"console" = {
+						"hostname"       = "console.custom.example.com"
+						"tls_secret_ref" = "console-tls-secret"
+					}
+					"downloads" = {
+						"hostname"       = "downloads.custom.example.com"
+						"tls_secret_ref" = "downloads-tls-secret"
+					}
+				}
+			}`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_hcp_default_ingress", "default_ingress")
+		Expect(resource).To(MatchJQ(".attributes.component_routes.console.hostname", "console.custom.example.com"))
+		Expect(resource).To(MatchJQ(".attributes.component_routes.console.tls_secret_ref", "console-tls-secret"))
+		Expect(resource).To(MatchJQ(".attributes.component_routes.downloads.hostname", "downloads.custom.example.com"))
+		Expect(resource).To(MatchJQ(".attributes.component_routes.downloads.tls_secret_ref", "downloads-tls-secret"))
+	})
+
+	It("When component_routes with only console is set it should update successfully", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, clusterReady),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses"),
+				RespondWithJSON(http.StatusOK, defaultDay1Template),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				VerifyJQ(".component_routes.console.hostname", "console.custom.example.com"),
+				VerifyJQ(".component_routes.console.tls_secret_ref", "console-tls-secret"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						}
+					}
+				}`),
+			),
+		)
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+				component_routes = {
+					"console" = {
+						"hostname"       = "console.custom.example.com"
+						"tls_secret_ref" = "console-tls-secret"
+					}
+				}
+			}`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_hcp_default_ingress", "default_ingress")
+		Expect(resource).To(MatchJQ(".attributes.component_routes.console.hostname", "console.custom.example.com"))
+		Expect(resource).To(MatchJQ(".attributes.component_routes.console.tls_secret_ref", "console-tls-secret"))
+	})
+
+It("When component_routes block is removed it should clear routes", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, clusterReady),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses"),
+				RespondWithJSON(http.StatusOK, defaultDay1Template),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				VerifyJQ(".component_routes.console.hostname", "console.custom.example.com"),
+				VerifyJQ(".component_routes.downloads.hostname", "downloads.custom.example.com"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						},
+						"downloads": {
+							"hostname": "downloads.custom.example.com",
+							"tls_secret_ref": "downloads-tls-secret"
+						}
+					}
+				}`),
+			),
+		)
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+				component_routes = {
+					"console" = {
+						"hostname"       = "console.custom.example.com"
+						"tls_secret_ref" = "console-tls-secret"
+					}
+					"downloads" = {
+						"hostname"       = "downloads.custom.example.com"
+						"tls_secret_ref" = "downloads-tls-secret"
+					}
+				}
+			}`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						},
+						"downloads": {
+							"hostname": "downloads.custom.example.com",
+							"tls_secret_ref": "downloads-tls-secret"
+						}
+					}
+				}`),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com"
+				}`),
+			),
+		)
+
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+			}`)
+		runOutput = Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_hcp_default_ingress", "default_ingress")
+		Expect(resource).To(MatchJQ(".attributes.component_routes", nil))
+	})
+
 	It("Update default ingress and delete it", func() {
 		// Prepare the server:
 		TestServer.AppendHandlers(

--- a/subsystem/hcp/default_ingress_resource_test.go
+++ b/subsystem/hcp/default_ingress_resource_test.go
@@ -116,6 +116,356 @@ var _ = Describe("rhcs_cluster_rosa_hcp - default ingress", func() {
 		Expect(runOutput.ExitCode).To(BeZero())
 	})
 
+	It("When component_routes with console and downloads are set it should update successfully", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, clusterReady),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses"),
+				RespondWithJSON(http.StatusOK, defaultDay1Template),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				VerifyJQ(".component_routes.console.hostname", "console.custom.example.com"),
+				VerifyJQ(".component_routes.console.tls_secret_ref", "console-tls-secret"),
+				VerifyJQ(".component_routes.downloads.hostname", "downloads.custom.example.com"),
+				VerifyJQ(".component_routes.downloads.tls_secret_ref", "downloads-tls-secret"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						},
+						"downloads": {
+							"hostname": "downloads.custom.example.com",
+							"tls_secret_ref": "downloads-tls-secret"
+						}
+					}
+				}`),
+			),
+		)
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+				component_routes = {
+					"console" = {
+						"hostname"       = "console.custom.example.com"
+						"tls_secret_ref" = "console-tls-secret"
+					}
+					"downloads" = {
+						"hostname"       = "downloads.custom.example.com"
+						"tls_secret_ref" = "downloads-tls-secret"
+					}
+				}
+			}`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_hcp_default_ingress", "default_ingress")
+		Expect(resource).To(MatchJQ(".attributes.component_routes.console.hostname", "console.custom.example.com"))
+		Expect(resource).To(MatchJQ(".attributes.component_routes.console.tls_secret_ref", "console-tls-secret"))
+		Expect(resource).To(MatchJQ(".attributes.component_routes.downloads.hostname", "downloads.custom.example.com"))
+		Expect(resource).To(MatchJQ(".attributes.component_routes.downloads.tls_secret_ref", "downloads-tls-secret"))
+	})
+
+	It("When component_routes with only console is set it should update successfully", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, clusterReady),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses"),
+				RespondWithJSON(http.StatusOK, defaultDay1Template),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				VerifyJQ(".component_routes.console.hostname", "console.custom.example.com"),
+				VerifyJQ(".component_routes.console.tls_secret_ref", "console-tls-secret"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						}
+					}
+				}`),
+			),
+		)
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+				component_routes = {
+					"console" = {
+						"hostname"       = "console.custom.example.com"
+						"tls_secret_ref" = "console-tls-secret"
+					}
+				}
+			}`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_hcp_default_ingress", "default_ingress")
+		Expect(resource).To(MatchJQ(".attributes.component_routes.console.hostname", "console.custom.example.com"))
+		Expect(resource).To(MatchJQ(".attributes.component_routes.console.tls_secret_ref", "console-tls-secret"))
+	})
+
+	It("When component_routes shrinks from both to console-only it should clear downloads", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, clusterReady),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses"),
+				RespondWithJSON(http.StatusOK, defaultDay1Template),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						},
+						"downloads": {
+							"hostname": "downloads.custom.example.com",
+							"tls_secret_ref": "downloads-tls-secret"
+						}
+					}
+				}`),
+			),
+		)
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+				component_routes = {
+					"console" = {
+						"hostname"       = "console.custom.example.com"
+						"tls_secret_ref" = "console-tls-secret"
+					}
+					"downloads" = {
+						"hostname"       = "downloads.custom.example.com"
+						"tls_secret_ref" = "downloads-tls-secret"
+					}
+				}
+			}`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						},
+						"downloads": {
+							"hostname": "downloads.custom.example.com",
+							"tls_secret_ref": "downloads-tls-secret"
+						}
+					}
+				}`),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				VerifyJQ(".component_routes.console.hostname", "console.custom.example.com"),
+				VerifyJQ(".component_routes.console.tls_secret_ref", "console-tls-secret"),
+				VerifyJQ(".component_routes.downloads.hostname", ""),
+				VerifyJQ(".component_routes.downloads.tls_secret_ref", ""),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						}
+					}
+				}`),
+			),
+		)
+
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+				component_routes = {
+					"console" = {
+						"hostname"       = "console.custom.example.com"
+						"tls_secret_ref" = "console-tls-secret"
+					}
+				}
+			}`)
+		runOutput = Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_hcp_default_ingress", "default_ingress")
+		Expect(resource).To(MatchJQ(".attributes.component_routes.console.hostname", "console.custom.example.com"))
+	})
+
+	It("When downloads has empty hostname and tls_secret_ref it should not fail validation", func() {
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+				component_routes = {
+					"console" = {
+						"hostname"       = "console.custom.example.com"
+						"tls_secret_ref" = "console-tls-secret"
+					}
+					"downloads" = {
+						"hostname"       = ""
+						"tls_secret_ref" = ""
+					}
+				}
+			}`)
+		runOutput := Terraform.Validate()
+		Expect(runOutput.ExitCode).To(BeZero())
+	})
+
+	It("When component_routes block is removed it should clear routes", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, clusterReady),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses"),
+				RespondWithJSON(http.StatusOK, defaultDay1Template),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				VerifyJQ(".component_routes.console.hostname", "console.custom.example.com"),
+				VerifyJQ(".component_routes.downloads.hostname", "downloads.custom.example.com"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						},
+						"downloads": {
+							"hostname": "downloads.custom.example.com",
+							"tls_secret_ref": "downloads-tls-secret"
+						}
+					}
+				}`),
+			),
+		)
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+				component_routes = {
+					"console" = {
+						"hostname"       = "console.custom.example.com"
+						"tls_secret_ref" = "console-tls-secret"
+					}
+					"downloads" = {
+						"hostname"       = "downloads.custom.example.com"
+						"tls_secret_ref" = "downloads-tls-secret"
+					}
+				}
+			}`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com",
+					"component_routes": {
+						"console": {
+							"hostname": "console.custom.example.com",
+							"tls_secret_ref": "console-tls-secret"
+						},
+						"downloads": {
+							"hostname": "downloads.custom.example.com",
+							"tls_secret_ref": "downloads-tls-secret"
+						}
+					}
+				}`),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2"),
+				RespondWithJSON(http.StatusOK, `
+				{
+					"kind": "Ingress",
+					"href": "/api/clusters_mgmt/v1/clusters/123/ingresses/d6z2",
+					"id": "d6z2",
+					"listening": "external",
+					"default": true,
+					"dns_name": "redhat.com"
+				}`),
+			),
+		)
+
+		Terraform.Source(`
+			resource "rhcs_hcp_default_ingress" "default_ingress" {
+				cluster = "123"
+				listening_method = "external"
+			}`)
+		runOutput = Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_hcp_default_ingress", "default_ingress")
+		Expect(resource).To(MatchJQ(".attributes.component_routes", nil))
+	})
+
 	It("Update default ingress and delete it", func() {
 		// Prepare the server:
 		TestServer.AppendHandlers(


### PR DESCRIPTION
## PR Summary

Add `component_routes` support to the `rhcs_hcp_default_ingress` resource, enabling ROSA HCP customers to configure custom hostnames and TLS certificates for Console and Downloads routes — matching feature parity with the Classic `rhcs_default_ingress` resource.

## Detailed Description of the Issue

ROSA HCP customers cannot customize hostnames for Console or Downloads routes. This blocks customers migrating from ROSA Classic who rely on custom component routes, and those with strict enterprise domain/compliance requirements (e.g., GovCloud). The Classic default ingress resource already supports `component_routes`, but the HCP resource only exposed `listening_method`.

## Related Issues and PRs
- Jira: [ROSAENG-9174](https://redhat.atlassian.net/browse/ROSAENG-9174)
- Feature: [ROSA-62](https://issues.redhat.com/browse/ROSA-62)
- Clusters-service MR: 11393 (merged)
- HyperShift PR: [openshift/hypershift#8838](https://github.com/openshift/hypershift/pull/8838) (merged)
- HyperShift bug: [OCPBUGS-92791](https://redhat.atlassian.net/browse/OCPBUGS-92791)
- ROSA CLI PR: [openshift/rosa#3376](https://github.com/openshift/rosa/pull/3376) (merged)

## Type of Change
- [x] feat - adds a new user-facing capability.

## Previous Behavior

The `rhcs_hcp_default_ingress` resource only supported the `listening_method` attribute. Customers could not configure `component_routes` for HCP clusters via Terraform. The field was silently ignored.

## Behavior After This Change

The `rhcs_hcp_default_ingress` resource now supports an optional `component_routes` map attribute for Console and Downloads routes (OAuth is not supported on HCP — the OAuth server runs on the management cluster). Customers can set custom hostnames and reference TLS secrets:

```hcl
resource "rhcs_hcp_default_ingress" "default" {
  cluster          = rhcs_cluster_rosa_hcp.example.id
  listening_method = "external"

  component_routes = {
    console = {
      hostname       = "console.company.com"
      tls_secret_ref = "console-tls"
    }
    downloads = {
      hostname       = "downloads.company.com"
      tls_secret_ref = "downloads-tls"
    }
  }
}
```

For HCP clusters, only the routes specified by the user are sent to the API (no `ResetComponentRoutes()`). This avoids sending an empty oauth route which the backend correctly rejects on HCP.

## How to Test (Step-by-Step)
### Preconditions
- A running ROSA HCP cluster
- The `hypershift-component-routes` feature toggle enabled
- HyperShift operator >= v0.1.79 deployed
- A TLS secret created in `openshift-config` namespace on the hosted cluster
- ROSA CLI change merged ([openshift/rosa#3376](https://github.com/openshift/rosa/pull/3376))

### Test Steps
1. Configure the `rhcs_hcp_default_ingress` resource with `component_routes` for console and/or downloads
2. Run `terraform plan` — should show the component_routes as a new attribute
3. Run `terraform apply` — should update the ingress via the OCM API
4. Verify on the cluster: `oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.componentRoutes}'`
5. Verify custom routes: `oc get routes -n openshift-console`

### Expected Results
- `terraform plan` shows the component_routes diff correctly
- `terraform apply` succeeds
- The cluster's ingress config reflects the custom hostnames
- Custom routes are created (e.g. `console-custom`, `downloads-custom`)
- Original routes redirect (301) to the custom hostnames
- Setting an OAuth component route returns an error from the backend

## Proof of the Fix
- Verified end-to-end in integration on cluster `2ri09onv6bra4994h79m4eu2t2oh9spq`
- `terraform plan` correctly shows console and downloads component_routes
- `terraform apply` succeeds, componentRoutes propagate to hosted cluster ingress config
- Both `console-custom` and `downloads-custom` routes created on the hosted cluster
- Console accessible at custom hostname via curl

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make pre-push-checks` passes.
- [x] `make fmt-check` passes.
- [x] `make build` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional `component_routes` support to the HCP default ingress resource for `console` and `downloads`.
  - Allows configuring `hostname` and `tls_secret_ref` per route, with validation requiring both values together.
  - Component routes are applied during create/update, and removed routes are reflected in state.

- **Documentation**
  - Documented the `component_routes` attribute schema and noted OAuth is not supported on HCP clusters.

- **Tests**
  - Added coverage for PATCH payloads and state changes when setting and clearing `component_routes`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->