### PR TITLE
ROSAENG-60521 | fix(upgrade): skip recurring upgrade policies with empty version (#1186)

### DIFF
--- a/provider/clusterrosa/classic/upgrade/cluster_upgrade.go
+++ b/provider/clusterrosa/classic/upgrade/cluster_upgrade.go
@@ -142,6 +142,14 @@ func CheckAndCancelUpgrades(ctx context.Context, client *cmv1.ClustersClient, up
 
 	for _, upgrade := range upgrades {
 		tflog.Debug(ctx, fmt.Sprintf("Found existing upgrade policy to %s in state %s", upgrade.Version(), upgrade.State()))
+		// Recurring (automatic) upgrade policies have no pinned version - OCM
+		// selects the target version at runtime - so Version() is empty. Skip
+		// them rather than failing semver parsing (issue #1186); they are not a
+		// pending pinned upgrade that needs reconciling against desiredVersion.
+		if upgrade.Version() == "" {
+			tflog.Debug(ctx, "Skipping recurring upgrade policy with no pinned version")
+			continue
+		}
 		toVersion, err := semver.NewVersion(upgrade.Version())
 		if err != nil {
 			return false, fmt.Errorf("failed to parse upgrade version: %v", err)

--- a/provider/clusterrosa/classic/upgrade/cluster_upgrade_test.go
+++ b/provider/clusterrosa/classic/upgrade/cluster_upgrade_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	semver "github.com/hashicorp/go-version"
+	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
+	. "github.com/onsi/gomega"             // nolint
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+// TestUpgrade is the entry point for the Cluster Rosa Classic Upgrade Ginkgo suite.
+func TestUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster Rosa Classic Upgrade Suite")
+}
+
+var _ = Describe("CheckAndCancelUpgrades", func() {
+	ctx := context.Background()
+
+	// newUpgrade builds a ClusterUpgrade with the given version and state.
+	newUpgrade := func(version string, scheduleType cmv1.ScheduleType,
+		state cmv1.UpgradePolicyStateValue) ClusterUpgrade {
+		policy, err := cmv1.NewUpgradePolicy().
+			ScheduleType(scheduleType).
+			Version(version).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		policyState, err := cmv1.NewUpgradePolicyState().Value(state).Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		return ClusterUpgrade{policy: policy, policyState: policyState}
+	}
+
+	It("skips recurring (automatic) policies that have no pinned version (issue #1186)", func() {
+		// A recurring schedule reports an empty Version() because OCM selects the
+		// target at runtime. Before the fix this crashed semver parsing and failed
+		// the whole apply. The empty-version policy is skipped before any client
+		// call, so a nil client is safe here.
+		desired := semver.Must(semver.NewVersion("4.21.20"))
+		upgrades := []ClusterUpgrade{
+			newUpgrade("", cmv1.ScheduleTypeAutomatic, cmv1.UpgradePolicyStateValuePending),
+		}
+
+		correctUpgradePending, err := CheckAndCancelUpgrades(ctx, nil, upgrades, desired)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(correctUpgradePending).To(BeFalse())
+	})
+
+	It("returns no pending upgrade when the policy list is empty", func() {
+		desired := semver.Must(semver.NewVersion("4.21.20"))
+
+		correctUpgradePending, err := CheckAndCancelUpgrades(ctx, nil, []ClusterUpgrade{}, desired)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(correctUpgradePending).To(BeFalse())
+	})
+
+	It("reports a correct pending upgrade for a started policy matching the desired version", func() {
+		desired := semver.Must(semver.NewVersion("4.21.20"))
+		upgrades := []ClusterUpgrade{
+			newUpgrade("4.21.20", cmv1.ScheduleTypeManual, cmv1.UpgradePolicyStateValueStarted),
+		}
+
+		correctUpgradePending, err := CheckAndCancelUpgrades(ctx, nil, upgrades, desired)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(correctUpgradePending).To(BeTrue())
+	})
+
+	It("errors when a started upgrade is for a different version", func() {
+		desired := semver.Must(semver.NewVersion("4.21.20"))
+		upgrades := []ClusterUpgrade{
+			newUpgrade("4.21.19", cmv1.ScheduleTypeManual, cmv1.UpgradePolicyStateValueStarted),
+		}
+
+		_, err := CheckAndCancelUpgrades(ctx, nil, upgrades, desired)
+
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/provider/clusterrosa/hcp/upgrade/upgrade.go
+++ b/provider/clusterrosa/hcp/upgrade/upgrade.go
@@ -120,6 +120,14 @@ func CheckAndCancelUpgrades(
 
 	for _, upgrade := range upgrades {
 		tflog.Debug(ctx, fmt.Sprintf("Found existing upgrade policy to '%s' in state '%s'", upgrade.Policy.Version(), upgrade.PolicyState.Value()))
+		// Recurring (automatic) upgrade policies have no pinned version - OCM
+		// selects the target version at runtime - so Version() is empty. Skip
+		// them rather than failing semver parsing (issue #1186); they are not a
+		// pending pinned upgrade that needs reconciling against desiredVersion.
+		if upgrade.Policy.Version() == "" {
+			tflog.Debug(ctx, "Skipping recurring upgrade policy with no pinned version")
+			continue
+		}
 		toVersion, err := semver.NewVersion(upgrade.Policy.Version())
 		if err != nil {
 			return false, fmt.Errorf("failed to parse upgrade version: %v", err)

--- a/provider/clusterrosa/hcp/upgrade/upgrade_test.go
+++ b/provider/clusterrosa/hcp/upgrade/upgrade_test.go
@@ -25,6 +25,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
+// TestUpgrade is the entry point for the Cluster Rosa HCP Upgrade Ginkgo suite.
 func TestUpgrade(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Cluster Rosa HCP Upgrade Suite")

--- a/provider/clusterrosa/hcp/upgrade/upgrade_test.go
+++ b/provider/clusterrosa/hcp/upgrade/upgrade_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	semver "github.com/hashicorp/go-version"
+	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
+	. "github.com/onsi/gomega"             // nolint
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+func TestUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster Rosa HCP Upgrade Suite")
+}
+
+var _ = Describe("CheckAndCancelUpgrades", func() {
+	ctx := context.Background()
+
+	// newPolicy builds a ControlPlaneUpgrade with the given version and state.
+	newUpgrade := func(version string, scheduleType cmv1.ScheduleType,
+		state cmv1.UpgradePolicyStateValue) ControlPlaneUpgrade {
+		policy, err := cmv1.NewControlPlaneUpgradePolicy().
+			ScheduleType(scheduleType).
+			Version(version).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		policyState, err := cmv1.NewUpgradePolicyState().Value(state).Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		return ControlPlaneUpgrade{Policy: policy, PolicyState: policyState}
+	}
+
+	It("skips recurring (automatic) policies that have no pinned version (issue #1186)", func() {
+		// A recurring schedule reports an empty Version() because OCM selects the
+		// target at runtime. Before the fix this crashed semver parsing and failed
+		// the whole apply. The empty-version policy is skipped before any client
+		// call, so a nil client is safe here.
+		desired := semver.Must(semver.NewVersion("4.21.20"))
+		upgrades := []ControlPlaneUpgrade{
+			newUpgrade("", cmv1.ScheduleTypeAutomatic, cmv1.UpgradePolicyStateValuePending),
+		}
+
+		correctUpgradePending, err := CheckAndCancelUpgrades(ctx, nil, upgrades, desired)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(correctUpgradePending).To(BeFalse())
+	})
+
+	It("returns no pending upgrade when the policy list is empty", func() {
+		desired := semver.Must(semver.NewVersion("4.21.20"))
+
+		correctUpgradePending, err := CheckAndCancelUpgrades(ctx, nil, []ControlPlaneUpgrade{}, desired)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(correctUpgradePending).To(BeFalse())
+	})
+
+	It("reports a correct pending upgrade for a started policy matching the desired version", func() {
+		desired := semver.Must(semver.NewVersion("4.21.20"))
+		upgrades := []ControlPlaneUpgrade{
+			newUpgrade("4.21.20", cmv1.ScheduleTypeManual, cmv1.UpgradePolicyStateValueStarted),
+		}
+
+		correctUpgradePending, err := CheckAndCancelUpgrades(ctx, nil, upgrades, desired)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(correctUpgradePending).To(BeTrue())
+	})
+
+	It("errors when a started upgrade is for a different version", func() {
+		desired := semver.Must(semver.NewVersion("4.21.20"))
+		upgrades := []ControlPlaneUpgrade{
+			newUpgrade("4.21.19", cmv1.ScheduleTypeManual, cmv1.UpgradePolicyStateValueStarted),
+		}
+
+		_, err := CheckAndCancelUpgrades(ctx, nil, upgrades, desired)
+
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## PR Summary
`CheckAndCancelUpgrades` (HCP control plane) crashes `terraform apply` on any cluster with a recurring (automatic) upgrade schedule, because recurring policies have an empty version that fails semver parsing. This skips empty-version policies before parsing.

## Detailed Description of the Issue
A recurring/automatic OCM upgrade schedule has no pinned target version — OCM selects it at runtime — so `upgrade.Policy.Version()` returns `""`. `CheckAndCancelUpgrades` passes that straight to `semver.NewVersion("")`, which errors, and the entire apply fails with `failed to parse upgrade version: Malformed version: ""`. Any HCP cluster using the recurring auto-upgrade feature cannot be `terraform apply`-ed without first disabling the schedule in OCM and re-enabling it afterward — operationally painful and easy to forget.

## Related Issues and PRs
- Jira: N/A (community contribution)
- Fixes: `#1186`
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [x] fix - resolves an incorrect behavior or bug.

## Previous Behavior
`terraform apply` against an HCP cluster with an active recurring upgrade schedule fails with `failed to parse upgrade version: Malformed version: ""`.

## Behavior After This Change
Recurring policies with an empty version are skipped (they are not a pending pinned upgrade to reconcile against the desired version), so apply proceeds normally while the recurring schedule remains active.

## How to Test (Step-by-Step)
### Preconditions
An HCP cluster managed by the provider with a recurring (automatic) control-plane upgrade schedule configured in OCM.

### Test Steps
1. With the recurring schedule active, run `terraform apply` (or `terraform plan` paths that reach `CheckAndCancelUpgrades`).
2. Observe the failure before this change.
3. Apply this change and re-run.

### Expected Results
Apply completes without the `Malformed version: ""` error; the recurring schedule is left untouched.

## Proof of the Fix
- Logs/CLI output: new unit test `skips recurring (automatic) policies that have no pinned version (issue #1186)` fails on `main` with `failed to parse upgrade version` and passes with this change. `make coverage-changed-files` reports 100% of changed lines covered; `make lint`, `make fmt-check`, `make build`, `make check-subsystem-registry` all pass locally.

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone. (Hooks not installed, but `make fmt-check`, `lint`, `build`, `coverage-changed-files`, `check-subsystem-registry`, and package tests were run manually and pass.)
- [x] `make pre-push-checks` passes. (Run via the individual gate targets above; all green.)
- [ ] Documentation was added/updated where appropriate. (N/A — internal bug fix, no user-facing API/schema change.)
- [x] Any risk, limitation, or follow-up work is documented.

### Testing
- [x] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`provider/clusterrosa/hcp/upgrade/upgrade_test.go`).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible. (N/A — covered by the regression unit test; reproduced against a real recurring-schedule cluster is the original #1186 report.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade handling so automatic recurring control plane policies without a pinned version are no longer treated as pending upgrades.
  * Prevented errors from being raised when no version is set for these policies.
  * Added coverage for empty upgrade lists, matching versions, and mismatched versions to improve reliability of upgrade checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->