### PR TITLE
ROSAENG-60113 | ci(test): add pre-merge test gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -78,10 +78,14 @@ For details, see: ./CONTRIBUTING.md
 - [ ] PR description clearly explains both **what** changed and **why**.
 - [ ] Relevant Jira/GitHub issues and related PRs are linked.
 - [ ] `make install-hooks` has been run in this clone.
-- [ ] Tests were added/updated where appropriate.
-- [ ] I manually tested the change.
 - [ ] `make pre-push-checks` passes.
-- [ ] `make fmt-check` passes.
-- [ ] `make build` passes.
 - [ ] Documentation was added/updated where appropriate.
 - [ ] Any risk, limitation, or follow-up work is documented.
+
+### Testing (check all that apply; use N/A when not relevant)
+- [ ] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
+- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
+- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
+- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
+- [ ] `make check-subsystem-registry` passes.
+- [ ] I manually tested the change when behavior is user-visible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,18 @@ These are **review and design expectations**. They are not all enforced by autom
 4. Add/update unit tests and subsystem tests for the primary query flow.
 5. Regenerate and validate docs for the new/changed data source.
 
+## Subsystem registry check
+
+`make check-subsystem-registry` (script: `hack/check-subsystem-registry.sh`) verifies that every Terraform type registered in `provider/` is referenced in at least one subsystem test (`resource "rhcs_…"` or `data "rhcs_…"` under `subsystem/`). It runs as part of `make pre-push-checks` and fails the push/CI when the check fails.
+
+**When adding a resource or data source:** add or update a subsystem test that references the type. Do **not** add an allowlist entry for new types.
+
+**When to use `hack/subsystem-registry-allowlist.yaml`:** only for **temporary, documented exceptions** — for example a known gap being fixed in a follow-up PR. Each entry must include `type`, `ticket`, and `reason`. Remove the entry in the same PR that adds subsystem coverage. Allowlist is not a substitute for subsystem tests on new provider types.
+
+**New types on the branch** (compared to the merge base with `main`) without a subsystem reference always fail the check, even if allowlisted elsewhere.
+
+Run locally: `make check-subsystem-registry`.
+
 ## Breaking change policy
 
 Treat any change below as potentially breaking unless proven otherwise:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,8 @@ The hooks are configured in `.pre-commit-config.yaml` and perform:
 
 - `pre-commit`: formats staged Go files with `gci` + `gofmt` plus staged Terraform files under `examples/` and `tests/`, adds Apache 2.0 license headers to staged files missing them, and blocks the commit if files were rewritten so you can review and stage the updates
 - `commit-msg`: validates the commit message format (JIRA-123 | type(scope): message)
-- `pre-push`: runs the same steps as `make pre-push-checks` (format-check, build, generated-files check, lint, docs-lint, license-check, changed-files coverage, and `make test`)
+- `pre-push`: runs the same steps as `make pre-push-checks` (format-check, build, generated-files check, lint, docs-lint, license-check, changed-files coverage, subsystem registry check, and `make test`)
+- `pre-push` runs against committed content and blocks when staged or unstaged tracked changes are present
 - check runs are fail-fast: execution stops at the first failing step
 
 To manually run all hooks on all files:
@@ -77,11 +78,42 @@ pre-commit autoupdate
 If you previously set `core.hooksPath=.githooks` in a local clone, run `make install-hooks` — it will automatically unset that configuration and install the pre-commit hooks in its place. No manual cleanup is needed.
 
 ### 4. Test your changes and use the CI (Pre Merge)
