### PR TITLE
ROSAENG-57757 | feat(sts): add trust_policy_external_id for ROSA Classic and HCP

### DIFF
--- a/docs/data-sources/cluster_rosa_classic.md
+++ b/docs/data-sources/cluster_rosa_classic.md
@@ -117,10 +117,6 @@ Read-Only:
 <a id="nestedatt--sts"></a>
 ### Nested Schema for `sts`
 
-Optional:
-
-- `trust_policy_external_id` (String) External ID for trust policy condition in account roles
-
 Read-Only:
 
 - `instance_iam_roles` (Attributes) Instance IAM Roles (see [below for nested schema](#nestedatt--sts--instance_iam_roles))
@@ -130,6 +126,7 @@ Read-Only:
 - `role_arn` (String) Installer Role
 - `support_role_arn` (String) Support Role
 - `thumbprint` (String) SHA1-hash value of the root CA of the issuer URL
+- `trust_policy_external_id` (String) External ID for trust policy condition in account roles
 
 <a id="nestedatt--sts--instance_iam_roles"></a>
 ### Nested Schema for `sts.instance_iam_roles`

--- a/docs/data-sources/cluster_rosa_hcp.md
+++ b/docs/data-sources/cluster_rosa_hcp.md
@@ -204,10 +204,6 @@ Read-Only:
 <a id="nestedatt--sts"></a>
 ### Nested Schema for `sts`
 
-Optional:
-
-- `trust_policy_external_id` (String) External ID for trust policy condition in account roles
-
 Read-Only:
 
 - `instance_iam_roles` (Attributes) Instance IAM Roles (see [below for nested schema](#nestedatt--sts--instance_iam_roles))
@@ -217,6 +213,7 @@ Read-Only:
 - `role_arn` (String) Installer Role
 - `support_role_arn` (String) Support Role
 - `thumbprint` (String) SHA1-hash value of the root CA of the issuer URL
+- `trust_policy_external_id` (String) External ID for trust policy condition in account roles
 
 <a id="nestedatt--sts--instance_iam_roles"></a>
 ### Nested Schema for `sts.instance_iam_roles`

--- a/docs/guides/trust-policy-external-id.md
+++ b/docs/guides/trust-policy-external-id.md
@@ -64,8 +64,53 @@ resource "rhcs_cluster_rosa_classic" "example" {
 - **Required**: No (Optional)
 - **Description**: External ID for trust policy condition in account roles
 
+## Create-time validation
+
+On cluster create, the provider reads installer and support role trust policies from AWS and validates `sts.trust_policy_external_id`:
+
+- When set, the value must appear in both role trust policies.
+- When omitted, create fails if the roles define an external ID that must be declared explicitly. The error includes the discovered value when unambiguous, for example: `set sts.trust_policy_external_id = "your-external-id"`.
+- When omitted and the roles define conflicting external IDs, create fails with an error asking you to set the attribute explicitly.
+- When omitted and the roles define ambiguous external IDs, create fails with an error asking you to set the attribute explicitly.
+
+Use the same value on the account IAM module and the cluster resource so Terraform configuration, IAM, and OCM stay aligned.
+
 ## Useful Resources
 
 - [ROSA Classic Cluster Resource](../resources/cluster_rosa_classic.md)
 - [ROSA HCP Cluster Resource](../resources/cluster_rosa_hcp.md)
 - [AWS IAM External ID Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)
+
+## Account roles modules
+
+When creating account roles with Terraform modules, pass the same value to `trust_policy_external_id` on the account IAM module and to `sts.trust_policy_external_id` on the cluster resource. Use the module for your cluster type:
+
+- ROSA Classic: `terraform-redhat/rosa-classic/rhcs//modules/account-iam-resources`
+- ROSA HCP: `terraform-redhat/rosa-hcp/rhcs//modules/account-iam-resources`
+
+Example for ROSA HCP:
+
+```terraform
+module "create_account_roles" {
+  source  = "terraform-redhat/rosa-hcp/rhcs//modules/account-iam-resources"
+  version = ">=1.6.3"
+
+  account_role_prefix      = var.account_role_prefix
+  trust_policy_external_id = var.trust_policy_external_id
+}
+
+resource "rhcs_cluster_rosa_hcp" "example" {
+  # ...
+  sts = {
+    role_arn                  = module.create_account_roles.account_role_arns.installer
+    support_role_arn          = module.create_account_roles.account_role_arns.support
+    operator_role_prefix      = module.create_account_roles.account_role_prefix
+    trust_policy_external_id  = var.trust_policy_external_id
+    instance_iam_roles = {
+      worker_role_arn = module.create_account_roles.account_role_arns.worker
+    }
+  }
+}
+```
+
+For ROSA Classic, use `rhcs_cluster_rosa_classic` and the `terraform-redhat/rosa-classic/rhcs//modules/account-iam-resources` module with the same `trust_policy_external_id` wiring.

--- a/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
@@ -921,6 +921,26 @@ func (r *ClusterRosaClassicResource) Create(ctx context.Context, request resourc
 		return
 	}
 
+	if state.Sts != nil {
+		region := ""
+		if common.HasValue(state.CloudRegion) {
+			region = state.CloudRegion.ValueString()
+		}
+		if err := sts.ValidateTrustPolicyExternalIDFromConfig(
+			ctx, state.Sts.TrustPolicyExternalID, state.Sts.RoleARN,
+			state.Sts.SupportRoleArn, region,
+		); err != nil {
+			response.Diagnostics.AddError(
+				summary,
+				fmt.Sprintf(
+					"Invalid sts.trust_policy_external_id for cluster '%s': %v",
+					state.Name.ValueString(), err,
+				),
+			)
+			return
+		}
+	}
+
 	object, err := createClassicClusterObject(ctx, state, diags)
 	if err != nil {
 		response.Diagnostics.AddError(
@@ -1760,6 +1780,7 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 		if ok && oidcConfig != nil {
 			state.Sts.OIDCConfigID = types.StringValue(oidcConfig.ID())
 		}
+		sts.PopulateTrustPolicyExternalIDFromSTS(stsState, &state.Sts.TrustPolicyExternalID)
 	}
 
 	subnetIds, ok := object.AWS().GetSubnetIDs()

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -1010,6 +1010,26 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 		return
 	}
 
+	if state.Sts != nil {
+		region := ""
+		if common.HasValue(state.CloudRegion) {
+			region = state.CloudRegion.ValueString()
+		}
+		if err := sts.ValidateTrustPolicyExternalIDFromConfig(
+			ctx, state.Sts.TrustPolicyExternalID, state.Sts.RoleARN,
+			state.Sts.SupportRoleArn, region,
+		); err != nil {
+			response.Diagnostics.AddError(
+				summary,
+				fmt.Sprintf(
+					"Invalid sts.trust_policy_external_id for cluster '%s': %v",
+					state.Name.ValueString(), err,
+				),
+			)
+			return
+		}
+	}
+
 	object, err := createHcpClusterObject(ctx, state, diags)
 	if err != nil {
 		response.Diagnostics.AddError(
@@ -2047,6 +2067,7 @@ func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, stat
 		if ok && oidcConfig != nil {
 			state.Sts.OIDCConfigID = types.StringValue(oidcConfig.ID())
 		}
+		sts.PopulateTrustPolicyExternalIDFromSTS(stsState, &state.Sts.TrustPolicyExternalID)
 	}
 
 	subnetIds, ok := object.AWS().GetSubnetIDs()

--- a/provider/clusterrosa/sts/main_test.go
+++ b/provider/clusterrosa/sts/main_test.go
@@ -1,0 +1,16 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package sts
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSts(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "STS Suite")
+}

--- a/provider/clusterrosa/sts/sts.go
+++ b/provider/clusterrosa/sts/sts.go
@@ -4,11 +4,17 @@
 package sts
 
 import (
+	"context"
+
 	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/openshift-online/ocm-common/pkg/aws/ststrust"
+
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common/attrvalidators"
 )
 
 const externalIdDescription = "External ID for trust policy condition in account roles"
@@ -54,6 +60,7 @@ type hcpInstanceIAMRole struct {
 	WorkerRoleARN types.String `tfsdk:"worker_role_arn"`
 }
 
+// ClassicStsResource returns the STS nested block schema for ROSA Classic cluster resources.
 func ClassicStsResource() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"oidc_endpoint_url": schema.StringAttribute{
@@ -112,10 +119,16 @@ func ClassicStsResource() map[string]schema.Attribute {
 		"trust_policy_external_id": schema.StringAttribute{
 			Description: externalIdDescription,
 			Optional:    true,
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+			Validators: trustPolicyExternalIDValidators(),
 		},
 	}
 }
 
+// ClassicStsDatasource returns the STS nested block schema for ROSA Classic cluster data sources.
 func ClassicStsDatasource() map[string]dsschema.Attribute {
 	return map[string]dsschema.Attribute{
 		"oidc_endpoint_url": schema.StringAttribute{
@@ -156,13 +169,14 @@ func ClassicStsDatasource() map[string]dsschema.Attribute {
 			Description: "Operator IAM Role prefix",
 			Computed:    true,
 		},
-		"trust_policy_external_id": schema.StringAttribute{
+		"trust_policy_external_id": dsschema.StringAttribute{
 			Description: externalIdDescription,
-			Optional:    true,
+			Computed:    true,
 		},
 	}
 }
 
+// HcpStsResource returns the STS nested block schema for ROSA HCP cluster resources.
 func HcpStsResource() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"oidc_endpoint_url": schema.StringAttribute{
@@ -217,10 +231,16 @@ func HcpStsResource() map[string]schema.Attribute {
 		"trust_policy_external_id": schema.StringAttribute{
 			Description: externalIdDescription,
 			Optional:    true,
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+			Validators: trustPolicyExternalIDValidators(),
 		},
 	}
 }
 
+// HcpStsDatasource returns the STS nested block schema for ROSA HCP cluster data sources.
 func HcpStsDatasource() map[string]dsschema.Attribute {
 	return map[string]dsschema.Attribute{
 		"oidc_endpoint_url": schema.StringAttribute{
@@ -257,9 +277,58 @@ func HcpStsDatasource() map[string]dsschema.Attribute {
 			Description: "Operator IAM Role prefix",
 			Computed:    true,
 		},
-		"trust_policy_external_id": schema.StringAttribute{
+		"trust_policy_external_id": dsschema.StringAttribute{
 			Description: externalIdDescription,
-			Optional:    true,
+			Computed:    true,
 		},
 	}
+}
+
+// trustPolicyExternalIDValidators returns plan-time validators for sts.trust_policy_external_id format.
+func trustPolicyExternalIDValidators() []validator.String {
+	return []validator.String{
+		attrvalidators.NewStringValidator(
+			"Must be a valid STS external ID for trust policy conditions.",
+			func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+				if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+					return
+				}
+				if err := ststrust.ValidateSTSExternalIDFormat(req.ConfigValue.ValueString()); err != nil {
+					resp.Diagnostics.AddAttributeError(req.Path, "Invalid trust_policy_external_id", err.Error())
+				}
+			},
+		),
+	}
+}
+
+// ValidateTrustPolicyExternalIDFromConfig validates trust_policy_external_id using Terraform config values.
+// Both Classic and HCP cluster Create functions delegate to this helper.
+func ValidateTrustPolicyExternalIDFromConfig(
+	ctx context.Context,
+	trustPolicyExternalID, roleARN, supportRoleARN types.String,
+	region string,
+) error {
+	entered := ""
+	if !trustPolicyExternalID.IsUnknown() && !trustPolicyExternalID.IsNull() {
+		entered = trustPolicyExternalID.ValueString()
+	}
+	return ValidateTrustPolicyExternalID(ctx, entered, roleARN.ValueString(), supportRoleARN.ValueString(), region)
+}
+
+// stsExternalIDSource reads the STS external ID from an OCM cluster STS object.
+type stsExternalIDSource interface {
+	GetExternalID() (string, bool)
+}
+
+// PopulateTrustPolicyExternalIDFromSTS sets trust_policy_external_id from the OCM STS object.
+func PopulateTrustPolicyExternalIDFromSTS(stsState stsExternalIDSource, target *types.String) {
+	if stsState == nil {
+		*target = types.StringNull()
+		return
+	}
+	if externalID, ok := stsState.GetExternalID(); ok && externalID != "" {
+		*target = types.StringValue(externalID)
+		return
+	}
+	*target = types.StringNull()
 }

--- a/provider/clusterrosa/sts/sts_test.go
+++ b/provider/clusterrosa/sts/sts_test.go
@@ -1,0 +1,225 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package sts
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type mockSTSExternalIDSource struct {
+	externalID string
+	ok         bool
+}
+
+func (m *mockSTSExternalIDSource) GetExternalID() (string, bool) {
+	return m.externalID, m.ok
+}
+
+var _ = Describe("STS schema and helpers", func() {
+	Context("ClassicStsResource", func() {
+		It("marks trust_policy_external_id as optional and computed", func() {
+			schema := ClassicStsResource()
+
+			attr, exists := schema["trust_policy_external_id"]
+			Expect(exists).To(BeTrue())
+			Expect(attr.IsOptional()).To(BeTrue())
+			Expect(attr.IsComputed()).To(BeTrue())
+		})
+	})
+
+	Context("HcpStsResource", func() {
+		It("marks trust_policy_external_id as optional and computed", func() {
+			schema := HcpStsResource()
+
+			attr, exists := schema["trust_policy_external_id"]
+			Expect(exists).To(BeTrue())
+			Expect(attr.IsOptional()).To(BeTrue())
+			Expect(attr.IsComputed()).To(BeTrue())
+		})
+	})
+
+	Context("ClassicStsDatasource", func() {
+		It("marks trust_policy_external_id as computed only", func() {
+			schema := ClassicStsDatasource()
+
+			attr, exists := schema["trust_policy_external_id"]
+			Expect(exists).To(BeTrue())
+			Expect(attr.IsComputed()).To(BeTrue())
+			Expect(attr.IsOptional()).To(BeFalse())
+		})
+	})
+
+	Context("HcpStsDatasource", func() {
+		It("marks trust_policy_external_id as computed only", func() {
+			schema := HcpStsDatasource()
+
+			attr, exists := schema["trust_policy_external_id"]
+			Expect(exists).To(BeTrue())
+			Expect(attr.IsComputed()).To(BeTrue())
+			Expect(attr.IsOptional()).To(BeFalse())
+		})
+	})
+
+	Context("trustPolicyExternalIDValidators", func() {
+		It("returns a non-empty list of validators", func() {
+			validators := trustPolicyExternalIDValidators()
+			Expect(validators).NotTo(BeEmpty())
+		})
+
+		It("accepts a valid external ID", func() {
+			validators := trustPolicyExternalIDValidators()
+			req := validator.StringRequest{
+				Path:        path.Root("test"),
+				ConfigValue: types.StringValue("valid-external-id-123"),
+			}
+			resp := &validator.StringResponse{}
+			validators[0].ValidateString(context.Background(), req, resp)
+			Expect(resp.Diagnostics.HasError()).To(BeFalse())
+		})
+
+		It("rejects an invalid external ID", func() {
+			validators := trustPolicyExternalIDValidators()
+			req := validator.StringRequest{
+				Path:        path.Root("test"),
+				ConfigValue: types.StringValue("x"),
+			}
+			resp := &validator.StringResponse{}
+			validators[0].ValidateString(context.Background(), req, resp)
+			Expect(resp.Diagnostics.HasError()).To(BeTrue())
+		})
+
+		It("skips validation for null values", func() {
+			validators := trustPolicyExternalIDValidators()
+			req := validator.StringRequest{
+				Path:        path.Root("test"),
+				ConfigValue: types.StringNull(),
+			}
+			resp := &validator.StringResponse{}
+			validators[0].ValidateString(context.Background(), req, resp)
+			Expect(resp.Diagnostics.HasError()).To(BeFalse())
+		})
+
+		It("skips validation for unknown values", func() {
+			validators := trustPolicyExternalIDValidators()
+			req := validator.StringRequest{
+				Path:        path.Root("test"),
+				ConfigValue: types.StringUnknown(),
+			}
+			resp := &validator.StringResponse{}
+			validators[0].ValidateString(context.Background(), req, resp)
+			Expect(resp.Diagnostics.HasError()).To(BeFalse())
+		})
+	})
+
+	Context("ValidateTrustPolicyExternalIDFromConfig", func() {
+		const (
+			installerARN = "arn:aws:iam::123456789012:role/my-installer"
+			supportARN   = "arn:aws:iam::123456789012:role/my-support"
+			externalID   = "valid-external-id-123"
+		)
+
+		AfterEach(func() {
+			TrustPolicyValidator = validateTrustPolicyExternalIDWithAWS
+		})
+
+		It("passes value when trust_policy_external_id is set", func() {
+			TrustPolicyValidator = func(
+				_ context.Context, entered, _, _, _ string,
+			) error {
+				Expect(entered).To(Equal(externalID))
+				return nil
+			}
+
+			err := ValidateTrustPolicyExternalIDFromConfig(
+				context.Background(),
+				types.StringValue(externalID),
+				types.StringValue(installerARN),
+				types.StringValue(supportARN),
+				"us-east-1",
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("passes empty when trust_policy_external_id is null", func() {
+			TrustPolicyValidator = func(
+				_ context.Context, entered, _, _, _ string,
+			) error {
+				Expect(entered).To(BeEmpty())
+				return nil
+			}
+
+			err := ValidateTrustPolicyExternalIDFromConfig(
+				context.Background(),
+				types.StringNull(),
+				types.StringValue(installerARN),
+				types.StringValue(supportARN),
+				"us-east-1",
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("passes empty when trust_policy_external_id is unknown", func() {
+			TrustPolicyValidator = func(
+				_ context.Context, entered, _, _, _ string,
+			) error {
+				Expect(entered).To(BeEmpty())
+				return nil
+			}
+
+			err := ValidateTrustPolicyExternalIDFromConfig(
+				context.Background(),
+				types.StringUnknown(),
+				types.StringValue(installerARN),
+				types.StringValue(supportARN),
+				"us-east-1",
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns validation errors", func() {
+			err := ValidateTrustPolicyExternalIDFromConfig(
+				context.Background(),
+				types.StringValue("x"),
+				types.StringValue(installerARN),
+				types.StringValue(supportARN),
+				"us-east-1",
+			)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("PopulateTrustPolicyExternalIDFromSTS", func() {
+		It("sets null when stsState is nil", func() {
+			target := types.StringValue("prior")
+
+			PopulateTrustPolicyExternalIDFromSTS(nil, &target)
+
+			Expect(target.IsNull()).To(BeTrue())
+		})
+
+		It("sets value when external ID is present", func() {
+			target := types.StringNull()
+			source := &mockSTSExternalIDSource{externalID: "discovered-id", ok: true}
+
+			PopulateTrustPolicyExternalIDFromSTS(source, &target)
+
+			Expect(target.ValueString()).To(Equal("discovered-id"))
+		})
+
+		It("sets null when external ID is missing or empty", func() {
+			target := types.StringValue("prior")
+			source := &mockSTSExternalIDSource{externalID: "", ok: false}
+
+			PopulateTrustPolicyExternalIDFromSTS(source, &target)
+
+			Expect(target.IsNull()).To(BeTrue())
+		})
+	})
+})

--- a/provider/clusterrosa/sts/trust_policy.go
+++ b/provider/clusterrosa/sts/trust_policy.go
@@ -1,0 +1,242 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package sts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/openshift-online/ocm-common/pkg/aws/ststrust"
+)
+
+// TrustPolicyValidatorFunc validates trust_policy_external_id against installer and support IAM role trust policies.
+// Tests may replace TrustPolicyValidator to avoid AWS calls.
+type TrustPolicyValidatorFunc func(context.Context, string, string, string, string) error
+
+// TrustPolicyValidator validates trust_policy_external_id against installer and support IAM role trust policies.
+var TrustPolicyValidator TrustPolicyValidatorFunc = validateTrustPolicyExternalIDWithAWS
+
+var errMismatchedSTSExternalIDTrustPolicies = errors.New(
+	"installer and support role trust policies define STS external IDs with no value in common; " +
+		"set sts.trust_policy_external_id explicitly",
+)
+
+var errAmbiguousSTSExternalIDTrustPolicies = errors.New(
+	"could not determine a single STS external ID from the installer and support role trust policies; " +
+		"set sts.trust_policy_external_id explicitly",
+)
+
+// trustPolicyExternalIDRequiredError reports that IAM roles require an explicit external ID in Terraform config.
+type trustPolicyExternalIDRequiredError struct {
+	Discovered string
+}
+
+// Error implements the error interface.
+func (e *trustPolicyExternalIDRequiredError) Error() string {
+	return fmt.Sprintf(
+		"installer and support roles define STS external ID %q; set sts.trust_policy_external_id = %q",
+		e.Discovered,
+		e.Discovered,
+	)
+}
+
+// ValidateTrustPolicyExternalID validates sts.trust_policy_external_id against installer and support IAM roles.
+// When entered is set, it must appear in both trust policies. When unset, create fails if a single external ID
+// can be discovered from IAM (explicit config required) or if IAM external IDs are ambiguous.
+func ValidateTrustPolicyExternalID(
+	ctx context.Context,
+	entered, installerRoleARN, supportRoleARN, region string,
+) error {
+	if entered != "" {
+		if err := ststrust.ValidateSTSExternalIDFormat(entered); err != nil {
+			return err
+		}
+		if installerRoleARN == "" || supportRoleARN == "" {
+			return fmt.Errorf(
+				"installer and support role ARNs are required in sts when trust_policy_external_id is set",
+			)
+		}
+		return TrustPolicyValidator(ctx, entered, installerRoleARN, supportRoleARN, region)
+	}
+	if installerRoleARN == "" || supportRoleARN == "" {
+		return nil
+	}
+	return TrustPolicyValidator(ctx, "", installerRoleARN, supportRoleARN, region)
+}
+
+// validateTrustPolicyExternalIDWithAWS loads installer and support trust policies from IAM and validates
+// the entered value.
+func validateTrustPolicyExternalIDWithAWS(
+	ctx context.Context,
+	entered, installerRoleARN, supportRoleARN, region string,
+) error {
+	if os.Getenv("IS_TEST") == "true" {
+		return nil
+	}
+	loader, err := newTrustPolicyLoader(ctx, region)
+	if err != nil {
+		return fmt.Errorf("failed to load AWS configuration for trust policy validation: %w", err)
+	}
+	installerPolicy, err := loader.trustPolicyJSONForRoleARN(ctx, installerRoleARN)
+	if err != nil {
+		return fmt.Errorf("failed to read installer role trust policy: %w", err)
+	}
+	supportPolicy, err := loader.trustPolicyJSONForRoleARN(ctx, supportRoleARN)
+	if err != nil {
+		return fmt.Errorf("failed to read support role trust policy: %w", err)
+	}
+	if entered != "" {
+		return ststrust.ValidateEnteredForRoleTrustPolicies(entered, installerPolicy, supportPolicy)
+	}
+	return validateRequiredTrustPolicyExternalIDUnset(installerPolicy, supportPolicy)
+}
+
+// validateRequiredTrustPolicyExternalIDUnset enforces explicit config when IAM requires an external ID
+// or when discovery is ambiguous.
+func validateRequiredTrustPolicyExternalIDUnset(installerPolicy, supportPolicy string) error {
+	discovered, err := ststrust.DiscoverSTSExternalID(installerPolicy, supportPolicy)
+	if err != nil {
+		return err
+	}
+	if discovered != "" {
+		return &trustPolicyExternalIDRequiredError{Discovered: discovered}
+	}
+
+	installerIDs, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(installerPolicy)
+	if err != nil {
+		return err
+	}
+	supportIDs, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(supportPolicy)
+	if err != nil {
+		return err
+	}
+	if len(installerIDs) == 0 && len(supportIDs) == 0 {
+		return nil
+	}
+	if hasMismatchedSTSExternalIDTrustPolicies(installerIDs, supportIDs) {
+		return errMismatchedSTSExternalIDTrustPolicies
+	}
+	if isSTSExternalIDDiscoveryAmbiguous(discovered, installerIDs, supportIDs) {
+		return errAmbiguousSTSExternalIDTrustPolicies
+	}
+	return nil
+}
+
+// hasMismatchedSTSExternalIDTrustPolicies reports when installer and support define external IDs with no overlap.
+func hasMismatchedSTSExternalIDTrustPolicies(installerIDs, supportIDs []string) bool {
+	if len(installerIDs) == 0 || len(supportIDs) == 0 {
+		return false
+	}
+	lookup := make(map[string]struct{}, len(installerIDs))
+	for _, id := range installerIDs {
+		lookup[id] = struct{}{}
+	}
+	for _, id := range supportIDs {
+		if _, ok := lookup[id]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+// isSTSExternalIDDiscoveryAmbiguous reports whether trust policies contain external IDs that cannot be
+// resolved to one value, using precomputed discovery and ID lists.
+func isSTSExternalIDDiscoveryAmbiguous(discovered string, installerIDs, supportIDs []string) bool {
+	if len(installerIDs) == 0 && len(supportIDs) == 0 {
+		return false
+	}
+	return discovered == ""
+}
+
+// iamRoleGetter abstracts the IAM GetRole API so tests can inject a stub.
+type iamRoleGetter interface {
+	GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+}
+
+// iamTrustPolicyLoader reads IAM role trust policies.
+type iamTrustPolicyLoader struct {
+	client iamRoleGetter
+}
+
+// newTrustPolicyLoader constructs an iamTrustPolicyLoader. Tests may replace this to inject a stub.
+var newTrustPolicyLoader = newIAMTrustPolicyLoader
+
+// newIAMTrustPolicyLoader constructs an IAM trust policy loader for the given AWS region.
+func newIAMTrustPolicyLoader(ctx context.Context, region string) (*iamTrustPolicyLoader, error) {
+	opts := []func(*awsconfig.LoadOptions) error{}
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &iamTrustPolicyLoader{client: iam.NewFromConfig(cfg)}, nil
+}
+
+// trustPolicyJSONForRoleARN returns the decoded assume-role policy document for the given role ARN.
+func (l *iamTrustPolicyLoader) trustPolicyJSONForRoleARN(ctx context.Context, roleARN string) (string, error) {
+	if roleARN == "" {
+		return "", nil
+	}
+	roleName, err := roleNameFromARN(roleARN)
+	if err != nil {
+		return "", err
+	}
+	output, err := l.client.GetRole(ctx, &iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return "", err
+	}
+	if output.Role == nil {
+		return "", fmt.Errorf("GetRole returned no role for %q", roleName)
+	}
+	return trustPolicyJSONFromRole(*output.Role)
+}
+
+// roleNameFromARN extracts the IAM role name from a role ARN for use with GetRole.
+// IAM role names are unique per account; GetRole expects the name without the path prefix.
+func roleNameFromARN(roleARN string) (string, error) {
+	parsed, err := awsarn.Parse(roleARN)
+	if err != nil {
+		return "", fmt.Errorf("invalid role ARN %q: %w", roleARN, err)
+	}
+	const rolePrefix = "role/"
+	if !strings.HasPrefix(parsed.Resource, rolePrefix) {
+		return "", fmt.Errorf("invalid role ARN %q: expected IAM role resource", roleARN)
+	}
+	roleResource := parsed.Resource[len(rolePrefix):]
+	if roleResource == "" {
+		return "", fmt.Errorf("invalid role ARN %q: missing role name", roleARN)
+	}
+	if idx := strings.LastIndex(roleResource, "/"); idx >= 0 {
+		roleResource = roleResource[idx+1:]
+	}
+	if roleResource == "" {
+		return "", fmt.Errorf("invalid role ARN %q: missing role name", roleARN)
+	}
+	return roleResource, nil
+}
+
+// trustPolicyJSONFromRole decodes the assume-role policy document attached to an IAM role.
+func trustPolicyJSONFromRole(role iamtypes.Role) (string, error) {
+	if role.AssumeRolePolicyDocument == nil {
+		return "", fmt.Errorf("role %q has no assume role policy document", aws.ToString(role.RoleName))
+	}
+	decoded, err := url.PathUnescape(aws.ToString(role.AssumeRolePolicyDocument))
+	if err != nil {
+		return "", fmt.Errorf("failed to decode trust policy for role %q: %w", aws.ToString(role.RoleName), err)
+	}
+	return decoded, nil
+}

--- a/provider/clusterrosa/sts/trust_policy_test.go
+++ b/provider/clusterrosa/sts/trust_policy_test.go
@@ -1,0 +1,492 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package sts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-online/ocm-common/pkg/aws/ststrust"
+)
+
+// stubIAMClient implements iamRoleGetter for deterministic offline tests.
+type stubIAMClient struct {
+	roles map[string]*iam.GetRoleOutput
+	err   error
+}
+
+func (s *stubIAMClient) GetRole(_ context.Context, input *iam.GetRoleInput, _ ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if out, ok := s.roles[aws.ToString(input.RoleName)]; ok {
+		return out, nil
+	}
+	return nil, fmt.Errorf("NoSuchEntity: role %q not found", aws.ToString(input.RoleName))
+}
+
+func stubLoader(client iamRoleGetter) func(context.Context, string) (*iamTrustPolicyLoader, error) {
+	return func(context.Context, string) (*iamTrustPolicyLoader, error) {
+		return &iamTrustPolicyLoader{client: client}, nil
+	}
+}
+
+func stubLoaderError(err error) func(context.Context, string) (*iamTrustPolicyLoader, error) {
+	return func(context.Context, string) (*iamTrustPolicyLoader, error) {
+		return nil, err
+	}
+}
+
+func roleOutput(name, policyDoc string) *iam.GetRoleOutput {
+	return &iam.GetRoleOutput{
+		Role: &iamtypes.Role{
+			RoleName:                 aws.String(name),
+			AssumeRolePolicyDocument: aws.String(policyDoc),
+		},
+	}
+}
+
+var _ = Describe("ValidateTrustPolicyExternalID", func() {
+	const (
+		installerARN = "arn:aws:iam::123456789012:role/my-installer"
+		supportARN   = "arn:aws:iam::123456789012:role/my-support"
+		externalID   = "valid-external-id-123"
+	)
+
+	AfterEach(func() {
+		TrustPolicyValidator = validateTrustPolicyExternalIDWithAWS
+	})
+
+	It("returns nil when external ID is empty and roles do not require one", func() {
+		TrustPolicyValidator = func(
+			_ context.Context, entered, _, _, _ string,
+		) error {
+			Expect(entered).To(BeEmpty())
+			return validateRequiredTrustPolicyExternalIDUnset(
+				policyWithoutExternalID(),
+				policyWithoutExternalID(),
+			)
+		}
+
+		err := ValidateTrustPolicyExternalID(context.Background(), "", installerARN, supportARN, "us-east-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns nil when external ID is empty and role ARNs are missing", func() {
+		err := ValidateTrustPolicyExternalID(context.Background(), "", "", supportARN, "us-east-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("requires installer and support role ARNs when external ID is set", func() {
+		err := ValidateTrustPolicyExternalID(context.Background(), externalID, "", supportARN, "us-east-1")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("installer and support role ARNs are required"))
+	})
+
+	It("validates format before calling TrustPolicyValidator", func() {
+		TrustPolicyValidator = func(context.Context, string, string, string, string) error {
+			Fail("TrustPolicyValidator should not be called for invalid format")
+			return nil
+		}
+
+		err := ValidateTrustPolicyExternalID(context.Background(), "x", installerARN, supportARN, "us-east-1")
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ststrust.ErrExternalIDFormat)).To(BeTrue())
+	})
+
+	It("delegates membership validation to TrustPolicyValidator", func() {
+		TrustPolicyValidator = func(
+			_ context.Context, entered, _, _, _ string,
+		) error {
+			Expect(entered).To(Equal(externalID))
+			return ststrust.ValidateEnteredForRoleTrustPolicies(
+				entered,
+				policyWithExternalID(externalID),
+				policyWithExternalID(externalID),
+			)
+		}
+
+		err := ValidateTrustPolicyExternalID(context.Background(), externalID, installerARN, supportARN, "us-east-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns membership errors from TrustPolicyValidator", func() {
+		TrustPolicyValidator = func(
+			_ context.Context, entered, _, _, _ string,
+		) error {
+			return ststrust.ValidateEnteredForRoleTrustPolicies(
+				entered,
+				policyWithExternalID("other-id"),
+				policyWithExternalID(externalID),
+			)
+		}
+
+		err := ValidateTrustPolicyExternalID(context.Background(), externalID, installerARN, supportARN, "us-east-1")
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ststrust.ErrExternalIDNotInTrustPolicy)).To(BeTrue())
+	})
+})
+
+var _ = Describe("validateRequiredTrustPolicyExternalIDUnset", func() {
+	const externalID = "discovered-external-id"
+
+	It("returns nil when neither role defines an external ID", func() {
+		err := validateRequiredTrustPolicyExternalIDUnset(
+			policyWithoutExternalID(),
+			policyWithoutExternalID(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("requires explicit trust_policy_external_id when a single ID is discoverable", func() {
+		err := validateRequiredTrustPolicyExternalIDUnset(
+			policyWithExternalID(externalID),
+			policyWithExternalID(externalID),
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("set sts.trust_policy_external_id = \"discovered-external-id\""))
+	})
+
+	It("fails when installer and support define external IDs with no value in common", func() {
+		err := validateRequiredTrustPolicyExternalIDUnset(
+			policyWithExternalID("installer-id"),
+			policyWithExternalID("support-id"),
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, errMismatchedSTSExternalIDTrustPolicies)).To(BeTrue())
+	})
+
+	It("fails when multiple external IDs are ambiguous", func() {
+		err := validateRequiredTrustPolicyExternalIDUnset(
+			policyWithExternalIDs("id-a", "id-b"),
+			policyWithoutExternalID(),
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, errAmbiguousSTSExternalIDTrustPolicies)).To(BeTrue())
+	})
+})
+
+var _ = Describe("hasMismatchedSTSExternalIDTrustPolicies", func() {
+	It("returns false when installer IDs are empty", func() {
+		Expect(hasMismatchedSTSExternalIDTrustPolicies(nil, []string{"a"})).To(BeFalse())
+	})
+
+	It("returns false when support IDs are empty", func() {
+		Expect(hasMismatchedSTSExternalIDTrustPolicies([]string{"a"}, nil)).To(BeFalse())
+	})
+
+	It("returns false when there is overlap", func() {
+		Expect(hasMismatchedSTSExternalIDTrustPolicies([]string{"a", "b"}, []string{"b", "c"})).To(BeFalse())
+	})
+
+	It("returns true when there is no overlap", func() {
+		Expect(hasMismatchedSTSExternalIDTrustPolicies([]string{"a"}, []string{"b"})).To(BeTrue())
+	})
+})
+
+var _ = Describe("isSTSExternalIDDiscoveryAmbiguous", func() {
+	It("returns false when both ID lists are empty", func() {
+		Expect(isSTSExternalIDDiscoveryAmbiguous("", nil, nil)).To(BeFalse())
+	})
+
+	It("returns false when discovered is non-empty", func() {
+		Expect(isSTSExternalIDDiscoveryAmbiguous("found", []string{"a"}, nil)).To(BeFalse())
+	})
+
+	It("returns true when discovered is empty but IDs exist", func() {
+		Expect(isSTSExternalIDDiscoveryAmbiguous("", []string{"a", "b"}, nil)).To(BeTrue())
+	})
+})
+
+var _ = Describe("roleNameFromARN", func() {
+	It("extracts role name without path prefix", func() {
+		name, err := roleNameFromARN("arn:aws:iam::123456789012:role/path/my-role")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("my-role"))
+	})
+
+	It("extracts role name from advanced path ARN used in e2e profiles", func() {
+		name, err := roleNameFromARN(
+			"arn:aws:iam::123456789012:role/advanced/ci-rhcs-hcp-ad-1h2-pr-HCP-ROSA-Installer-Role",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("ci-rhcs-hcp-ad-1h2-pr-HCP-ROSA-Installer-Role"))
+	})
+
+	It("extracts role name when ARN has no path", func() {
+		name, err := roleNameFromARN("arn:aws:iam::123456789012:role/my-installer")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("my-installer"))
+	})
+
+	It("rejects non-role ARNs", func() {
+		_, err := roleNameFromARN("arn:aws:s3:::my-bucket")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("rejects role ARN with empty role name", func() {
+		_, err := roleNameFromARN("arn:aws:iam::123456789012:role/")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("missing role name"))
+	})
+
+	It("rejects role ARN with empty role name after path", func() {
+		_, err := roleNameFromARN("arn:aws:iam::123456789012:role/path/")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("missing role name"))
+	})
+})
+
+var _ = Describe("trustPolicyJSONFromRole", func() {
+	It("preserves literal plus signs in RFC 3986 percent-encoded policy documents", func() {
+		role := iamtypes.Role{
+			RoleName:                 aws.String("test-role"),
+			AssumeRolePolicyDocument: aws.String(`%7B%22ExternalId%22%3A%22a+b%22%7D`),
+		}
+
+		decoded, err := trustPolicyJSONFromRole(role)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decoded).To(Equal(`{"ExternalId":"a+b"}`))
+	})
+
+	It("returns error when assume role policy document is nil", func() {
+		role := iamtypes.Role{
+			RoleName: aws.String("test-role"),
+		}
+
+		_, err := trustPolicyJSONFromRole(role)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no assume role policy document"))
+	})
+})
+
+var _ = Describe("validateTrustPolicyExternalIDWithAWS", func() {
+	const (
+		installerARN = "arn:aws:iam::123456789012:role/my-installer"
+		supportARN   = "arn:aws:iam::123456789012:role/my-support"
+		externalID   = "valid-external-id-123"
+	)
+
+	savedLoader := newTrustPolicyLoader
+
+	AfterEach(func() {
+		newTrustPolicyLoader = savedLoader
+	})
+
+	It("returns nil when IS_TEST is set", func() {
+		os.Setenv("IS_TEST", "true")
+		defer os.Unsetenv("IS_TEST")
+
+		err := validateTrustPolicyExternalIDWithAWS(
+			context.Background(),
+			externalID,
+			installerARN,
+			supportARN,
+			"us-east-1",
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns error when loader construction fails", func() {
+		os.Unsetenv("IS_TEST")
+		newTrustPolicyLoader = stubLoaderError(fmt.Errorf("no credentials"))
+
+		err := validateTrustPolicyExternalIDWithAWS(
+			context.Background(), externalID, installerARN, supportARN, "us-east-1",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to load AWS configuration"))
+	})
+
+	It("returns error when installer role lookup fails", func() {
+		os.Unsetenv("IS_TEST")
+		newTrustPolicyLoader = stubLoader(&stubIAMClient{
+			err: fmt.Errorf("access denied"),
+		})
+
+		err := validateTrustPolicyExternalIDWithAWS(
+			context.Background(), externalID, installerARN, supportARN, "us-east-1",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to read installer role trust policy"))
+	})
+
+	It("returns error when support role lookup fails", func() {
+		os.Unsetenv("IS_TEST")
+		newTrustPolicyLoader = stubLoader(&stubIAMClient{
+			roles: map[string]*iam.GetRoleOutput{
+				"my-installer": roleOutput("my-installer", policyWithExternalID(externalID)),
+			},
+		})
+
+		err := validateTrustPolicyExternalIDWithAWS(
+			context.Background(), externalID, installerARN, supportARN, "us-east-1",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to read support role trust policy"))
+	})
+
+	It("validates entered external ID against both policies", func() {
+		os.Unsetenv("IS_TEST")
+		newTrustPolicyLoader = stubLoader(&stubIAMClient{
+			roles: map[string]*iam.GetRoleOutput{
+				"my-installer": roleOutput("my-installer", policyWithExternalID(externalID)),
+				"my-support":   roleOutput("my-support", policyWithExternalID(externalID)),
+			},
+		})
+
+		err := validateTrustPolicyExternalIDWithAWS(
+			context.Background(), externalID, installerARN, supportARN, "us-east-1",
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns error when entered external ID is not in trust policies", func() {
+		os.Unsetenv("IS_TEST")
+		newTrustPolicyLoader = stubLoader(&stubIAMClient{
+			roles: map[string]*iam.GetRoleOutput{
+				"my-installer": roleOutput("my-installer", policyWithExternalID("other-id")),
+				"my-support":   roleOutput("my-support", policyWithExternalID("other-id")),
+			},
+		})
+
+		err := validateTrustPolicyExternalIDWithAWS(
+			context.Background(), externalID, installerARN, supportARN, "us-east-1",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ststrust.ErrExternalIDNotInTrustPolicy)).To(BeTrue())
+	})
+
+	It("delegates to validateRequiredTrustPolicyExternalIDUnset when entered is empty", func() {
+		os.Unsetenv("IS_TEST")
+		newTrustPolicyLoader = stubLoader(&stubIAMClient{
+			roles: map[string]*iam.GetRoleOutput{
+				"my-installer": roleOutput("my-installer", policyWithoutExternalID()),
+				"my-support":   roleOutput("my-support", policyWithoutExternalID()),
+			},
+		})
+
+		err := validateTrustPolicyExternalIDWithAWS(
+			context.Background(), "", installerARN, supportARN, "us-east-1",
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("newIAMTrustPolicyLoader", func() {
+	It("constructs a loader with a region", func() {
+		loader, err := newIAMTrustPolicyLoader(context.Background(), "us-east-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loader).NotTo(BeNil())
+		Expect(loader.client).NotTo(BeNil())
+	})
+
+	It("constructs a loader without a region", func() {
+		loader, err := newIAMTrustPolicyLoader(context.Background(), "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loader).NotTo(BeNil())
+	})
+})
+
+var _ = Describe("trustPolicyJSONForRoleARN", func() {
+	It("returns empty string for empty role ARN", func() {
+		loader := &iamTrustPolicyLoader{client: &stubIAMClient{}}
+		result, err := loader.trustPolicyJSONForRoleARN(context.Background(), "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeEmpty())
+	})
+
+	It("returns error for invalid ARN", func() {
+		loader := &iamTrustPolicyLoader{client: &stubIAMClient{}}
+		_, err := loader.trustPolicyJSONForRoleARN(context.Background(), "not-an-arn")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns error when GetRole fails", func() {
+		loader := &iamTrustPolicyLoader{client: &stubIAMClient{
+			err: fmt.Errorf("access denied"),
+		}}
+		_, err := loader.trustPolicyJSONForRoleARN(
+			context.Background(), "arn:aws:iam::123456789012:role/my-role",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("access denied"))
+	})
+
+	It("returns error when GetRole returns nil role", func() {
+		loader := &iamTrustPolicyLoader{client: &stubIAMClient{
+			roles: map[string]*iam.GetRoleOutput{
+				"my-role": {Role: nil},
+			},
+		}}
+		_, err := loader.trustPolicyJSONForRoleARN(
+			context.Background(), "arn:aws:iam::123456789012:role/my-role",
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("GetRole returned no role"))
+	})
+
+	It("decodes and returns the trust policy document", func() {
+		loader := &iamTrustPolicyLoader{client: &stubIAMClient{
+			roles: map[string]*iam.GetRoleOutput{
+				"my-role": roleOutput("my-role", policyWithoutExternalID()),
+			},
+		}}
+		result, err := loader.trustPolicyJSONForRoleARN(
+			context.Background(), "arn:aws:iam::123456789012:role/my-role",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(ContainSubstring("sts:AssumeRole"))
+	})
+})
+
+// policyWithExternalID returns IAM trust policy JSON with a single sts:ExternalId condition.
+func policyWithExternalID(externalID string) string {
+	return `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": "sts:AssumeRole",
+			"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+			"Condition": {"StringEquals": {"sts:ExternalId": "` + externalID + `"}}
+		}]
+	}`
+}
+
+// policyWithExternalIDs returns IAM trust policy JSON with multiple sts:ExternalId condition values.
+func policyWithExternalIDs(externalIDs ...string) string {
+	values := make([]string, len(externalIDs))
+	for i, externalID := range externalIDs {
+		values[i] = `"` + externalID + `"`
+	}
+	return `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": "sts:AssumeRole",
+			"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+			"Condition": {"StringEquals": {"sts:ExternalId": [` + strings.Join(values, ", ") + `]}}
+		}]
+	}`
+}
+
+// policyWithoutExternalID returns IAM trust policy JSON without an sts:ExternalId condition.
+func policyWithoutExternalID() string {
+	return `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": "sts:AssumeRole",
+			"Principal": {"AWS": "arn:aws:iam::123456789012:root"}
+		}]
+	}`
+}

--- a/subsystem/classic/trust_policy_external_id_test.go
+++ b/subsystem/classic/trust_policy_external_id_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package classic
+
+import (
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
+	. "github.com/onsi/gomega"             // nolint
+	. "github.com/onsi/gomega/ghttp"       // nolint
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+
+	"github.com/terraform-redhat/terraform-provider-rhcs/build"
+	. "github.com/terraform-redhat/terraform-provider-rhcs/subsystem/framework"
+)
+
+var _ = Describe("Classic trust policy external ID", func() {
+	const externalID = "rhcs-subsystem-classic-external-id"
+
+	It("creates cluster with trust_policy_external_id and refreshes it from the API", func() {
+		spec, err := cmv1.NewCluster().
+			ID("123").
+			ExternalID("123").
+			Name("my-cluster").
+			AWS(cmv1.NewAWS().
+				AccountID("123456789012").
+				BillingAccountID("123456789012").
+				SubnetIDs("id1", "id2", "id3").
+				STS(cmv1.NewSTS().
+					RoleARN("arn:aws:iam::123456789012:role/installer").
+					SupportRoleARN("arn:aws:iam::123456789012:role/support").
+					OperatorRolePrefix("test").
+					ExternalID(externalID).
+					InstanceIAMRoles(cmv1.NewInstanceIAMRoles().
+						MasterRoleARN("arn:aws:iam::123456789012:role/master").
+						WorkerRoleARN("arn:aws:iam::123456789012:role/worker")))).
+			State(cmv1.ClusterStateReady).
+			Region(cmv1.NewCloudRegion().ID("us-west-1")).
+			MultiAZ(true).
+			Properties(map[string]string{
+				"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+				"rosa_tf_version":  build.Version,
+				"rosa_tf_commit":   build.Commit,
+			}).
+			Nodes(cmv1.NewClusterNodes().
+				Compute(3).
+				AvailabilityZones("us-west-1a").
+				ComputeMachineType(cmv1.NewMachineType().ID("r5.xlarge"))).
+			Network(cmv1.NewNetwork().
+				MachineCIDR("10.0.0.0/16").
+				ServiceCIDR("172.30.0.0/16").
+				PodCIDR("10.128.0.0/14").
+				HostPrefix(23)).
+			Version(cmv1.NewVersion().ChannelGroup("stable").
+				Enabled(true).
+				ROSAEnabled(true).
+				ID("openshift-v4.10.0").
+				RawID("4.10.0")).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		b := new(strings.Builder)
+		Expect(cmv1.MarshalCluster(spec, b)).To(Succeed())
+		template := b.String()
+
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, versionListPage1),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				VerifyJQ(`.aws.sts.external_id`, externalID),
+				RespondWithPatchedJSON(http.StatusCreated, template, `[
+				{
+				  "op": "add",
+				  "path": "/aws",
+				  "value": {
+				    "sts": {
+				      "role_arn": "arn:aws:iam::123456789012:role/installer",
+				      "support_role_arn": "arn:aws:iam::123456789012:role/support",
+				      "operator_role_prefix": "test",
+				      "external_id": "`+externalID+`",
+				      "instance_iam_roles": {
+				        "master_role_arn": "arn:aws:iam::123456789012:role/master",
+				        "worker_role_arn": "arn:aws:iam::123456789012:role/worker"
+				      }
+				    }
+				  }
+				}]`),
+			),
+		)
+
+		Terraform.Source(`
+			resource "rhcs_cluster_rosa_classic" "my_cluster" {
+			  name           = "my-cluster"
+			  cloud_region   = "us-west-1"
+			  aws_account_id = "123456789012"
+			  sts = {
+			    operator_role_prefix     = "test"
+			    role_arn                 = "arn:aws:iam::123456789012:role/installer"
+			    support_role_arn         = "arn:aws:iam::123456789012:role/support"
+			    trust_policy_external_id = "` + externalID + `"
+			    instance_iam_roles = {
+			      master_role_arn = "arn:aws:iam::123456789012:role/master"
+			      worker_role_arn = "arn:aws:iam::123456789012:role/worker"
+			    }
+			  }
+			  aws_subnet_ids = ["id1", "id2", "id3"]
+			  availability_zones = ["us-west-1a"]
+			  version = "4.10.0"
+			  wait_for_create_complete = false
+			}
+		`)
+
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster").(map[string]interface{})
+		attributes := resource["attributes"].(map[string]interface{})
+		stsBlock := attributes["sts"].(map[string]interface{})
+		Expect(stsBlock["trust_policy_external_id"]).To(Equal(externalID))
+	})
+})

--- a/subsystem/hcp/trust_policy_external_id_test.go
+++ b/subsystem/hcp/trust_policy_external_id_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hcp
+
+import (
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
+	. "github.com/onsi/gomega"             // nolint
+	. "github.com/onsi/gomega/ghttp"       // nolint
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+
+	"github.com/terraform-redhat/terraform-provider-rhcs/build"
+	. "github.com/terraform-redhat/terraform-provider-rhcs/subsystem/framework"
+)
+
+const versionListPage4140 = `{
+	"kind": "VersionList",
+	"page": 1,
+	"size": 1,
+	"total": 1,
+	"items": [{
+		"kind": "Version",
+		"id": "openshift-v4.14.0",
+		"href": "/api/clusters_mgmt/v1/versions/openshift-v4.14.0",
+		"raw_id": "4.14.0",
+		"available_channels": ["stable-4.14"]
+	}]
+}`
+
+var _ = Describe("HCP trust policy external ID", func() {
+	const externalID = "rhcs-subsystem-external-id"
+
+	It("creates cluster with trust_policy_external_id and refreshes it from the API", func() {
+		spec, err := cmv1.NewCluster().
+			ID("123").
+			ExternalID("123").
+			Name("my-cluster").
+			AWS(cmv1.NewAWS().
+				AccountID("123456789012").
+				BillingAccountID("123456789012").
+				SubnetIDs("id1", "id2", "id3").
+				STS(cmv1.NewSTS().
+					RoleARN("arn:aws:iam::123456789012:role/installer").
+					SupportRoleARN("arn:aws:iam::123456789012:role/support").
+					OperatorRolePrefix("test").
+					ExternalID(externalID).
+					InstanceIAMRoles(cmv1.NewInstanceIAMRoles().
+						WorkerRoleARN("arn:aws:iam::123456789012:role/worker")))).
+			State(cmv1.ClusterStateReady).
+			Region(cmv1.NewCloudRegion().ID("us-west-1")).
+			MultiAZ(true).
+			Hypershift(cmv1.NewHypershift().Enabled(true)).
+			Properties(map[string]string{
+				"rosa_creator_arn": "arn:aws:iam::123456789012:user/dummy",
+				"rosa_tf_version":  build.Version,
+				"rosa_tf_commit":   build.Commit,
+			}).
+			Nodes(cmv1.NewClusterNodes().
+				Compute(3).
+				AvailabilityZones("us-west-1a", "us-west-1b", "us-west-1c").
+				ComputeMachineType(cmv1.NewMachineType().ID("r5.xlarge"))).
+			Network(cmv1.NewNetwork().
+				MachineCIDR("10.0.0.0/16").
+				ServiceCIDR("172.30.0.0/16").
+				PodCIDR("10.128.0.0/14").
+				HostPrefix(23)).
+			Version(cmv1.NewVersion().ChannelGroup("stable").
+				Enabled(true).
+				ROSAEnabled(true).
+				HostedControlPlaneEnabled(true).
+				ID("openshift-v4.14.0").
+				RawID("4.14.0")).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		b := new(strings.Builder)
+		Expect(cmv1.MarshalCluster(spec, b)).To(Succeed())
+		template := b.String()
+
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, versionListPage4140),
+			),
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				VerifyJQ(`.aws.sts.external_id`, externalID),
+				RespondWithPatchedJSON(http.StatusCreated, template, `[
+				{
+				  "op": "add",
+				  "path": "/aws",
+				  "value": {
+				    "sts": {
+				      "role_arn": "arn:aws:iam::123456789012:role/installer",
+				      "support_role_arn": "arn:aws:iam::123456789012:role/support",
+				      "operator_role_prefix": "test",
+				      "external_id": "`+externalID+`",
+				      "instance_iam_roles": {
+				        "worker_role_arn": "arn:aws:iam::123456789012:role/worker"
+				      }
+				    }
+				  }
+				}]`),
+			),
+		)
+
+		Terraform.Source(`
+			resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+			  name           = "my-cluster"
+			  cloud_region   = "us-west-1"
+			  aws_account_id = "123456789012"
+			  aws_billing_account_id = "123456789012"
+			  sts = {
+			    operator_role_prefix     = "test"
+			    role_arn                 = "arn:aws:iam::123456789012:role/installer"
+			    support_role_arn         = "arn:aws:iam::123456789012:role/support"
+			    trust_policy_external_id = "` + externalID + `"
+			    instance_iam_roles = {
+			      worker_role_arn = "arn:aws:iam::123456789012:role/worker"
+			    }
+			  }
+			  aws_subnet_ids = ["id1", "id2", "id3"]
+			  availability_zones = ["us-west-1a", "us-west-1b", "us-west-1c"]
+			  version = "4.14.0"
+			  wait_for_create_complete = false
+			}
+		`)
+
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster").(map[string]interface{})
+		attributes := resource["attributes"].(map[string]interface{})
+		stsBlock := attributes["sts"].(map[string]interface{})
+		Expect(stsBlock["trust_policy_external_id"]).To(Equal(externalID))
+	})
+})

--- a/templates/guides/trust-policy-external-id.md.tmpl
+++ b/templates/guides/trust-policy-external-id.md.tmpl
@@ -64,8 +64,53 @@ resource "rhcs_cluster_rosa_classic" "example" {
 - **Required**: No (Optional)
 - **Description**: External ID for trust policy condition in account roles
 
+## Create-time validation
+
+On cluster create, the provider reads installer and support role trust policies from AWS and validates `sts.trust_policy_external_id`:
+
+- When set, the value must appear in both role trust policies.
+- When omitted, create fails if the roles define an external ID that must be declared explicitly. The error includes the discovered value when unambiguous, for example: `set sts.trust_policy_external_id = "your-external-id"`.
+- When omitted and the roles define conflicting external IDs, create fails with an error asking you to set the attribute explicitly.
+- When omitted and the roles define ambiguous external IDs, create fails with an error asking you to set the attribute explicitly.
+
+Use the same value on the account IAM module and the cluster resource so Terraform configuration, IAM, and OCM stay aligned.
+
 ## Useful Resources
 
 - [ROSA Classic Cluster Resource](../resources/cluster_rosa_classic.md)
 - [ROSA HCP Cluster Resource](../resources/cluster_rosa_hcp.md)
 - [AWS IAM External ID Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)
+
+## Account roles modules
+
+When creating account roles with Terraform modules, pass the same value to `trust_policy_external_id` on the account IAM module and to `sts.trust_policy_external_id` on the cluster resource. Use the module for your cluster type:
+
+- ROSA Classic: `terraform-redhat/rosa-classic/rhcs//modules/account-iam-resources`
+- ROSA HCP: `terraform-redhat/rosa-hcp/rhcs//modules/account-iam-resources`
+
+Example for ROSA HCP:
+
+```terraform
+module "create_account_roles" {
+  source  = "terraform-redhat/rosa-hcp/rhcs//modules/account-iam-resources"
+  version = ">=1.6.3"
+
+  account_role_prefix      = var.account_role_prefix
+  trust_policy_external_id = var.trust_policy_external_id
+}
+
+resource "rhcs_cluster_rosa_hcp" "example" {
+  # ...
+  sts = {
+    role_arn                  = module.create_account_roles.account_role_arns.installer
+    support_role_arn          = module.create_account_roles.account_role_arns.support
+    operator_role_prefix      = module.create_account_roles.account_role_prefix
+    trust_policy_external_id  = var.trust_policy_external_id
+    instance_iam_roles = {
+      worker_role_arn = module.create_account_roles.account_role_arns.worker
+    }
+  }
+}
+```
+
+For ROSA Classic, use `rhcs_cluster_rosa_classic` and the `terraform-redhat/rosa-classic/rhcs//modules/account-iam-resources` module with the same `trust_policy_external_id` wiring.

--- a/tests/tf-manifests/aws/account-roles/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-classic/main.tf
@@ -31,11 +31,12 @@ locals {
 module "create_account_roles" {
   source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-classic//modules/account-iam-resources?ref=main"
 
-  account_role_prefix  = var.account_role_prefix
-  openshift_version    = var.openshift_version
-  path                 = local.path
-  permissions_boundary = var.permissions_boundary
-  tags                 = var.tags
+  account_role_prefix      = var.account_role_prefix
+  openshift_version        = var.openshift_version
+  path                     = local.path
+  permissions_boundary     = var.permissions_boundary
+  tags                     = var.tags
+  trust_policy_external_id = var.trust_policy_external_id
 }
 
 module "rosa-classic_operator-policies" {

--- a/tests/tf-manifests/aws/account-roles/rosa-classic/output.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-classic/output.tf
@@ -12,3 +12,11 @@ output "installer_role_arn" {
 output "aws_account_id" {
   value = local.aws_account_id
 }
+
+output "account_roles_arn" {
+  value = module.create_account_roles.account_roles_arn
+}
+
+output "trust_policy_external_id" {
+  value = module.create_account_roles.trust_policy_external_id
+}

--- a/tests/tf-manifests/aws/account-roles/rosa-classic/variables.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-classic/variables.tf
@@ -34,3 +34,9 @@ variable "tags" {
   type        = map(string)
   default     = null
 }
+
+variable "trust_policy_external_id" {
+  description = "Optional external ID injected into installer and support account role trust policies."
+  type        = string
+  default     = null
+}

--- a/tests/tf-manifests/aws/account-roles/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-hcp/main.tf
@@ -31,8 +31,9 @@ locals {
 module "create_account_roles" {
   source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp//modules/account-iam-resources?ref=main"
 
-  account_role_prefix  = var.account_role_prefix
-  path                 = local.path
-  permissions_boundary = var.permissions_boundary
-  tags                 = var.tags
+  account_role_prefix      = var.account_role_prefix
+  path                     = local.path
+  permissions_boundary     = var.permissions_boundary
+  tags                     = var.tags
+  trust_policy_external_id = var.trust_policy_external_id
 }

--- a/tests/tf-manifests/aws/account-roles/rosa-hcp/output.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-hcp/output.tf
@@ -12,3 +12,11 @@ output "installer_role_arn" {
 output "aws_account_id" {
   value = local.aws_account_id
 }
+
+output "account_roles_arn" {
+  value = module.create_account_roles.account_roles_arn
+}
+
+output "trust_policy_external_id" {
+  value = module.create_account_roles.trust_policy_external_id
+}

--- a/tests/tf-manifests/aws/account-roles/rosa-hcp/variables.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-hcp/variables.tf
@@ -34,3 +34,9 @@ variable "tags" {
   type        = map(string)
   default     = null
 }
+
+variable "trust_policy_external_id" {
+  description = "Optional external ID injected into installer and support account role trust policies."
+  type        = string
+  default     = null
+}

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -42,8 +42,9 @@ locals {
       master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-ControlPlane-Role",
       worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Worker-Role"
     },
-    operator_role_prefix = var.operator_role_prefix
-    oidc_config_id       = var.oidc_config_id
+    operator_role_prefix     = var.operator_role_prefix
+    oidc_config_id           = var.oidc_config_id
+    trust_policy_external_id = var.sts_trust_policy_external_id
   }
 }
 

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -243,3 +243,9 @@ variable "full_resources" {
   type    = bool
   default = false
 }
+
+variable "sts_trust_policy_external_id" {
+  description = "Optional external ID for installer and support account role trust policies."
+  type        = string
+  default     = null
+}

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
@@ -44,8 +44,9 @@ locals {
     instance_iam_roles = {
       worker_role_arn = var.worker_role != null ? var.worker_role : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.account_role_path}${var.account_role_prefix}-HCP-ROSA-Worker-Role"
     }
-    operator_role_prefix = var.operator_role_prefix
-    oidc_config_id       = var.oidc_config_id
+    operator_role_prefix     = var.operator_role_prefix
+    oidc_config_id           = var.oidc_config_id
+    trust_policy_external_id = var.sts_trust_policy_external_id
   }
 }
 

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/variables.tf
@@ -272,3 +272,9 @@ variable "max_replicas" {
   type    = number
   default = null
 }
+
+variable "sts_trust_policy_external_id" {
+  description = "Optional external ID for installer and support account role trust policies."
+  type        = string
+  default     = null
+}

--- a/tests/utils/exec/account-roles.go
+++ b/tests/utils/exec/account-roles.go
@@ -9,12 +9,13 @@ import (
 )
 
 type AccountRolesArgs struct {
-	AccountRolePrefix   *string            `hcl:"account_role_prefix"`
-	OpenshiftVersion    *string            `hcl:"openshift_version"`
-	UnifiedAccRolesPath *string            `hcl:"path"`
-	SharedVpcRoleArn    *string            `hcl:"shared_vpc_role_arn"`
-	PermissionsBoundary *string            `hcl:"permissions_boundary"`
-	Tags                *map[string]string `hcl:"tags"`
+	AccountRolePrefix     *string            `hcl:"account_role_prefix"`
+	OpenshiftVersion      *string            `hcl:"openshift_version"`
+	UnifiedAccRolesPath   *string            `hcl:"path"`
+	SharedVpcRoleArn      *string            `hcl:"shared_vpc_role_arn"`
+	PermissionsBoundary   *string            `hcl:"permissions_boundary"`
+	Tags                  *map[string]string `hcl:"tags"`
+	TrustPolicyExternalID *string            `hcl:"trust_policy_external_id"`
 }
 
 type AccountRolesOutput struct {


### PR DESCRIPTION
## PR Summary

Adds optional `sts.trust_policy_external_id` to ROSA Classic and HCP cluster resources with create-time IAM validation (aligned with ROSA CLI), OCM read refresh, and test/guide coverage.

## Detailed Description of the Issue

Customers can require an `sts:ExternalId` condition on ROSA installer and support account role trust policies. OCM must receive the same external ID at cluster create time or installation fails at `AssumeRole` even when Terraform apply succeeds.

The RHCS provider previously had no way to declare or validate this value. Account roles are created via separate Terraform modules (`rosa-classic` / `rosa-hcp`), so the provider must validate cluster configuration against live IAM trust policies and send the value to OCM.

## Related Issues and PRs

- Jira: [ROSAENG-57757](https://issues.redhat.com/browse/ROSAENG-57757)
- Related PR(s):
  - [terraform-rhcs-rosa-classic](https://github.com/terraform-redhat/terraform-rhcs-rosa-classic/pull/149): account-iam-resources `trust_policy_external_id` support
  - [terraform-rhcs-rosa-hcp](https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp/pull/160): support role external ID fix in account-iam-resources

## Type of Change

- [x] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- No `sts.trust_policy_external_id` attribute on `rhcs_cluster_rosa_classic` or `rhcs_cluster_rosa_hcp`.
- No create-time validation against installer/support IAM trust policies.
- Test manifests did not wire external ID through account-roles or cluster modules.
- `examples/create_account_roles` uses deprecated `terraform-redhat/rosa-sts/aws` (unchanged; that module does not support external ID).

## Behavior After This Change

### Schema and lifecycle

- Optional `sts.trust_policy_external_id` on Classic and HCP cluster resources and data sources.
- **Plan:** format validation (2–1224 characters, OCM charset) when the attribute is set.
- **Create:** reads installer and support role trust policies via `iam:GetRole` when an `sts` block is present.
- **Read:** refreshes state from OCM `sts.external_id`.
- **Update:** attribute is immutable.

### Create-time validation (`provider/clusterrosa/sts/trust_policy.go`)

Uses `ocm-common/pkg/aws/ststrust` (bumped to v0.0.42):

| Scenario | Result |
|----------|--------|
| Attribute omitted; IAM has no external ID | Create proceeds |
| Attribute omitted; single discoverable external ID in IAM | **Create fails** with actionable message: `set sts.trust_policy_external_id = "<id>"` |
| Attribute omitted; installer/support IDs conflict | Create fails |
| Attribute omitted; ambiguous external IDs in IAM | Create fails |
| Attribute set; value not in IAM policies | Create fails |
| Attribute set; value wrong for installer or support | Create fails |
| Attribute set; value matches both roles | Create proceeds; value sent to OCM |

### Intentional difference from ROSA CLI

When `--external-id` is unset and IAM defines a **single** unambiguous external ID, ROSA CLI auto-discovers and sends it to OCM. Terraform **fails** and requires explicit HCL configuration to avoid config/state drift in IaC workflows.

### Tests and docs

- Unit tests: `provider/clusterrosa/sts/trust_policy_test.go`
- Subsystem tests: `subsystem/classic/trust_policy_external_id_test.go`, `subsystem/hcp/trust_policy_external_id_test.go`
- E2E: `tests/e2e/trust_policy_external_id_test.go`
- Test manifests updated for `rosa-classic` / `rosa-hcp` account-roles and cluster modules
- Guide: `docs/guides/trust-policy-external-id.md`

## How to Test (Step-by-Step)

### Preconditions

- Local RHCS provider built/installed (`make install`)
- OCM token and AWS credentials with `iam:GetRole` on installer/support roles
- Account roles created with `trust_policy_external_id` via `rosa-classic` or `rosa-hcp` `account-iam-resources` module

### Test Steps

1. Run unit tests:
   ```bash
   go test ./provider/clusterrosa/sts/... -count=1
   ```
2. Run subsystem tests (requires local provider registry from `make install`):
   ```bash
   make test-subsystem-classic SUBSYSTEM_FOCUS="trust policy external ID"
   make test-subsystem-hcp SUBSYSTEM_FOCUS="trust policy external ID"
   ```
3. **Happy path:** set the same `trust_policy_external_id` on account-roles module and cluster `sts` block; apply should succeed.
4. **Fail-fast:** create account roles with external ID but omit `sts.trust_policy_external_id` on cluster; apply should fail before OCM create with discovered value in the error.
5. **Mismatch:** set wrong external ID on cluster; apply should fail with membership error.

### Expected Results

- Unit and subsystem tests pass.
- Create fails early with clear diagnostics for misconfiguration.
- Successful create sends external ID to OCM; read populates state.

## Proof of the Fix

- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: attach `go test` and sample `terraform apply` output for fail-fast and happy-path cases
- Other artifacts: N/A

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan

N/A — new optional attribute. Existing configurations without the attribute behave as before unless IAM roles already require an external ID (create will now fail with guidance instead of succeeding and failing at install time).

## Developer Verification Checklist

- [ ] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [ ] PR description clearly explains both **what** changed and **why**.
- [ ] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make pre-push-checks` passes.
- [ ] `make fmt-check` passes.
- [ ] `make build` passes.
- [ ] Documentation was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added create-time validation for `sts.trust_policy_external_id` during ROSA Classic and HCP cluster creation by checking installer/support trust policies (with region-aware matching and improved error handling).
  * Updated `sts.trust_policy_external_id` schema/behavior for Classic and HCP resources and their datasources to support correct plan/state handling and plan-time format validation.

* **Documentation**
  * Updated the trust-policy external ID guide with new create-time validation details and updated account-roles wiring examples to pass the value consistently.

* **Tests**
  * Expanded STS unit tests and ROSA Classic/HCP end-to-end tests to verify request payloads and state wiring for `sts.trust_policy_external_id`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->