### PR TITLE
ROSAENG-60113 | test(subsystem): add subsystem tests for uncovered datasources

### DIFF
--- a/subsystem/classic/info_data_source_test.go
+++ b/subsystem/classic/info_data_source_test.go
@@ -1,0 +1,43 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package classic
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"             // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+
+	. "github.com/terraform-redhat/terraform-provider-rhcs/subsystem/framework"
+)
+
+var _ = Describe("Info data source", func() {
+	It("Can read current account information", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusOK, ocmRoleCurrentAccountResponse),
+			),
+		)
+
+		Terraform.Source(`
+		  data "rhcs_info" "info" {
+		  }
+		`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_info", "info")
+		Expect(resource).To(MatchJQ(`.attributes.account_id`, "1234567890"))
+		Expect(resource).To(MatchJQ(`.attributes.account_name`, "Test User"))
+		Expect(resource).To(MatchJQ(`.attributes.account_username`, "testuser"))
+		Expect(resource).To(MatchJQ(`.attributes.account_email`, "testuser@example.com"))
+		Expect(resource).To(MatchJQ(`.attributes.organization_id`, "org123"))
+		Expect(resource).To(MatchJQ(`.attributes.organization_external_id`, "ext-org-456"))
+		Expect(resource).To(MatchJQ(`.attributes.organization_name`, "Test Org"))
+		Expect(resource).To(MatchJQ(`.attributes.ocm_aws_account_id`, "710019948333"))
+	})
+})

--- a/subsystem/hcp/image_mirrors_data_source_test.go
+++ b/subsystem/hcp/image_mirrors_data_source_test.go
@@ -1,0 +1,56 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package hcp
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"             // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+
+	. "github.com/terraform-redhat/terraform-provider-rhcs/subsystem/framework"
+)
+
+var _ = Describe("Image mirrors data source", func() {
+	It("Can list image mirrors for a cluster", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/image_mirrors"),
+				RespondWithJSON(http.StatusOK, `{
+				  "page": 1,
+				  "size": 1,
+				  "total": 1,
+				  "items": [
+				    {
+				      "id": "mirror-1",
+				      "type": "digest",
+				      "source": "registry.example.com/team",
+				      "mirrors": ["mirror.corp.com/team"],
+				      "creation_timestamp": "2024-01-01T00:00:00Z",
+				      "last_update_timestamp": "2024-01-02T00:00:00Z"
+				    }
+				  ]
+				}`),
+			),
+		)
+
+		Terraform.Source(`
+		  data "rhcs_image_mirrors" "cluster_mirrors" {
+		    cluster_id = "123"
+		  }
+		`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_image_mirrors", "cluster_mirrors")
+		Expect(resource).To(MatchJQ(`.attributes.cluster_id`, "123"))
+		Expect(resource).To(MatchJQ(`.attributes.image_mirrors | length`, 1))
+		Expect(resource).To(MatchJQ(`.attributes.image_mirrors[0].id`, "mirror-1"))
+		Expect(resource).To(MatchJQ(`.attributes.image_mirrors[0].type`, "digest"))
+		Expect(resource).To(MatchJQ(`.attributes.image_mirrors[0].source`, "registry.example.com/team"))
+		Expect(resource).To(MatchJQ(`.attributes.image_mirrors[0].mirrors[0]`, "mirror.corp.com/team"))
+	})
+})

