### PR TITLE
ROSAENG-60113 | test(unit): add clusterrosa validator coverage

### DIFF
--- a/provider/clusterrosa/common/validators_test.go
+++ b/provider/clusterrosa/common/validators_test.go
@@ -1,0 +1,179 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Availability zone validator", func() {
+	DescribeTable("should validate correctly",
+		func(request validator.StringRequest, expectedErr bool) {
+			response := validator.StringResponse{}
+			AvailabilityZoneValidator.ValidateString(context.Background(), request, &response)
+			Expect(response.Diagnostics.HasError()).To(Equal(expectedErr))
+		},
+		Entry("AZ contains cloud_region -> ok",
+			validator.StringRequest{
+				Path:           path.Root("availability_zone"),
+				PathExpression: path.MatchRoot("availability_zone"),
+				Config:         buildCloudRegionConfig("us-east-1"),
+				ConfigValue:    types.StringValue("us-east-1a"),
+			},
+			false,
+		),
+		Entry("AZ does not contain cloud_region -> error",
+			validator.StringRequest{
+				Path:           path.Root("availability_zone"),
+				PathExpression: path.MatchRoot("availability_zone"),
+				Config:         buildCloudRegionConfig("us-east-1"),
+				ConfigValue:    types.StringValue("us-west-2a"),
+			},
+			true,
+		),
+	)
+})
+
+var _ = Describe("Private hosted zone validator", func() {
+	privateHZAttrTypes := map[string]attr.Type{
+		"id":       types.StringType,
+		"role_arn": types.StringType,
+	}
+
+	DescribeTable("should validate correctly",
+		func(request validator.ObjectRequest, expectedErr bool) {
+			response := validator.ObjectResponse{}
+			PrivateHZValidator.ValidateObject(context.Background(), request, &response)
+			Expect(response.Diagnostics.HasError()).To(Equal(expectedErr))
+		},
+		Entry("valid id and role_arn -> ok",
+			validator.ObjectRequest{
+				Path:           path.Root("private_hosted_zone"),
+				PathExpression: path.MatchRoot("private_hosted_zone"),
+				ConfigValue: types.ObjectValueMust(privateHZAttrTypes, map[string]attr.Value{
+					"id":       types.StringValue("Z05646003S02O1ENCDCSN"),
+					"role_arn": types.StringValue("arn:aws:iam::123456789012:role/route53"),
+				}),
+			},
+			false,
+		),
+		Entry("empty id -> error",
+			validator.ObjectRequest{
+				Path:           path.Root("private_hosted_zone"),
+				PathExpression: path.MatchRoot("private_hosted_zone"),
+				ConfigValue: types.ObjectValueMust(privateHZAttrTypes, map[string]attr.Value{
+					"id":       types.StringValue(""),
+					"role_arn": types.StringValue("arn:aws:iam::123456789012:role/route53"),
+				}),
+			},
+			true,
+		),
+		Entry("empty role_arn -> error",
+			validator.ObjectRequest{
+				Path:           path.Root("private_hosted_zone"),
+				PathExpression: path.MatchRoot("private_hosted_zone"),
+				ConfigValue: types.ObjectValueMust(privateHZAttrTypes, map[string]attr.Value{
+					"id":       types.StringValue("Z05646003S02O1ENCDCSN"),
+					"role_arn": types.StringValue(""),
+				}),
+			},
+			true,
+		),
+		Entry("null object -> ok",
+			validator.ObjectRequest{
+				Path:           path.Root("private_hosted_zone"),
+				PathExpression: path.MatchRoot("private_hosted_zone"),
+				ConfigValue:    types.ObjectNull(privateHZAttrTypes),
+			},
+			false,
+		),
+		Entry("unknown object -> ok",
+			validator.ObjectRequest{
+				Path:           path.Root("private_hosted_zone"),
+				PathExpression: path.MatchRoot("private_hosted_zone"),
+				ConfigValue:    types.ObjectUnknown(privateHZAttrTypes),
+			},
+			false,
+		),
+	)
+})
+
+var _ = Describe("Properties validator", func() {
+	DescribeTable("should validate correctly",
+		func(request validator.MapRequest, expectedErr bool) {
+			response := validator.MapResponse{}
+			PropertiesValidator.ValidateMap(context.Background(), request, &response)
+			Expect(response.Diagnostics.HasError()).To(Equal(expectedErr))
+		},
+		Entry("custom property key -> ok",
+			validator.MapRequest{
+				Path:           path.Root("properties"),
+				PathExpression: path.MatchRoot("properties"),
+				ConfigValue: types.MapValueMust(types.StringType, map[string]attr.Value{
+					"custom_key": types.StringValue("value"),
+				}),
+			},
+			false,
+		),
+		Entry("reserved OCM property key -> error",
+			validator.MapRequest{
+				Path:           path.Root("properties"),
+				PathExpression: path.MatchRoot("properties"),
+				ConfigValue: types.MapValueMust(types.StringType, map[string]attr.Value{
+					PropertyRosaTfVersion: types.StringValue("override"),
+				}),
+			},
+			true,
+		),
+		Entry("null map -> ok",
+			validator.MapRequest{
+				Path:           path.Root("properties"),
+				PathExpression: path.MatchRoot("properties"),
+				ConfigValue:    types.MapNull(types.StringType),
+			},
+			false,
+		),
+		Entry("unknown map -> ok",
+			validator.MapRequest{
+				Path:           path.Root("properties"),
+				PathExpression: path.MatchRoot("properties"),
+				ConfigValue:    types.MapUnknown(types.StringType),
+			},
+			false,
+		),
+	)
+})
+
+func buildCloudRegionConfig(region string) tfsdk.Config {
+	regionVal, _ := types.StringValue(region).ToTerraformValue(context.Background())
+	return tfsdk.Config{
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"cloud_region": schema.StringAttribute{
+					Optional: true,
+				},
+			},
+		},
+		Raw: tftypes.NewValue(
+			tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"cloud_region": tftypes.String,
+				},
+			},
+			map[string]tftypes.Value{
+				"cloud_region": regionVal,
+			},
+		),
+	}
+}

