### PR TITLE
ROSAENG-60113 | test(unit): add attrvalidators coverage

### DIFF
--- a/provider/common/attrvalidators/notemptymap_validator_test.go
+++ b/provider/common/attrvalidators/notemptymap_validator_test.go
@@ -1,0 +1,59 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package attrvalidators
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Not empty map validator", func() {
+	DescribeTable("should validate correctly",
+		func(request validator.MapRequest, expectedErr bool) {
+			response := validator.MapResponse{}
+			NotEmptyMapValidator().ValidateMap(context.Background(), request, &response)
+			Expect(response.Diagnostics.HasError()).To(Equal(expectedErr))
+		},
+		Entry("non-empty map -> ok",
+			validator.MapRequest{
+				Path:           path.Root("labels"),
+				PathExpression: path.MatchRoot("labels"),
+				ConfigValue: types.MapValueMust(types.StringType, map[string]attr.Value{
+					"env": types.StringValue("prod"),
+				}),
+			},
+			false,
+		),
+		Entry("empty map -> error",
+			validator.MapRequest{
+				Path:           path.Root("labels"),
+				PathExpression: path.MatchRoot("labels"),
+				ConfigValue:    types.MapValueMust(types.StringType, map[string]attr.Value{}),
+			},
+			true,
+		),
+		Entry("null map -> ok",
+			validator.MapRequest{
+				Path:           path.Root("labels"),
+				PathExpression: path.MatchRoot("labels"),
+				ConfigValue:    types.MapNull(types.StringType),
+			},
+			false,
+		),
+		Entry("unknown map -> ok",
+			validator.MapRequest{
+				Path:           path.Root("labels"),
+				PathExpression: path.MatchRoot("labels"),
+				ConfigValue:    types.MapUnknown(types.StringType),
+			},
+			false,
+		),
+	)
+})

--- a/provider/common/attrvalidators/string_enum_test.go
+++ b/provider/common/attrvalidators/string_enum_test.go
@@ -1,0 +1,58 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package attrvalidators
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Enum value validator", func() {
+	allowed := []string{"digest", "wildcard"}
+
+	DescribeTable("should validate correctly",
+		func(request validator.StringRequest, expectedErr bool) {
+			response := validator.StringResponse{}
+			EnumValueValidator(allowed).ValidateString(context.Background(), request, &response)
+			Expect(response.Diagnostics.HasError()).To(Equal(expectedErr))
+		},
+		Entry("allowed value -> ok",
+			validator.StringRequest{
+				Path:           path.Root("type"),
+				PathExpression: path.MatchRoot("type"),
+				ConfigValue:    types.StringValue("digest"),
+			},
+			false,
+		),
+		Entry("disallowed value -> error",
+			validator.StringRequest{
+				Path:           path.Root("type"),
+				PathExpression: path.MatchRoot("type"),
+				ConfigValue:    types.StringValue("invalid"),
+			},
+			true,
+		),
+		Entry("null value -> ok",
+			validator.StringRequest{
+				Path:           path.Root("type"),
+				PathExpression: path.MatchRoot("type"),
+				ConfigValue:    types.StringNull(),
+			},
+			false,
+		),
+		Entry("unknown value -> ok",
+			validator.StringRequest{
+				Path:           path.Root("type"),
+				PathExpression: path.MatchRoot("type"),
+				ConfigValue:    types.StringUnknown(),
+			},
+			false,
+		),
+	)
+})


### PR DESCRIPTION
## PR Summary

Add unit tests for shared `EnumValueValidator` and `NotEmptyMapValidator` in `provider/common/attrvalidators`. **PR 1 of 6** in the [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113) unit-test coverage series.

### Planned follow-up PRs
1. `provider/common/attrvalidators` — **this PR**
2. `provider/clusterrosa/common` + `hcp/shared_vpc` — domain validators
3. `provider/common` (root) — helpers and HTPasswd validators
4. `provider/clusterrosa/hcp` — untested `validate*` / small pure funcs
5. `provider/clusterrosa/classic` — validators only (not CRUD)
6. `provider/proxy` — `Contains` (optional, if still uncovered)

## Detailed Description of the Issue

`provider/common/attrvalidators` had low package coverage because only `ConflictsWithNotEmpty` was unit-tested. `EnumValueValidator` and `NotEmptyMapValidator` are used across multiple resources but had no direct unit tests.

## Related Issues and PRs
- Jira: [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113)
- Related PR(s): Independent of subsystem-test PRs; part 1 of 6 (`ROSAENG-60113-unit-tests-1`).

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

No unit tests covered `EnumValueValidator` or `NotEmptyMapValidator`; only `ConflictsWithNotEmpty` had tests in this package.

## Behavior After This Change

Table-driven Ginkgo unit tests validate allowed/disallowed/null/unknown inputs for both validators. No production code changes.

## How to Test (Step-by-Step)

### Preconditions
- Go toolchain and repo dependencies installed.

### Test Steps
1. `go test -cover ./provider/common/attrvalidators/...`
2. `make pre-push-checks`

### Expected Results
- All attrvalidators specs pass; package coverage increases (thin `New*Validator` wrappers remain intentionally untested).
- Pre-push checks pass.

## Proof of the Fix
- Logs/CLI output: local `make pre-push-checks` (8/8 passed) and CodeRabbit local review (0 findings).

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make pre-push-checks` passes.
- [x] `make fmt-check` passes.
- [x] `make build` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for map validation behavior, including empty, non-empty, null, and unknown values.
  * Added test coverage for string enum validation, confirming allowed and disallowed values are handled correctly, while null and unknown values remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->