--- a/subsystem/hcp/log_forwarders_data_source_test.go
+++ b/subsystem/hcp/log_forwarders_data_source_test.go
@@ -1,0 +1,80 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package hcp
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"             // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+
+	. "github.com/terraform-redhat/terraform-provider-rhcs/subsystem/framework"
+)
+
+var _ = Describe("Log forwarders data source", func() {
+	It("fails if cluster ID is empty", func() {
+		Terraform.Source(`
+		  data "rhcs_log_forwarders" "all" {
+		    cluster = ""
+		  }
+		`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).ToNot(BeZero())
+		runOutput.VerifyErrorContainsSubstring("cluster ID may not be empty/blank string")
+	})
+
+	It("Can list log forwarders for a cluster", func() {
+		listResponse := `{
+				  "page": 1,
+				  "size": 2,
+				  "total": 2,
+				  "items": [
+				    {
+				      "id": "log-fwd-1",
+				      "s3": {
+				        "bucket_name": "my-logs",
+				        "bucket_prefix": "rosa/"
+				      },
+				      "applications": ["audit", "infrastructure"]
+				    },
+				    {
+				      "id": "log-fwd-2",
+				      "cloudwatch": {
+				        "log_group_name": "/aws/rosa/logs",
+				        "log_distribution_role_arn": "arn:aws:iam::123456789012:role/log-forwarder"
+				      },
+				      "applications": ["audit"]
+				    }
+				  ]
+				}`
+		listHandler := CombineHandlers(
+			VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/456/control_plane/log_forwarders"),
+			RespondWithJSON(http.StatusOK, listResponse),
+		)
+		// Data source reads run during plan and apply.
+		TestServer.AppendHandlers(listHandler, listHandler)
+
+		Terraform.Source(`
+		  data "rhcs_log_forwarders" "all" {
+		    cluster = "456"
+		  }
+		`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_log_forwarders", "all")
+		Expect(resource).To(MatchJQ(`.attributes.cluster`, "456"))
+		Expect(resource).To(MatchJQ(`.attributes.items | length`, 2))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].id`, "log-fwd-1"))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].cluster_id`, "456"))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].s3.bucket_name`, "my-logs"))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].s3.bucket_prefix`, "rosa/"))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].applications[0]`, "audit"))
+		Expect(resource).To(MatchJQ(`.attributes.items[1].id`, "log-fwd-2"))
+		Expect(resource).To(MatchJQ(`.attributes.items[1].cloudwatch.log_group_name`, "/aws/rosa/logs"))
+		Expect(resource).To(MatchJQ(`.attributes.items[1].cloudwatch.log_distribution_role_arn`, "arn:aws:iam::123456789012:role/log-forwarder"))
+	})
+})

--- a/subsystem/hcp/rosa_hcp_operator_roles_data_source_test.go
+++ b/subsystem/hcp/rosa_hcp_operator_roles_data_source_test.go
@@ -1,0 +1,122 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package hcp
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"             // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+
+	. "github.com/terraform-redhat/terraform-provider-rhcs/subsystem/framework"
+)
+
+const getStsCredentialRequests = `{
+	"page": 1,
+	"size": 2,
+	"total": 2,
+	"items": [
+		{
+			"kind": "STSOperator",
+			"name": "cluster_csi_drivers_ebs_cloud_credentials",
+			"operator": {
+				"name": "ebs-cloud-credentials",
+				"namespace": "openshift-cluster-csi-drivers",
+				"service_accounts": [
+					"aws-ebs-csi-driver-operator",
+					"aws-ebs-csi-driver-controller-sa"
+				],
+				"min_version": "",
+				"max_version": ""
+			}
+		},
+		{
+			"kind": "STSOperator",
+			"name": "cloud_network_config_controller_cloud_credentials",
+			"operator": {
+				"name": "cloud-credentials",
+				"namespace": "openshift-cloud-network-config-controller",
+				"service_accounts": [
+					"cloud-network-config-controller"
+				],
+				"min_version": "4.10",
+				"max_version": ""
+			}
+		}
+	]
+}`
+
+var _ = Describe("ROSA HCP operator roles data source", func() {
+	It("Can list HCP operator IAM roles", func() {
+		TestServer.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/aws_inquiries/sts_credential_requests"),
+				VerifyFormKV("is_hypershift", "true"),
+				RespondWithJSON(http.StatusOK, getStsCredentialRequests),
+			),
+		)
+
+		Terraform.Source(`
+		  data "rhcs_rosa_hcp_operator_roles" "operator_roles" {
+		    operator_role_prefix = "terraform-operator"
+		    account_role_prefix  = "TerraformAccountPrefix"
+		  }
+		`)
+		runOutput := Terraform.Apply()
+		Expect(runOutput.ExitCode).To(BeZero())
+
+		resource := Terraform.Resource("rhcs_rosa_hcp_operator_roles", "operator_roles")
+		Expect(resource).To(MatchJQ(`.attributes.operator_role_prefix`, "terraform-operator"))
+		Expect(resource).To(MatchJQ(`.attributes.account_role_prefix`, "TerraformAccountPrefix"))
+		Expect(resource).To(MatchJQ(`.attributes.operator_iam_roles | length`, 2))
+
+		index := 0
+		firstOperatorName := resource.(map[string]interface{})["attributes"].(map[string]interface{})["operator_iam_roles"].([]interface{})[0].(map[string]interface{})["operator_name"].(string)
+		if firstOperatorName != "ebs-cloud-credentials" {
+			index = 1
+		}
+
+		compareHCPResultOfRoles(resource, index,
+			"ebs-cloud-credentials",
+			"openshift-cluster-csi-drivers",
+			"TerraformAccountPrefix-openshift-cluster-csi-drivers-ebs-cloud-c",
+			"terraform-operator-openshift-cluster-csi-drivers-ebs-cloud-crede",
+			2,
+			[]string{
+				"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator",
+				"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa",
+			},
+		)
+
+		compareHCPResultOfRoles(resource, 1-index,
+			"cloud-credentials",
+			"openshift-cloud-network-config-controller",
+			"TerraformAccountPrefix-openshift-cloud-network-config-controller",
+			"terraform-operator-openshift-cloud-network-config-controller-clo",
+			1,
+			[]string{"system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller"},
+		)
+	})
+})
+
+func compareHCPResultOfRoles(resource interface{}, index int, name, namespace, policyName, roleName string, serviceAccountLen int, serviceAccounts []string) {
+	operatorNameFmt := ".attributes.operator_iam_roles[%v].operator_name"
+	operatorNamespaceFmt := ".attributes.operator_iam_roles[%v].operator_namespace"
+	policyNameFmt := ".attributes.operator_iam_roles[%v].policy_name"
+	roleNameFmt := ".attributes.operator_iam_roles[%v].role_name"
+	serviceAccountLenFmt := ".attributes.operator_iam_roles[%v].service_accounts | length"
+	serviceAccountFmt := ".attributes.operator_iam_roles[%v].service_accounts[%v]"
+
+	Expect(resource).To(MatchJQ(fmt.Sprintf(operatorNameFmt, index), name))
+	Expect(resource).To(MatchJQ(fmt.Sprintf(operatorNamespaceFmt, index), namespace))
+	Expect(resource).To(MatchJQ(fmt.Sprintf(policyNameFmt, index), policyName))
+	Expect(resource).To(MatchJQ(fmt.Sprintf(roleNameFmt, index), roleName))
+	Expect(resource).To(MatchJQ(fmt.Sprintf(serviceAccountLenFmt, index), serviceAccountLen))
+	for k, v := range serviceAccounts {
+		Expect(resource).To(MatchJQ(fmt.Sprintf(serviceAccountFmt, index, k), v))
+	}
+}


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary
Add subsystem tests with mock OCM for `rhcs_info`, `rhcs_image_mirrors`, `rhcs_log_forwarders`, and `rhcs_rosa_hcp_operator_roles`.

## Detailed Description of the Issue
Four data sources had no subsystem test coverage. Subsystem tests are the primary behavioral gate for provider types that talk to OCM. Without them, plan/apply/read paths for these types are not exercised in CI.

This PR is independent of #1205 (pre-merge gates and subsystem registry). It adds only test files on `main`.

## Related Issues and PRs
- Jira: [ROSAENG-60113](https://issues.redhat.com/browse/ROSAENG-60113)
- Related PR(s): #1205 (subsystem registry gate; separate follow-up)
- Related design/docs: N/A

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
No subsystem tests referenced `data "rhcs_info"`, `data "rhcs_image_mirrors"`, `data "rhcs_log_forwarders"`, or `data "rhcs_rosa_hcp_operator_roles"`.

## Behavior After This Change
Subsystem suites exercise the main read paths for those four data sources using mock OCM handlers. Provider behavior is unchanged.

## How to Test (Step-by-Step)
### Preconditions
- Clone with hooks installed (`make install-hooks`)
- Go toolchain per `CONTRIBUTING.md`

### Test Steps
1. Run focused tests:

       go test -count=1 ./subsystem/classic -ginkgo.focus "Info data source"
       go test -count=1 ./subsystem/hcp -ginkgo.focus "Image mirrors data source|Log forwarders data source|ROSA HCP operator roles data source"

2. Run full pre-push checks:

       make pre-push-checks

### Expected Results
- All four new specs pass.
- `make pre-push-checks` completes with no failures.

## Proof of the Fix
- Logs/CLI output:
  - `make pre-push-checks`: 8/8 passed (format, build, generated files, lint, docs-lint, license headers, coverage-changed-files, unit + subsystem tests)
  - Focused `go test` runs for new specs: pass

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make pre-push-checks` passes.
- [x] `make fmt-check` passes.
- [x] `make build` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the `rhcs_info` data source validating account and organization attributes.
  * Added test coverage for the `rhcs_image_mirrors` data source with cluster-specific mirror data validation.
  * Added test coverage for the `rhcs_log_forwarders` data source including error handling and log forwarder configuration validation.
  * Added test coverage for the `rhcs_rosa_hcp_operator_roles` data source with operator role and service account attribute validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->