--- a/provider/clusterrosa/hcp/shared_vpc/shared_vpc_test.go
+++ b/provider/clusterrosa/hcp/shared_vpc/shared_vpc_test.go
@@ -1,0 +1,119 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package sharedvpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/gomega"    // nolint
+)
+
+func TestSharedVpc(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shared VPC Suite")
+}
+
+var sharedVpcAttrTypes = map[string]attr.Type{
+	"ingress_private_hosted_zone_id":                types.StringType,
+	"internal_communication_private_hosted_zone_id": types.StringType,
+	"route53_role_arn":                              types.StringType,
+	"vpce_role_arn":                                 types.StringType,
+}
+
+func validSharedVpcValues() map[string]attr.Value {
+	return map[string]attr.Value{
+		"ingress_private_hosted_zone_id":                types.StringValue("Z05646003S02O1ENCDCSN"),
+		"internal_communication_private_hosted_zone_id": types.StringValue("Z05646003S02O1ENCDCSN"),
+		"route53_role_arn":                              types.StringValue("arn:aws:iam::123456789012:role/route53"),
+		"vpce_role_arn":                                 types.StringValue("arn:aws:iam::123456789012:role/vpce"),
+	}
+}
+
+var _ = Describe("HCP shared VPC validator", func() {
+	DescribeTable("should validate correctly",
+		func(request validator.ObjectRequest, expectedErr bool) {
+			response := validator.ObjectResponse{}
+			HcpSharedVpcValidator.ValidateObject(context.Background(), request, &response)
+			Expect(response.Diagnostics.HasError()).To(Equal(expectedErr))
+		},
+		Entry("all attributes set -> ok",
+			validator.ObjectRequest{
+				Path:           path.Root("shared_vpc"),
+				PathExpression: path.MatchRoot("shared_vpc"),
+				ConfigValue:    types.ObjectValueMust(sharedVpcAttrTypes, validSharedVpcValues()),
+			},
+			false,
+		),
+		Entry("empty ingress_private_hosted_zone_id -> error",
+			validator.ObjectRequest{
+				Path:           path.Root("shared_vpc"),
+				PathExpression: path.MatchRoot("shared_vpc"),
+				ConfigValue: func() types.Object {
+					values := validSharedVpcValues()
+					values["ingress_private_hosted_zone_id"] = types.StringValue("")
+					return types.ObjectValueMust(sharedVpcAttrTypes, values)
+				}(),
+			},
+			true,
+		),
+		Entry("empty internal_communication_private_hosted_zone_id -> error",
+			validator.ObjectRequest{
+				Path:           path.Root("shared_vpc"),
+				PathExpression: path.MatchRoot("shared_vpc"),
+				ConfigValue: func() types.Object {
+					values := validSharedVpcValues()
+					values["internal_communication_private_hosted_zone_id"] = types.StringValue("")
+					return types.ObjectValueMust(sharedVpcAttrTypes, values)
+				}(),
+			},
+			true,
+		),
+		Entry("empty route53_role_arn -> error",
+			validator.ObjectRequest{
+				Path:           path.Root("shared_vpc"),
+				PathExpression: path.MatchRoot("shared_vpc"),
+				ConfigValue: func() types.Object {
+					values := validSharedVpcValues()
+					values["route53_role_arn"] = types.StringValue("")
+					return types.ObjectValueMust(sharedVpcAttrTypes, values)
+				}(),
+			},
+			true,
+		),
+		Entry("empty vpce_role_arn -> error",
+			validator.ObjectRequest{
+				Path:           path.Root("shared_vpc"),
+				PathExpression: path.MatchRoot("shared_vpc"),
+				ConfigValue: func() types.Object {
+					values := validSharedVpcValues()
+					values["vpce_role_arn"] = types.StringValue("")
+					return types.ObjectValueMust(sharedVpcAttrTypes, values)
+				}(),
+			},
+			true,
+		),
+		Entry("null object -> ok",
+			validator.ObjectRequest{
+				Path:           path.Root("shared_vpc"),
+				PathExpression: path.MatchRoot("shared_vpc"),
+				ConfigValue:    types.ObjectNull(sharedVpcAttrTypes),
+			},
+			false,
+		),
+		Entry("unknown object -> ok",
+			validator.ObjectRequest{
+				Path:           path.Root("shared_vpc"),
+				PathExpression: path.MatchRoot("shared_vpc"),
+				ConfigValue:    types.ObjectUnknown(sharedVpcAttrTypes),
+			},
+			false,
+		),
+	)
+})