-We are holding three types of tests that must pass for a PR to finally be accepted and merged:
-* `unit-tests` - for testing a small unit of resource or data source functionality [here is an example of cluster_rosa_classic unit-tests](provider/clusterrosa/classic/cluster_rosa_classic_resource_test.go)
-* `subsystem test` - write a test that describing what you will fix and locate it in the [subsystem test directory](subsystem).
-* `end-to-end tests` - those tests simulate a real resources and run in official OpenShift CI platform.
-Both `unit-tests` and `subsystem`, can be run locally before submitting a PR by running `make test`.
+
+The provider uses four automated test layers before merge:
+
+| Layer | Command | What it exercises |
+|-------|---------|-------------------|
+| **Unit** | `make unit-test` | Validators, plan modifiers, mapping, and helpers in `provider/` and `internal/` |
+| **Subsystem** | `make subsystem-test` | Terraform plan/apply against a mock OCM API (`subsystem/`) |
+| **Utils** | `make e2e-unit-test` | Unit tests for e2e harness helpers under `tests/utils/` |
+| **E2e** | `make e2e_test` | Real clusters on OpenShift CI — **not** required for every PR |
+
+Run unit, subsystem, and utils tests locally with:
+
+```shell
+make test
+```
+
+#### Pre-merge requirements
+
+`make pre-push-checks` (also run by the pre-push git hook and GitHub Actions) verifies:
+
+- Formatting, build, generated files, lint, docs-lint, and license headers
+- **`make coverage-changed-files`** — at least 80% of changed lines in `provider/` and `internal/` (non-test `.go` files) must be covered by unit tests, compared to the merge base with `main`
+- **`make check-subsystem-registry`** — every registered resource and data source type must be referenced in `subsystem/` tests, or listed in `hack/subsystem-registry-allowlist.yaml` with a ticket and reason; **new types** added on the branch must include a subsystem test
+- **`make test`** — unit, subsystem, and utils suites pass
+
+See `AGENTS.md` for when to add unit versus subsystem tests.
+
+#### When to add which test
+
+| Change | Required test |
+|--------|----------------|
+| New or changed **resource or data source** | **Subsystem** test under `subsystem/classic/` or `subsystem/hcp/` |
+| New or changed **validation, plan modifiers, or helpers** (Go code) | **Unit** test in the same package (`*_test.go`) |
+| **Schema / ConfigValidators** (plan-time errors) | **Unit** and/or **one** subsystem test expecting plan/apply failure — avoid duplicating the same cases in both layers |
+
+`make unit-test-coverage` is optional for local debugging (`go tool cover -html=coverage.out`); it is **not** a merge gate.
 
 Use these commands before pushing:
 
@@ -90,10 +122,10 @@ make basic-checks      # convenience flow: starts with make fmt and may stop aft
 make pre-push-checks   # exact non-mutating verification used by the pre-push hook
 ```
 
-`make basic-checks` runs format, format-check, build, generated-files verification, lint, docs-lint (Vale), changed-files coverage, and unit/subsystem tests.
+`make basic-checks` runs format, format-check, build, generated-files verification, lint, docs-lint (Vale), changed-files coverage, subsystem registry check, and unit/subsystem/utils tests.
 `make lint` uses the repo's pinned `golangci-lint` v2 configuration.
 `make docs-lint` runs the pinned [Vale](https://docs.vale.sh/) CLI with only the custom inclusive-language rules under `styles/InclusiveLanguage/` (general Vale styles and packages are not used). Building Vale uses `CGO_ENABLED=1` and requires a C compiler toolchain on the first install.
-Changed-files coverage is enforced through `make coverage-changed-files` using `gocovdiff` with an 80% threshold for changed Go files under `provider/` and `internal/`.
+Changed-files coverage is enforced through `make coverage-changed-files` using `gocovdiff` with an 80% threshold for changed Go files under `provider/` and `internal/`, diffed against the merge base with `main`.
 
 ### 5. Manual testing and debugging using the locally compiled RHCS Provider binary
 Manual testing should be performed before opening a PR to ensure there isn't any regression behavior in the provider. You can find [here an example for that](https://github.com/terraform-redhat/terraform-rhcs-rosa/tree/main/examples/rosa-classic-public-with-unmanaged-oidc)

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,10 @@ e2e_test: $(GINKGO) install
 coverage-changed-files:
 	./hack/coverage-changed-files.sh
 
+.PHONY: check-subsystem-registry
+check-subsystem-registry:
+	./hack/check-subsystem-registry.sh
+
 .PHONY: check-gen
 check-gen:
 	@before_unstaged=$$(mktemp); \

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ make basic-checks      # convenience flow: starts with make fmt and may stop aft
 make pre-push-checks   # exact non-mutating verification used by the pre-push hook
 ```
 
-Changed-files coverage is enforced through `make coverage-changed-files` using `gocovdiff` with an 80% threshold for changed Go files under `provider/` and `internal/`.
+Changed-files coverage is enforced through `make coverage-changed-files` using `gocovdiff` with an 80% threshold for changed Go files under `provider/` and `internal/`, compared to the merge base with `main`.
+
+Subsystem coverage is checked with `make check-subsystem-registry`. See `CONTRIBUTING.md` and `AGENTS.md`.
 
 ## Provider documentation
 

