### PR TITLE
ROSAENG-57139 | ci: Add Dockerfile.clients to be used by Prow job pre…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Keep .git in the build context: ci-tf-e2e and make install use git describe for provider version paths.
+bin/
+**/.terraform/
+.terraform-docs-cache/

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -40,28 +40,3 @@ jobs:
           terraform_wrapper: false
       - name: Run pre-push checks
         run: make pre-push-checks
-
-  test:
-    name: Test
-    strategy:
-      matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - name: Checkout the source
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
-        with:
-          terraform_wrapper: false
-      - name: Run the tests
-        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ terraform.tfvars.d*
 /tests/rhcs_output
 terraform-provider-rhcs
 /bin/
+/.cache/
+/go/
+/.config/
 .vscode/**/*
 **/ginkgo.report
 /temp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,7 @@ The hooks are configured in `.pre-commit-config.yaml` and perform:
 
 - `pre-commit`: formats staged Go files with `gci` + `gofmt` plus staged Terraform files under `examples/` and `tests/`, adds Apache 2.0 license headers to staged files missing them, and blocks the commit if files were rewritten so you can review and stage the updates
 - `commit-msg`: validates the commit message format (JIRA-123 | type(scope): message)
-- `pre-push`: runs format-check, build, generated-files check, lint, docs-lint (Vale), changed-files coverage for changed Go files under `provider/` and `internal/`, and unit/subsystem tests
-- `pre-push` runs against committed content and blocks when staged or unstaged tracked changes are present
+- `pre-push`: runs the same steps as `make pre-push-checks` (format-check, build, generated-files check, lint, docs-lint, license-check, changed-files coverage, and `make test`)
 - check runs are fail-fast: execution stops at the first failing step
 
 To manually run all hooks on all files:

--- a/Dockerfile.clients
+++ b/Dockerfile.clients
@@ -1,0 +1,28 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.8-1780900431
+WORKDIR /app
+COPY . /app
+RUN yum install -y yum-utils shadow-utils unzip tar make git gcc gcc-c++ jq diffutils && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+# Prow / integration client image: Go toolchain follows go.mod; Terraform pinned below for fmt-check on examples/ and tests/.
+RUN GO_VER=$(awk '/^go / { print $2; exit }' go.mod) && \
+    GO_TAR="go${GO_VER}.linux-amd64.tar.gz" && \
+    curl -fsSL "https://dl.google.com/go/${GO_TAR}" -o "/tmp/${GO_TAR}" && \
+    curl -fsSL "https://dl.google.com/go/${GO_TAR}.sha256" -o /tmp/go.sha256 && \
+    printf '%s  %s\n' "$(tr -d '\n' < /tmp/go.sha256)" "${GO_TAR}" | (cd /tmp && sha256sum -c -) && \
+    tar -C /usr/local -xzf "/tmp/${GO_TAR}" && \
+    rm -f "/tmp/${GO_TAR}" /tmp/go.sha256 && \
+    /usr/local/go/bin/go version
+# renovate: datasource=github-releases depName=hashicorp/terraform
+ARG TERRAFORM_VERSION=1.15.4
+RUN yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
+    yum -y install "terraform-${TERRAFORM_VERSION}" && \
+    yum clean all && \
+    rm -rf /var/cache/yum && \
+    terraform version
+# OpenShift Prow: arbitrary UID runs with GID 0; group-writable /app for make pre-push-checks (bin/, Go/Vale caches).
+RUN mkdir -p /app/bin && \
+    chgrp -R 0 /app && \
+    chmod -R g+rwX /app
+ENV PATH="/usr/local/go/bin:/usr/local/bin:${PATH}" \
+    HOME="/app"

--- a/build/ci-tf-e2e.Dockerfile
+++ b/build/ci-tf-e2e.Dockerfile
@@ -1,6 +1,4 @@
-# Build from repository root (so go.mod is in context):
-#   docker build -f build/ci-tf-e2e.Dockerfile .
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:9.8-1780900431
 WORKDIR /root
 
 # oc
@@ -14,8 +12,13 @@ RUN yum install -y wget &&\
 # go — toolchain version follows the `go` line in go.mod (no separate pin to drift)
 COPY go.mod /tmp/go.mod
 RUN GO_VER=$(awk '/^go / { print $2; exit }' /tmp/go.mod) && \
-    curl -fsSL "https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz" | tar -C /usr/local -xzf - && \
-    rm -f /tmp/go.mod
+    GO_TAR="go${GO_VER}.linux-amd64.tar.gz" && \
+    curl -fsSL "https://dl.google.com/go/${GO_TAR}" -o "/tmp/${GO_TAR}" && \
+    curl -fsSL "https://dl.google.com/go/${GO_TAR}.sha256" -o /tmp/go.sha256 && \
+    printf '%s  %s\n' "$(tr -d '\n' < /tmp/go.sha256)" "${GO_TAR}" | (cd /tmp && sha256sum -c -) && \
+    tar -C /usr/local -xzf "/tmp/${GO_TAR}" && \
+    rm -f "/tmp/${GO_TAR}" /tmp/go.sha256 /tmp/go.mod && \
+    /usr/local/go/bin/go version
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GOPATH=/usr/local/go
 ENV TEST_OFFLINE_TOKEN=""

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,13 @@
     "config:recommended",
     ":gitSignOff"
   ],