### PR DESCRIPTION
## PR Summary

Add unit tests for domain validators in `provider/clusterrosa/common` and `provider/clusterrosa/hcp/shared_vpc`. **PR 2 of 6** in the [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113) unit-test coverage series.

### Planned follow-up PRs
1. `provider/common/attrvalidators` — merged ([#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212))
2. `provider/clusterrosa/common` + `hcp/shared_vpc` — domain validators — **this PR**
3. `provider/common` (root) — helpers and HTPasswd validators
4. `provider/clusterrosa/hcp` — untested `validate*` / small pure funcs
5. `provider/clusterrosa/classic` — validators only (not CRUD)
6. `provider/proxy` — `Contains` (optional, if still uncovered)

## Detailed Description of the Issue

`provider/clusterrosa/common/validators.go` and `provider/clusterrosa/hcp/shared_vpc/shared_vpc.go` define schema validators used by ROSA Classic and HCP resources, but only `UserArnRE` in `consts_test.go` had unit tests in `clusterrosa/common`. `HcpSharedVpcValidator` had no tests.

## Related Issues and PRs
- Jira: [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113)
- Related PR(s): [#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212) (PR 1 of series); part 2 of 6 (`ROSAENG-60113-unit-tests-2`).

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

No unit tests covered `AvailabilityZoneValidator`, `PrivateHZValidator`, `PropertiesValidator`, or `HcpSharedVpcValidator`.

## Behavior After This Change

Table-driven Ginkgo unit tests validate success and failure paths (including null/unknown) for each validator. No production code changes.

## How to Test (Step-by-Step)

### Preconditions
- Go toolchain and repo dependencies installed.

### Test Steps
1. `go test ./provider/clusterrosa/common/... ./provider/clusterrosa/hcp/shared_vpc/...`
2. `make pre-push-checks`

### Expected Results
- All specs pass for both packages.
- Pre-push checks pass.

## Proof of the Fix
- Logs/CLI output: local `make pre-push-checks` (9/9 passed) and CodeRabbit local review (0 findings).

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [x] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [x] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for validator inputs covering availability zone rules, private hosted zone field requirements, and property key acceptance/rejection, including checks for expected diagnostic errors and handling of null/unknown cases.
  * Added a shared VPC validation test suite to verify required attributes error when empty and pass with fully populated values, including acceptance of null/unknown objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->