--- a/hack/check-subsystem-registry.sh
+++ b/hack/check-subsystem-registry.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/git.sh
+source "${script_dir}/lib/git.sh"
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+provider_prefix="rhcs"
+allowlist_file="hack/subsystem-registry-allowlist.yaml"
+base_ref="${SUBSYSTEM_REGISTRY_BASE_REF:-}"
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/rhcs-subsystem-registry-XXXXXX")
+registered_types_file="$tmp_dir/registered.txt"
+subsystem_types_file="$tmp_dir/subsystem.txt"
+allowlist_types_file="$tmp_dir/allowlist.txt"
+new_types_file="$tmp_dir/new.txt"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+collect_registered_types() {
+  : >"$registered_types_file"
+  while IFS= read -r line; do
+    suffix=$(printf '%s' "$line" | sed -nE 's/.*ProviderTypeName \+ "(_[a-z0-9_]+)".*/\1/p')
+    if [ -n "$suffix" ]; then
+      echo "${provider_prefix}${suffix}"
+    fi
+  done < <(git grep -h -E 'ProviderTypeName \+ "_[a-z0-9_]+"' -- 'provider/*.go' 'provider/**/*.go' ':!*_test.go' 2>/dev/null || true) \
+    >>"$registered_types_file"
+
+  while IFS= read -r line; do
+    suffix=$(printf '%s' "$line" | sed -nE 's/.*resourceTypeName[[:space:]]*=[[:space:]]*"(_[a-z0-9_]+)".*/\1/p')
+    if [ -n "$suffix" ]; then
+      echo "${provider_prefix}${suffix}"
+    fi
+  done < <(git grep -h -E 'resourceTypeName[[:space:]]*=[[:space:]]*"_([a-z0-9_]+)"' -- 'provider/*.go' 'provider/**/*.go' ':!*_test.go' 2>/dev/null || true) \
+    >>"$registered_types_file"
+
+  sort -u -o "$registered_types_file" "$registered_types_file"
+}
+
+collect_subsystem_types() {
+  : >"$subsystem_types_file"
+  if [ ! -d subsystem ]; then
+    return
+  fi
+
+  while IFS= read -r line; do
+    type_name=$(printf '%s' "$line" | sed -nE 's/.*"(rhcs_[a-z0-9_]+)".*/\1/p')
+    if [ -n "$type_name" ]; then
+      echo "$type_name"
+    fi
+  done < <(git grep -h -E '(resource|data)[[:space:]]+"rhcs_[a-z0-9_]+"' -- 'subsystem/*.go' 'subsystem/**/*.go' 2>/dev/null || true) \
+    | sort -u >"$subsystem_types_file"
+}
+
+collect_allowlist_types() {
+  : >"$allowlist_types_file"
+  if [ ! -f "$allowlist_file" ]; then
+    return
+  fi
+
+  awk '
+    $1 == "-" && $2 == "type:" {
+      print $3
+    }
+  ' "$allowlist_file" | sort -u >"$allowlist_types_file"
+}
+
+resolve_merge_base_range() {
+  local -a base_refs=()
+
+  if [ -n "$base_ref" ]; then
+    base_refs=("$base_ref")
+  else
+    base_refs=(origin/main upstream/main main)
+  fi
+
+  merge_base_range HEAD "${base_refs[@]}"
+}
+
+collect_new_types() {
+  : >"$new_types_file"
+  local diff_range
+  diff_range=$(resolve_merge_base_range)
+  if [ -z "$diff_range" ]; then
+    return
+  fi
+
+  while IFS= read -r line; do
+    suffix=$(printf '%s' "$line" | sed -nE 's/.*"(_[a-z0-9_]+)".*/\1/p')
+    if [ -n "$suffix" ]; then
+      echo "${provider_prefix}${suffix}"
+    fi
+  done < <(git diff "$diff_range" -U0 -- 'provider/*.go' 'provider/**/*.go' ':!*_test.go' \
+    | grep -E '^\+.*TypeName.*\+ "_[a-z0-9_]+"' || true) >>"$new_types_file"
+
+  while IFS= read -r line; do
+    suffix=$(printf '%s' "$line" | sed -nE 's/.*"(_[a-z0-9_]+)".*/\1/p')
+    if [ -n "$suffix" ]; then
+      echo "${provider_prefix}${suffix}"
+    fi
+  done < <(git diff "$diff_range" -U0 -- 'provider/*.go' 'provider/**/*.go' ':!*_test.go' \
+    | grep -E '^\+.*resourceTypeName[[:space:]]*=[[:space:]]*"_([a-z0-9_]+)"' || true) >>"$new_types_file"
+
+  sort -u -o "$new_types_file" "$new_types_file"
+}
+
+is_listed_in_file() {
+  local needle=$1
+  local file=$2
+  grep -Fxq "$needle" "$file"
+}
+
+collect_registered_types
+collect_subsystem_types
+collect_allowlist_types
+collect_new_types
+
+registered_count=$(wc -l <"$registered_types_file" | tr -d ' ')
+subsystem_count=$(wc -l <"$subsystem_types_file" | tr -d ' ')
+allowlist_count=$(wc -l <"$allowlist_types_file" | tr -d ' ')
+
+echo "Subsystem registry check"
+echo "  Registered types: ${registered_count}"
+echo "  Referenced in subsystem tests: ${subsystem_count}"
+echo "  Allowlisted: ${allowlist_count}"
+echo
+
+declare -a uncovered=()
+declare -a allowlisted_missing=()
+declare -a blocking_missing=()
+declare -a new_uncovered=()
+
+while IFS= read -r type_name; do
+  [ -z "$type_name" ] && continue
+  if is_listed_in_file "$type_name" "$subsystem_types_file"; then
+    continue
+  fi
+
+  uncovered+=("$type_name")
+  if is_listed_in_file "$type_name" "$allowlist_types_file"; then
+    allowlisted_missing+=("$type_name")
+  else
+    blocking_missing+=("$type_name")
+  fi
+
+  if [ -s "$new_types_file" ] && is_listed_in_file "$type_name" "$new_types_file"; then
+    new_uncovered+=("$type_name")
+  fi
+done <"$registered_types_file"
+
+if [ "${#uncovered[@]}" -gt 0 ]; then
+  echo "Types without subsystem test reference:"
+  for type_name in "${uncovered[@]}"; do
+    if is_listed_in_file "$type_name" "$allowlist_types_file"; then
+      echo "  - ${type_name} (allowlisted)"
+    else
+      echo "  - ${type_name}"
+    fi
+  done
+  echo
+fi
+
+if [ -s "$new_types_file" ]; then
+  echo "New or changed types in branch (vs ${base_ref}):"
+  while IFS= read -r type_name; do
+    [ -z "$type_name" ] && continue
+    echo "  - ${type_name}"
+  done <"$new_types_file"
+  echo
+fi
+
+exit_code=0
+
+if [ "${#new_uncovered[@]}" -gt 0 ]; then
+  echo "ERROR: New provider types must include a subsystem test (resource \"...\" or data \"...\" under subsystem/):"
+  for type_name in "${new_uncovered[@]}"; do
+    echo "  - ${type_name}"
+  done
+  echo
+  exit_code=1
+fi
+
+if [ "${#blocking_missing[@]}" -gt 0 ]; then
+  echo "ERROR: Registered types missing subsystem coverage (not allowlisted):"
+  for type_name in "${blocking_missing[@]}"; do
+    echo "  - ${type_name}"
+  done
+  echo "Add a subsystem test or an entry in ${allowlist_file} with ticket and reason."
+  echo
+  exit_code=1
+fi
+
+if [ "$exit_code" -eq 0 ]; then
+  if [ "${#allowlisted_missing[@]}" -gt 0 ]; then
+    echo "OK: All uncovered types are allowlisted (${#allowlisted_missing[@]} pending subsystem tests)."
+  else
+    echo "OK: All registered types are referenced in subsystem tests."
+  fi
+fi
+
+exit "$exit_code"

