### PR TITLE
ROSAENG-60108 | test: Make test manifests use git version of modules

### DIFF
--- a/tests/tf-manifests/aws/account-roles/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-classic/main.tf
@@ -29,8 +29,7 @@ locals {
 }
 
 module "create_account_roles" {
-  source  = "terraform-redhat/rosa-classic/rhcs//modules/account-iam-resources"
-  version = ">=1.6.3"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-classic//modules/account-iam-resources?ref=main"
 
   account_role_prefix  = var.account_role_prefix
   openshift_version    = var.openshift_version
@@ -40,8 +39,7 @@ module "create_account_roles" {
 }
 
 module "rosa-classic_operator-policies" {
-  source  = "terraform-redhat/rosa-classic/rhcs//modules/operator-policies"
-  version = ">=1.6.3"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-classic//modules/operator-policies?ref=main"
 
   account_role_prefix = module.create_account_roles.account_role_prefix
   openshift_version   = var.openshift_version

--- a/tests/tf-manifests/aws/account-roles/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/account-roles/rosa-hcp/main.tf
@@ -23,15 +23,13 @@ data "aws_caller_identity" "current" {
 data "aws_partition" "current" {
 }
 
-
 locals {
   path           = coalesce(var.path, "/")
   aws_account_id = data.aws_caller_identity.current.account_id
 }
 
 module "create_account_roles" {
-  source  = "terraform-redhat/rosa-hcp/rhcs//modules/account-iam-resources"
-  version = ">=1.6.3"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp//modules/account-iam-resources?ref=main"
 
   account_role_prefix  = var.account_role_prefix
   path                 = local.path

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-classic/main.tf
@@ -30,7 +30,7 @@ locals {
 
 # Create OIDC config and provider in OCM
 module "oidc_config_and_provider" {
-  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-classic//modules/oidc-config-and-provider"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-classic//modules/oidc-config-and-provider?ref=main"
 
   installer_role_arn = local.managed ? null : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Installer-Role"
   managed            = local.managed
@@ -40,7 +40,7 @@ module "oidc_config_and_provider" {
 
 # Create operator roles on AWS
 module "operator_roles" {
-  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-classic//modules/operator-roles"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-classic//modules/operator-roles?ref=main"
 
   account_role_prefix  = var.account_role_prefix
   oidc_endpoint_url    = module.oidc_config_and_provider.oidc_endpoint_url

--- a/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/oidc-provider-operator-roles/rosa-hcp/main.tf
@@ -30,7 +30,7 @@ locals {
 
 # Create OIDC config and provider in OCM
 module "oidc_config_and_provider" {
-  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp//modules/oidc-config-and-provider"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp//modules/oidc-config-and-provider?ref=main"
 
   installer_role_arn = local.managed ? null : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-HCP-ROSA-Installer-Role"
   managed            = local.managed
@@ -40,7 +40,7 @@ module "oidc_config_and_provider" {
 
 # Create operator roles on AWS
 module "operator_roles" {
-  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp//modules/operator-roles"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp//modules/operator-roles?ref=main"
 
   oidc_endpoint_url    = module.oidc_config_and_provider.oidc_endpoint_url
   operator_role_prefix = var.operator_role_prefix

--- a/tests/tf-manifests/aws/shared-vpc-policy-and-hosted-zone/main.tf
+++ b/tests/tf-manifests/aws/shared-vpc-policy-and-hosted-zone/main.tf
@@ -1,14 +1,22 @@
 # Copyright Red Hat
 # SPDX-License-Identifier: Apache-2.0
 
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.20.0"
+    }
+  }
+}
+
 provider "aws" {
   region                   = var.region
   shared_credentials_files = var.shared_vpc_aws_shared_credentials_files
 }
 
 module "shared_vpc_policy_and_hosted_zone" {
-  source  = "terraform-redhat/rosa-classic/rhcs//modules/shared-vpc-policy-and-hosted-zone"
-  version = ">=1.6.3"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-classic//modules/shared-vpc-policy-and-hosted-zone?ref=main"
 
   cluster_name              = var.domain_prefix == null ? var.cluster_name : var.domain_prefix
   hosted_zone_base_domain   = var.dns_domain_id

--- a/tests/tf-manifests/aws/vpc/rosa-classic/main.tf
+++ b/tests/tf-manifests/aws/vpc/rosa-classic/main.tf
@@ -10,16 +10,13 @@ terraform {
   }
 }
 
-
-
 provider "aws" {
   region                   = var.aws_region
   shared_credentials_files = var.aws_shared_credentials_files
 }
 
 module "vpc" {
-  source  = "terraform-redhat/rosa-classic/rhcs//modules/vpc"
-  version = ">=1.6.3"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-classic//modules/vpc?ref=main"
 
   vpc_cidr                 = var.vpc_cidr
   name_prefix              = var.name_prefix

--- a/tests/tf-manifests/aws/vpc/rosa-hcp/main.tf
+++ b/tests/tf-manifests/aws/vpc/rosa-hcp/main.tf
@@ -16,12 +16,11 @@ provider "aws" {
 }
 
 module "vpc" {
-  source  = "terraform-redhat/rosa-hcp/rhcs//modules/vpc"
-  version = ">=1.6.3"
+  source = "git::https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp//modules/vpc?ref=main"
 
   vpc_cidr                 = var.vpc_cidr
   name_prefix              = var.name_prefix
+  availability_zones       = var.availability_zones
+  availability_zones_count = var.availability_zones_count
   tags                     = var.tags
-  availability_zones_count = var.availability_zones != null ? length(var.availability_zones) : var.availability_zones_count # Temp fix before OCM-10932 is implemented
-  # availability_zones = var.availability_zones
 }

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -31,9 +31,7 @@ const (
 	EnvChannelGroup          = "CHANNEL_GROUP"
 	EnvRHCSVersion           = "RHCS_VERSION"
 	EnvRHCSSource            = "RHCS_SOURCE"
-	EnvRHCSModuleVersion     = "RHCS_MODULE_VERSION"      // Set this to update the version for the terraform-redhat/rosa-classic/rhcs module
-	EnvRHCSModuleSource      = "RHCS_MODULE_SOURCE"       // Set this to update the source for the terraform-redhat/rosa-classic/rhcs module
-	EnvRHCSModuleSourceLocal = "RHCS_MODULE_SOURCE_LOCAL" // Set this to any value if `RHCS_MODULE_SOURCE` refers to a local path, in which case `RHCS_MODULE_VERSION` will be ignored
+	EnvRHCSModuleRef         = "RHCS_MODULE_REF" // Set this to update the git ref for the RHCS modules
 	EnvWaitOperators         = "WAIT_OPERATORS"
 	EnvRHCSClusterName       = "RHCS_CLUSTER_NAME"
 	EnvRHCSClusterNamePrefix = "RHCS_CLUSTER_NAME_PREFIX"
@@ -143,16 +141,8 @@ func GetRHCSVersion() string {
 	return GetEnvWithDefault(EnvRHCSVersion, "")
 }
 
-func GetRHCSModuleVersion() string {
-	return GetEnvWithDefault(EnvRHCSModuleVersion, "")
-}
-
-func GetRHCSModuleSource() string {
-	return GetEnvWithDefault(EnvRHCSModuleSource, "")
-}
-
-func GetRHCSModuleSourceLocal() string {
-	return GetEnvWithDefault(EnvRHCSModuleSourceLocal, "")
+func GetRHCSModuleRef() string {
+	return GetEnvWithDefault(EnvRHCSModuleRef, "")
 }
 
 func IsWaitForOperators() bool {

--- a/tests/utils/helper/assert.go
+++ b/tests/utils/helper/assert.go
@@ -22,6 +22,7 @@ import (
 // if e is not "timed out waiting for the condition", it print e and then case fails.
 
 func AssertWaitPollNoErr(e error, msg string) {
+	GinkgoHelper()
 	if e == nil {
 		return
 	}
@@ -42,6 +43,7 @@ func AssertWaitPollNoErr(e error, msg string) {
 // if e is  Nil, will print expected error info and then case fails.
 
 func AssertWaitPollWithErr(e error, msg string) {
+	GinkgoHelper()
 	if e != nil {
 		Logger.Infof("the error: %v", e)
 		return
@@ -52,5 +54,6 @@ func AssertWaitPollWithErr(e error, msg string) {
 }
 
 func ExpectTFErrorContains(err error, substring string) {
+	GinkgoHelper()
 	Expect(GetTFErrorMessage(err)).To(ContainSubstring(substring))
 }

--- a/tests/utils/helper/manifests_handler.go
+++ b/tests/utils/helper/manifests_handler.go
@@ -13,25 +13,13 @@ import (
 	. "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/log"
 )
 
-func ModuleSourceAlignment(manifestsFilePath string, source string, sourceLocal string, version string) error {
-	regexpP := regexp.MustCompile(`(source\s*=\s*")(terraform-redhat/rosa-classic/rhcs/)(.*"\s*\n)(\s*version\s*=\s*")(.*)"`)
+func ModuleSourceAlignment(manifestsFilePath string, ref string) error {
+	regexpP := regexp.MustCompile(
+		`"(git::https:\/\/github\.com\/terraform-redhat\/terraform-rhcs-rosa-(classic|hcp)\/\/modules\/[^?]+\?ref=)[^"]+"`,
+	)
 	var err error
-	if source != "" {
-		// err = ReplaceRegex(manifestsFilePath, *regexpP, fmt.Sprintf(`$1%s$3$4$5"`, source))
-		if sourceLocal != "" {
-			err = ReplaceRegex(manifestsFilePath, *regexpP, fmt.Sprintf(`source = "%s"`, source))
-		} else {
-			err = ReplaceRegex(manifestsFilePath, *regexpP, fmt.Sprintf(`source = "%s$3$4$5`, source))
-		}
-		if err != nil {
-			return err
-		}
-	}
-	if version != "" && sourceLocal == "" {
-		err = ReplaceRegex(manifestsFilePath, *regexpP, fmt.Sprintf(`source = "$2$3  version = "%s"`, version))
-		if err != nil {
-			return err
-		}
+	if ref != "" {
+		err = ReplaceRegex(manifestsFilePath, *regexpP, fmt.Sprintf(`"$1%s"`, ref))
 	}
 	return err
 }
@@ -104,15 +92,13 @@ func AlignRHCSSourceVersion(dir string) error {
 
 	rhcsSource := retrieveRHCSEnvVar("RHCS Source", config.GetRHCSSource)
 	rhcsVersion := retrieveRHCSEnvVar("RHCS Version", config.GetRHCSVersion)
-	rhcsModuleSource := retrieveRHCSEnvVar("RHCS Module Source", config.GetRHCSModuleSource)
-	rhcsModuleSourceLocal := retrieveRHCSEnvVar("RHCS Module Source Local", config.GetRHCSSource)
-	rhcsModuleVersion := retrieveRHCSEnvVar("RHCS Module Version", config.GetRHCSModuleVersion)
+	rhcsModuleRef := retrieveRHCSEnvVar("RHCS Module Ref", config.GetRHCSModuleRef)
 	if !foundEnv {
 		return nil
 	}
 
 	Logger.Warnf("RHCS Source: %s, RHCS Version: %s", rhcsSource, rhcsVersion)
-	Logger.Warnf("Module Source: %s, Module Version: %s", rhcsModuleSource, rhcsModuleVersion)
+	Logger.Warnf("Module ref: %s", rhcsModuleRef)
 	files, err := ScanManifestsDir(dir)
 	if err != nil {
 		return err
@@ -122,7 +108,7 @@ func AlignRHCSSourceVersion(dir string) error {
 		if err != nil {
 			return err
 		}
-		err = ModuleSourceAlignment(file, rhcsModuleSource, rhcsModuleSourceLocal, rhcsModuleVersion)
+		err = ModuleSourceAlignment(file, rhcsModuleRef)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary
Updates the `tests/tf-manifests` manifests to use the git version of the classic and HCP modules instead of the released versions

## Detailed Description of the Issue
When adding new tests that relies on something new being exposed through the modules, you traditionally needed to wait for a whole new release cycle before you could implement those tests. Now once the changes are merged into the modules you can just use it in the test code

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: https://redhat.atlassian.net/browse/ROSAENG-60108
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1.
2.
3.

### Expected Results
<!-- What should happen after running the steps above -->

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make pre-push-checks` passes.
- [x] `make fmt-check` passes.
- [x] `make build` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated Terraform test manifests to use Git-based module sources pinned to a specific branch, removing prior registry-style version constraints for consistent module selection.
  * Standardized test module selection to a single “module ref” configuration value.
  * Added an explicit AWS provider version constraint in the shared VPC/hosted zone manifest.
  * Refreshed ROSA HCP VPC inputs to pass availability zones directly.

* **Tests**
  * Improved test assertion helpers to initialize Ginkgo helpers for more consistent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->