+  "dockerfile": {
+    "fileMatch": [
+      "^Dockerfile$",
+      "^Dockerfile\\.clients$",
+      "^build/ci-tf-e2e\\.Dockerfile$"
+    ]
+  },
   "commitMessagePrefix": "OCM-00000 | ci: ",
   "prConcurrentLimit": 2,
   "prHourlyLimit": 0,
@@ -62,6 +69,14 @@
       "matchStrings": ["ADDLICENSE_VERSION \\?= (?<currentValue>\\S+)"],
       "datasourceTemplate": "go",
       "depNameTemplate": "github.com/google/addlicense"
+    },
+    {
+      "description": "Update vale in Makefile",
+      "customType": "regex",
+      "managerFilePatterns": ["/^Makefile$/"],
+      "matchStrings": ["VALE_VERSION \\?= (?<currentValue>\\S+)"],
+      "datasourceTemplate": "go",
+      "depNameTemplate": "github.com/errata-ai/vale/v3"
     }
   ],
   "labels": [
@@ -91,6 +106,18 @@
         "major"
       ],
       "enabled": false
+    },
+    {
+      "description": "CI client Dockerfile (UBI base, Terraform)",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchFileNames": [
+        "Dockerfile.clients"
+      ],
+      "groupName": "CI client image",
+      "groupSlug": "ci-client-image",
+      "automerge": false
     },
     {
       "description": "HashiCorp Terraform plugin stack",


### PR DESCRIPTION
<!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when the option is not applicable to your case.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary

  Adds `Dockerfile.clients`, a UBI9-based container image for the Prow `pre-push-checks` CI job, with a pinned Go toolchain, Terraform, and OpenShift-compatible arbitrary-UID permissions.

Note: the Github Action check will be removed once we have the target make pre-push-checks running via Prow.

  ## Detailed Description of the Issue

  Prow jobs need a reproducible environment to run `make pre-push-checks`. Without a dedicated image, the job depends on unpinned toolchain versions. `Dockerfile.clients` pins the Go version directly from `go.mod` at build time and pins Terraform via a Renovate-tracked `ARG
  TERRAFORM_VERSION`, ensuring the CI environment matches what developers run locally. The image is built on UBI9 and configures `/app` as group-writable to satisfy OpenShift's arbitrary-UID security model.

  ## Related Issues and PRs

  - Jira: [ROSAENG-57139](https://issues.redhat.com/browse/ROSAENG-57139)
  - Fixes: `#`
  - Related PR(s):
  - Related design/docs:

  ## Type of Change

  - [ ] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [x] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  No dedicated container image existed for the Prow `pre-push-checks` job.

  ## Behavior After This Change

  - `Dockerfile.clients` provides a reproducible UBI9 environment with Go (version read from `go.mod`) and Terraform (pinned via `ARG TERRAFORM_VERSION`, tracked by Renovate) for use in Prow CI.
  - `/app` is group-writable so `make pre-push-checks` can write to `bin/` and cache directories when the container runs as an arbitrary UID under OpenShift.
  - `renovate.json` tracks the UBI base image and `TERRAFORM_VERSION` ARG in `Dockerfile.clients`, and adds a regex manager for the Vale version in `Makefile`.
  - `.dockerignore` excludes `.git`, `bin/`, `.terraform/`, and `.terraform-docs-cache/` from the build context.
  - `CONTRIBUTING.md` updates the `pre-push` hook description to reference `make pre-push-checks` directly.

  ## How to Test (Step-by-Step)

  ### Preconditions

  - Docker or Podman available locally.

  ### Test Steps

  1. Build the image: `docker build -f Dockerfile.clients -t provider-clients:local .`
  2. Confirm Go is available: `docker run --rm provider-clients:local go version`
  3. Confirm Terraform is available: `docker run --rm provider-clients:local terraform version`
  4. Confirm `make pre-push-checks` runs inside the container without permission errors.

  ### Expected Results

  Image builds successfully; both `go version` and `terraform version` print without error; `make pre-push-checks` completes inside the container.

  ## Proof of the Fix

  - Screenshots:
  - Videos:
  - Logs/CLI output:
  - Other artifacts:

  ## Breaking Changes

  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ### Breaking Change Details / Migration Plan

  N/A

  ## Developer Verification Checklist

  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] Tests were added/updated where appropriate.
  - [ ] I manually tested the change.
  - [ ] `make pre-push-checks` passes.
  - [ ] `make fmt-check` passes.
  - [ ] `make build` passes.
  - [x] Documentation was added/updated where appropriate.
  - [ ] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a client-focused container image preloaded with Go and Terraform tooling.

* **Chores**
  * Reduced Docker build context by ignoring VCS and Terraform/tooling caches.
  * Hardened toolchain and Terraform installs with checksum verification and pinned base image versions.
  * Streamlined CI by consolidating verification into the existing pre-push checks flow (removed redundant test matrix).

* **Documentation**
  * Simplified contributor guidance for the unified pre-push verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->