--- a/hack/coverage-changed-files.sh
+++ b/hack/coverage-changed-files.sh
@@ -5,25 +5,54 @@
 
 set -euo pipefail
 
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/git.sh
+source "${script_dir}/lib/git.sh"
+
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
 required_coverage_percent="80"
 gocovdiff_module="github.com/vearutop/gocovdiff"
 gocovdiff_version="v1.4.2"
-
-diff_base_args=(--cached)
-mapfile -t candidate_files < <(git diff "${diff_base_args[@]}" --name-only --diff-filter=ACMR -- '*.go')
-if [ "${#candidate_files[@]}" -eq 0 ]; then
-  diff_base_args=()
-  mapfile -t candidate_files < <(git diff --name-only --diff-filter=ACMR -- '*.go')
-fi
+coverage_base_ref="${COVERAGE_BASE_REF:-}"
 
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/rhcs-changed-coverage-XXXXXX")
 coverage_profile="$tmp_dir/cover.out"
 diff_file="$tmp_dir/changes.diff"
 delta_file="$tmp_dir/delta-cov.txt"
 trap 'rm -rf "$tmp_dir"' EXIT
+
+resolve_diff_args() {
+  local -a base_refs=()
+  local diff_range
+
+  if [ -n "$coverage_base_ref" ]; then
+    base_refs=("$coverage_base_ref")
+  else
+    base_refs=(origin/main upstream/main main)
+  fi
+
+  diff_range=$(merge_base_range HEAD "${base_refs[@]}")
+  if [ -n "$diff_range" ]; then
+    mapfile -t merge_range_go_files < <(git diff "$diff_range" --name-only --diff-filter=ACMR -- '*.go')
+    if [ "${#merge_range_go_files[@]}" -gt 0 ]; then
+      diff_base_args=("$diff_range")
+      return
+    fi
+  fi
+
+  diff_base_args=(--cached)
+  mapfile -t candidate_files < <(git diff "${diff_base_args[@]}" --name-only --diff-filter=ACMR -- '*.go')
+  if [ "${#candidate_files[@]}" -eq 0 ]; then
+    diff_base_args=()
+  fi
+}
+
+declare -a diff_base_args=()
+resolve_diff_args
+
+mapfile -t candidate_files < <(git diff "${diff_base_args[@]}" --name-only --diff-filter=ACMR -- '*.go')
 
 declare -A package_seen=()
 declare -a changed_packages=()

--- a/hack/lib/git.sh
+++ b/hack/lib/git.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+# newest_merge_base HEAD ref...
+# Prints the newest merge-base among merge-base(HEAD, ref) for each reachable ref.
+newest_merge_base() {
+  local head=$1
+  shift
+
+  local best_mb=""
+  local ref mb
+
+  for ref in "$@"; do
+    [ -z "$ref" ] && continue
+    if ! git rev-parse --verify "${ref}^{commit}" >/dev/null 2>&1; then
+      continue
+    fi
+    if ! mb=$(git merge-base "$head" "${ref}" 2>/dev/null); then
+      continue
+    fi
+    if [ -z "$best_mb" ]; then
+      best_mb=$mb
+      continue
+    fi
+    if git merge-base --is-ancestor "$best_mb" "$mb" 2>/dev/null; then
+      best_mb=$mb
+    fi
+  done
+
+  printf '%s' "$best_mb"
+}
+
+# merge_base_range [HEAD] ref...
+# Prints merge_base...HEAD when a merge base exists.
+merge_base_range() {
+  local head=${1:-HEAD}
+  shift
+
+  local mb
+  mb=$(newest_merge_base "$head" "$@")
+  if [ -n "$mb" ]; then
+    printf '%s...%s' "$mb" "$head"
+  fi
+}

--- a/hack/run-checks.sh
+++ b/hack/run-checks.sh
@@ -18,8 +18,8 @@ Usage:
   make run-checks -- <mode> [--dry-run] [--list-steps]
 
 Modes:
-  pre-push                 Steps: format-check, build, generated-files, lint, docs-lint, license-check, coverage, tests
-  basic                    Steps: format, format-check, build, generated-files, lint, docs-lint, license-check, coverage, tests
+  pre-push                 Steps: format-check, build, generated-files, lint, docs-lint, license-check, coverage, subsystem-registry, tests
+  basic                    Steps: format, format-check, build, generated-files, lint, docs-lint, license-check, coverage, subsystem-registry, tests
 
 Flags:
   --dry-run                Print planned steps and commands without executing
@@ -84,6 +84,7 @@ case "$mode" in
     append_step "Documentation lint (Vale)" "make --no-print-directory docs-lint"
     append_step "License header check" "make --no-print-directory license-check"
     append_step "Coverage (changed files)" "make --no-print-directory coverage-changed-files"
+    append_step "Subsystem registry" "make --no-print-directory check-subsystem-registry"
     append_step "Unit and subsystem tests" "make --no-print-directory test"
     ;;
   basic)
@@ -95,6 +96,7 @@ case "$mode" in
     append_step "Documentation lint (Vale)" "make --no-print-directory docs-lint"
     append_step "License header check" "make --no-print-directory license-check"
     append_step "Coverage (changed files)" "make --no-print-directory coverage-changed-files"
+    append_step "Subsystem registry" "make --no-print-directory check-subsystem-registry"
     append_step "Unit and subsystem tests" "make --no-print-directory test"
     ;;
 esac

--- a/hack/subsystem-registry-allowlist.yaml
+++ b/hack/subsystem-registry-allowlist.yaml
@@ -1,0 +1,15 @@
+# Terraform types temporarily allowed without a subsystem test reference.
+# Remove entries when subsystem coverage is added (see AGENTS.md).
+allowlist:
+  - type: rhcs_info
+    ticket: ROSAENG-60113
+    reason: Subsystem test planned in follow-up PR 2
+  - type: rhcs_image_mirrors
+    ticket: ROSAENG-60113
+    reason: Subsystem test planned in follow-up PR 2
+  - type: rhcs_log_forwarders
+    ticket: ROSAENG-60113
+    reason: Subsystem test planned in follow-up PR 2
+  - type: rhcs_rosa_hcp_operator_roles
+    ticket: ROSAENG-60113
+    reason: Subsystem test planned in follow-up PR 2


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary

Add automated pre-merge test gates (`check-subsystem-registry`, merge-base changed-line coverage) and document when unit vs subsystem tests are required.

## Detailed Description of the Issue

Pre-merge checks ran unit and subsystem tests but did not verify that every registered resource/data source has subsystem coverage, and `coverage-changed-files` often skipped on committed PRs because it only diffed the working tree. Contributors also lacked a clear contract for which test layer to add.

**Coverage note:** The provider already has strong behavioral coverage through **unit tests** (validators, helpers, mapping) and **subsystem tests** (Terraform apply against mock OCM for most resources). That coverage is **not** visible as a high repo-wide unit coverage percentage—CRUD and lifecycle paths are exercised primarily in subsystem tests, not in `go test -cover` on `provider/` packages. This PR improves **enforcement and documentation**, not total line coverage %.

## Related Issues and PRs
- Jira: [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113)
- Fixes: `#`
- Related PR(s): Follow-up PR planned for subsystem tests for four allowlisted data sources (`rhcs_info`, `rhcs_image_mirrors`, `rhcs_log_forwarders`, `rhcs_rosa_hcp_operator_roles`).
- Related design/docs: `CONTRIBUTING.md`, `AGENTS.md`

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- `make pre-push-checks` did not verify subsystem coverage per registered Terraform type.
- `make coverage-changed-files` compared staged/unstaged diffs only, so it often passed on committed PRs without checking changed `provider/` / `internal/` Go.
- CONTRIBUTING and the PR template did not define unit vs subsystem expectations.

## Behavior After This Change

- `make check-subsystem-registry` discovers registered types from `provider/` and requires a `resource "rhcs_…"` or `data "rhcs_…"` reference under `subsystem/`, with a documented allowlist for four known data-source gaps.
- New types added on the branch fail the check without a subsystem test.
- `make coverage-changed-files` diffs against the merge base with `main` (fallback: staged/unstaged).
- `make pre-push-checks` runs the subsystem registry step before `make test`.
- CONTRIBUTING, AGENTS.md, README, and the PR template document the pre-merge test contract.

## How to Test (Step-by-Step)
### Preconditions
- Clone with `origin/main` available (`git fetch origin main`).

### Test Steps
1. Run `make check-subsystem-registry` — expect OK with four allowlisted gaps.
2. Run `make run-checks -- pre-push --list-steps` — confirm subsystem registry is step 8 of 9.
3. Run `make coverage-changed-files` on a branch with only doc/shell changes — expect exit 0.
4. (Optional) Add a fake `TypeName` in `provider/` without a subsystem test — expect `check-subsystem-registry` to fail.

### Expected Results
- Registry check passes on this branch with allowlist.
- Pre-push step list includes subsystem registry and changed-line coverage.
- New provider types without subsystem tests are blocked at pre-push/CI.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: `make check-subsystem-registry` reports OK with four allowlisted pending subsystem tests.
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and agent guidance with a clearer testing matrix, local pre-push/CI expectations, and changed-files coverage enforcement (merge-base vs `main`).
  * Added instructions for the new subsystem registry coverage check, including temporary allowlist behavior and removal guidance.
* **Chores**
  * Added `make check-subsystem-registry` and integrated the subsystem registry step into standard `pre-push` and basic check flows.
  * Improved changed-files coverage diff selection (merge-base range, caching fallback) and added required headers to coverage artifacts.
  * Refreshed the PR template testing checklist to match the new required workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->