### PR TITLE
ROSAENG-60521 | test(subsystem): add empty-version automatic upgrade coverage and docs

### DIFF
--- a/docs/guides/upgrading-classic-cluster.md
+++ b/docs/guides/upgrading-classic-cluster.md
@@ -31,6 +31,10 @@ To upgrade your ROSA cluster to another version, upgrade your account roles and 
         ```
 4. Run `terraform apply` to upgrade your cluster.
 
+## Coexistence with OCM automatic upgrade schedules
+
+You can configure recurring automatic cluster upgrade schedules in OCM (no pinned target version). On Classic, cluster upgrade policies upgrade the control plane and machine pools together. The provider does not manage those automatic OCM upgrade policies. When you change `version` in Terraform, the provider schedules a manual cluster upgrade to that version. Automatic schedules remain active and do not block `terraform apply`. Pending manual upgrade policies that do not match the Terraform `version` may be removed during apply.
+
 ## OpenShift documentation
 
  - [Upgrading ROSA Classic clusters with STS](https://docs.openshift.com/rosa/upgrading/rosa-upgrading-sts.html)

--- a/docs/guides/upgrading-hcp-cluster.md
+++ b/docs/guides/upgrading-hcp-cluster.md
@@ -33,6 +33,10 @@ To upgrade your ROSA cluster to another version, export the following variables,
         ```
 3. Run `terraform apply` to upgrade your cluster or machine pool.
 
+## Coexistence with OCM automatic upgrade schedules
+
+You can configure recurring automatic control-plane upgrades in OCM (no pinned target version). The provider does not manage those policies. When you change `version` in Terraform, the provider schedules a manual upgrade to that version. Automatic schedules remain active and do not block `terraform apply`. Pending manual upgrade policies that do not match the Terraform `version` may be removed during apply.
+
 ## OpenShift documentation
 
  - [Upgrading ROSA HCP clusters](https://docs.openshift.com/rosa/upgrading/rosa-hcp-upgrading.html)

--- a/subsystem/classic/cluster_resource_rosa_upgrade_test.go
+++ b/subsystem/classic/cluster_resource_rosa_upgrade_test.go
@@ -19,6 +19,7 @@ package classic
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"             // nolint
 	. "github.com/onsi/gomega"                         // nolint
@@ -663,6 +664,320 @@ var _ = Describe("rhcs_cluster_rosa_classic - upgrade", func() {
 		}`)
 			runOutput := Terraform.Apply()
 			Expect(runOutput.ExitCode).To(BeZero())
+		})
+
+		It("Ignores recurring automatic upgrade policy with no pinned version", func() {
+			// Subsystem coverage for #1215 / #1186 (mirrored in hcp/cluster_resource_test.go):
+			// OCM recurring automatic policies may have an empty version; apply must succeed without
+			// semver-parsing or cancelling policy 789.
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithJSON(http.StatusOK, template),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies"),
+					RespondWithJSON(http.StatusOK, `{
+					"kind": "UpgradePolicyList",
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [
+						{
+							"kind": "UpgradePolicy",
+							"id": "789",
+							"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/789",
+							"schedule_type": "automatic",
+							"upgrade_type": "OSD",
+							"version": "",
+							"next_run": "2023-06-09T20:59:00Z",
+							"cluster_id": "123",
+							"enable_minor_version_upgrades": true
+						}
+					]
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/789/state"),
+					RespondWithJSON(http.StatusOK, `{
+					"kind": "UpgradePolicyState",
+					"id": "789",
+					"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/789/state",
+					"description": "",
+					"value": "scheduled"
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithJSON(http.StatusOK, template),
+				),
+			)
+			Terraform.Source(`
+		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+			name           = "my-cluster"
+			cloud_region   = "us-west-1"
+			aws_account_id = "123456789012"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+			version = "4.10.0"
+		}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			for _, req := range TestServer.ReceivedRequests() {
+				Expect(req.Method == http.MethodDelete && strings.Contains(req.URL.Path, "upgrade_policies/789")).To(BeFalse(),
+					"automatic recurring upgrade policy must not be cancelled")
+			}
+		})
+
+		It("Schedules manual upgrade while ignoring recurring automatic policy with no pinned version", func() {
+			// When Terraform requests a new version, the provider schedules a manual upgrade while
+			// leaving the empty-version automatic policy (789) untouched.
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithJSON(http.StatusOK, template),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithJSON(http.StatusOK, template),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions/openshift-v4.10.1"),
+					RespondWithJSON(http.StatusOK, v4_10_1Info),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies"),
+					RespondWithJSON(http.StatusOK, `{
+					"kind": "UpgradePolicyList",
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [
+						{
+							"kind": "UpgradePolicy",
+							"id": "789",
+							"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/789",
+							"schedule_type": "automatic",
+							"upgrade_type": "OSD",
+							"version": "",
+							"next_run": "2023-06-09T20:59:00Z",
+							"cluster_id": "123",
+							"enable_minor_version_upgrades": true
+						}
+					]
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/789/state"),
+					RespondWithJSON(http.StatusOK, `{
+					"kind": "UpgradePolicyState",
+					"id": "789",
+					"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/789/state",
+					"description": "",
+					"value": "scheduled"
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies", "dryRun=true"),
+					VerifyJQ(".version", "4.10.1"),
+					RespondWithJSON(http.StatusNoContent, ""),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies"),
+					VerifyJQ(".version", "4.10.1"),
+					RespondWithJSON(http.StatusCreated, `
+				{
+					"kind": "UpgradePolicy",
+					"id": "123",
+					"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/123",
+					"schedule_type": "manual",
+					"upgrade_type": "OSD",
+					"version": "4.10.1",
+					"next_run": "2023-06-09T20:59:00Z",
+					"cluster_id": "123",
+					"enable_minor_version_upgrades": true
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/properties",
+					  "value": {
+						"rosa_tf_commit": "123",
+						"rosa_tf_version": "123"
+					  }
+					}
+				]`),
+				),
+			)
+			Terraform.Source(`
+		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+			name           = "my-cluster"
+			cloud_region   = "us-west-1"
+			aws_account_id = "123456789012"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+			version = "4.10.1"
+		}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			for _, req := range TestServer.ReceivedRequests() {
+				Expect(req.Method == http.MethodDelete && strings.Contains(req.URL.Path, "upgrade_policies/789")).To(BeFalse(),
+					"automatic recurring upgrade policy must not be cancelled")
+			}
+		})
+
+		It("Deletes stale manual upgrade policy but leaves automatic empty-version policy", func() {
+			// Combined scenario: OCM returns both an automatic empty-version policy and a stale
+			// manual pinned policy; only the manual one should be deleted during apply.
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithJSON(http.StatusOK, template),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithJSON(http.StatusOK, template),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions/openshift-v4.10.1"),
+					RespondWithJSON(http.StatusOK, v4_10_1Info),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies"),
+					RespondWithJSON(http.StatusOK, `{
+					"kind": "UpgradePolicyList",
+					"page": 1,
+					"size": 2,
+					"total": 2,
+					"items": [
+						{
+							"kind": "UpgradePolicy",
+							"id": "789",
+							"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/789",
+							"schedule_type": "automatic",
+							"upgrade_type": "OSD",
+							"version": "",
+							"next_run": "2023-06-09T20:59:00Z",
+							"cluster_id": "123",
+							"enable_minor_version_upgrades": true
+						},
+						{
+							"kind": "UpgradePolicy",
+							"id": "456",
+							"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/456",
+							"schedule_type": "manual",
+							"upgrade_type": "OSD",
+							"version": "4.10.0",
+							"next_run": "2023-06-09T20:59:00Z",
+							"cluster_id": "123",
+							"enable_minor_version_upgrades": true
+						}
+					]
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/789/state"),
+					RespondWithJSON(http.StatusOK, `{
+					"kind": "UpgradePolicyState",
+					"id": "789",
+					"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/789/state",
+					"description": "",
+					"value": "scheduled"
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/456/state"),
+					RespondWithJSON(http.StatusOK, `{
+					"kind": "UpgradePolicyState",
+					"id": "456",
+					"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/456/state",
+					"description": "",
+					"value": "scheduled"
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/456"),
+					RespondWithJSON(http.StatusOK, "{}"),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies", "dryRun=true"),
+					VerifyJQ(".version", "4.10.1"),
+					RespondWithJSON(http.StatusNoContent, ""),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/123/upgrade_policies"),
+					VerifyJQ(".version", "4.10.1"),
+					RespondWithJSON(http.StatusCreated, `
+				{
+					"kind": "UpgradePolicy",
+					"id": "123",
+					"href": "/api/clusters_mgmt/v1/clusters/123/upgrade_policies/123",
+					"schedule_type": "manual",
+					"upgrade_type": "OSD",
+					"version": "4.10.1",
+					"next_run": "2023-06-09T20:59:00Z",
+					"cluster_id": "123",
+					"enable_minor_version_upgrades": true
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/123"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/properties",
+					  "value": {
+						"rosa_tf_commit": "123",
+						"rosa_tf_version": "123"
+					  }
+					}
+				]`),
+				),
+			)
+			Terraform.Source(`
+		  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+			name           = "my-cluster"
+			cloud_region   = "us-west-1"
+			aws_account_id = "123456789012"
+			sts = {
+				operator_role_prefix = "test"
+				role_arn = "",
+				support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+			version = "4.10.1"
+		}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			deletedManual := false
+			for _, req := range TestServer.ReceivedRequests() {
+				if req.Method == http.MethodDelete && strings.Contains(req.URL.Path, "upgrade_policies/456") {
+					deletedManual = true
+				}
+				Expect(req.Method == http.MethodDelete && strings.Contains(req.URL.Path, "upgrade_policies/789")).To(BeFalse(),
+					"automatic recurring upgrade policy must not be cancelled")
+			}
+			Expect(deletedManual).To(BeTrue(), "stale manual upgrade policy must be cancelled")
 		})
 
 		It("Cancels upgrade if version=current_version", func() {

--- a/subsystem/hcp/cluster_resource_test.go
+++ b/subsystem/hcp/cluster_resource_test.go
@@ -6305,6 +6305,423 @@ var _ = Describe("HCP Cluster", func() {
 			Expect(runOutput.ExitCode).To(BeZero())
 		})
 
+		It("Ignores recurring automatic upgrade policy with no pinned version", func() {
+			// Subsystem coverage for #1215 / #1186 (mirrored in classic/cluster_resource_rosa_upgrade_test.go):
+			// OCM recurring automatic policies may have an empty version; apply must succeed without
+			// semver-parsing or cancelling policy 789.
+			TestServer.AppendHandlers(
+				// Refresh cluster state
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithJSON(http.StatusOK, template),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route+"/control_plane/upgrade_policies"),
+					RespondWithJSON(http.StatusOK, `{
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [
+						{
+							"id": "789",
+							"schedule_type": "automatic",
+							"upgrade_type": "ControlPlane",
+							"version": "",
+							"next_run": "2023-06-09T20:59:00Z",
+							"cluster_id": "123",
+							"enable_minor_version_upgrades": true
+						}
+					]
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route+"/control_plane/upgrade_policies/789"),
+					RespondWithJSON(http.StatusOK, `{
+						"id": "789",
+						"schedule_type": "automatic",
+						"upgrade_type": "ControlPlane",
+						"version": "",
+						"state": {
+							"description": "",
+							"value": "scheduled"
+						}
+					}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithJSON(http.StatusOK, template),
+				),
+			)
+			Terraform.Source(`
+			resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+				name           = "my-cluster"
+				cloud_region   = "us-west-1"
+				aws_account_id = "123456789012"
+				aws_billing_account_id = "123456789012"
+				sts = {
+					operator_role_prefix = "test"
+					role_arn = ""
+					support_role_arn = ""
+					instance_iam_roles = {
+						worker_role_arn = ""
+					}
+				}
+				aws_subnet_ids = [
+					"id1", "id2", "id3"
+				]
+				availability_zones = [
+					"us-west-1a",
+					"us-west-1b",
+					"us-west-1c",
+				]
+				version = "4.14.0"
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			for _, req := range TestServer.ReceivedRequests() {
+				Expect(req.Method == http.MethodDelete && strings.Contains(req.URL.Path, "upgrade_policies/789")).To(BeFalse(),
+					"automatic recurring upgrade policy must not be cancelled")
+			}
+		})
+
+		It("Schedules manual upgrade while ignoring recurring automatic policy with no pinned version", func() {
+			// When Terraform requests a new version, the provider schedules a manual upgrade while
+			// leaving the empty-version automatic policy (789) untouched.
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `
+					[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_tf_commit": "",
+								"rosa_tf_version": ""
+							}
+						}
+					]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `
+					[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_tf_commit": "",
+								"rosa_tf_version": ""
+							}
+						}
+					]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions/openshift-v4.14.1"),
+					RespondWithJSON(http.StatusOK, v4141Info),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route+"/control_plane/upgrade_policies"),
+					RespondWithJSON(http.StatusOK, `{
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [
+						{
+							"id": "789",
+							"schedule_type": "automatic",
+							"upgrade_type": "ControlPlane",
+							"version": "",
+							"next_run": "2023-06-09T20:59:00Z",
+							"cluster_id": "123",
+							"enable_minor_version_upgrades": true
+						}
+					]
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route+"/control_plane/upgrade_policies/789"),
+					RespondWithJSON(http.StatusOK, `{
+						"id": "789",
+						"schedule_type": "automatic",
+						"upgrade_type": "ControlPlane",
+						"version": "",
+						"state": {
+							"description": "",
+							"value": "scheduled"
+						}
+					}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, cluster123Route+"/control_plane/upgrade_policies", "dryRun=true"),
+					VerifyJQ(".version", "4.14.1"),
+					RespondWithJSON(http.StatusNoContent, ""),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, cluster123Route+"/control_plane/upgrade_policies"),
+					VerifyJQ(".version", "4.14.1"),
+					RespondWithJSON(http.StatusCreated, `{
+						"id": "123",
+						"schedule_type": "manual",
+						"upgrade_type": "ControlPlane",
+						"version": "4.14.1",
+						"next_run": "2023-06-09T20:59:00Z",
+						"cluster_id": "123",
+						"enable_minor_version_upgrades": true
+					}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithJSON(http.StatusOK, template),
+				),
+			)
+			Terraform.Source(`
+			resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+				name           = "my-cluster"
+				cloud_region   = "us-west-1"
+				aws_account_id = "123456789012"
+				aws_billing_account_id = "123456789012"
+				sts = {
+					operator_role_prefix = "test"
+					role_arn = ""
+					support_role_arn = ""
+					instance_iam_roles = {
+						worker_role_arn = ""
+					}
+				}
+				aws_subnet_ids = [
+					"id1", "id2", "id3"
+				]
+				availability_zones = [
+					"us-west-1a",
+					"us-west-1b",
+					"us-west-1c",
+				]
+				version = "4.14.1"
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			for _, req := range TestServer.ReceivedRequests() {
+				Expect(req.Method == http.MethodDelete && strings.Contains(req.URL.Path, "upgrade_policies/789")).To(BeFalse(),
+					"automatic recurring upgrade policy must not be cancelled")
+			}
+		})
+
+		It("Deletes stale manual upgrade policy but leaves automatic empty-version policy", func() {
+			// Combined scenario: OCM returns both an automatic empty-version policy and a stale
+			// manual pinned policy; only the manual one should be deleted during apply.
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `
+					[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_tf_commit": "",
+								"rosa_tf_version": ""
+							}
+						}
+					]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `
+					[
+						{
+							"op": "add",
+							"path": "/aws",
+							"value": {
+								"sts" : {
+									"oidc_endpoint_url": "https://127.0.0.1",
+									"thumbprint": "111111",
+									"role_arn": "",
+									"support_role_arn": "",
+									"instance_iam_roles" : {
+										"worker_role_arn" : ""
+									},
+									"operator_role_prefix" : "test"
+								}
+							}
+						},
+						{
+							"op": "add",
+							"path": "/properties",
+							"value": {
+								"rosa_tf_commit": "",
+								"rosa_tf_version": ""
+							}
+						}
+					]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions/openshift-v4.14.1"),
+					RespondWithJSON(http.StatusOK, v4141Info),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route+"/control_plane/upgrade_policies"),
+					RespondWithJSON(http.StatusOK, `{
+					"page": 1,
+					"size": 2,
+					"total": 2,
+					"items": [
+						{
+							"id": "789",
+							"schedule_type": "automatic",
+							"upgrade_type": "ControlPlane",
+							"version": "",
+							"next_run": "2023-06-09T20:59:00Z",
+							"cluster_id": "123",
+							"enable_minor_version_upgrades": true
+						},
+						{
+							"id": "456",
+							"schedule_type": "manual",
+							"upgrade_type": "ControlPlane",
+							"version": "4.14.0",
+							"next_run": "2023-06-09T20:59:00Z",
+							"cluster_id": "123",
+							"enable_minor_version_upgrades": true
+						}
+					]
+				}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route+"/control_plane/upgrade_policies/789"),
+					RespondWithJSON(http.StatusOK, `{
+						"id": "789",
+						"schedule_type": "automatic",
+						"upgrade_type": "ControlPlane",
+						"version": "",
+						"state": {
+							"description": "",
+							"value": "scheduled"
+						}
+					}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route+"/control_plane/upgrade_policies/456"),
+					RespondWithJSON(http.StatusOK, `{
+						"id": "456",
+						"state": {
+							"description": "",
+							"value": "scheduled"
+						}
+					}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodDelete, cluster123Route+"/control_plane/upgrade_policies/456"),
+					RespondWithJSON(http.StatusOK, "{}"),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, cluster123Route+"/control_plane/upgrade_policies", "dryRun=true"),
+					VerifyJQ(".version", "4.14.1"),
+					RespondWithJSON(http.StatusNoContent, ""),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, cluster123Route+"/control_plane/upgrade_policies"),
+					VerifyJQ(".version", "4.14.1"),
+					RespondWithJSON(http.StatusCreated, `{
+						"id": "123",
+						"schedule_type": "manual",
+						"upgrade_type": "ControlPlane",
+						"version": "4.14.1",
+						"next_run": "2023-06-09T20:59:00Z",
+						"cluster_id": "123",
+						"enable_minor_version_upgrades": true
+					}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithJSON(http.StatusOK, template),
+				),
+			)
+			Terraform.Source(`
+			resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+				name           = "my-cluster"
+				cloud_region   = "us-west-1"
+				aws_account_id = "123456789012"
+				aws_billing_account_id = "123456789012"
+				sts = {
+					operator_role_prefix = "test"
+					role_arn = ""
+					support_role_arn = ""
+					instance_iam_roles = {
+						worker_role_arn = ""
+					}
+				}
+				aws_subnet_ids = [
+					"id1", "id2", "id3"
+				]
+				availability_zones = [
+					"us-west-1a",
+					"us-west-1b",
+					"us-west-1c",
+				]
+				version = "4.14.1"
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			deletedManual := false
+			for _, req := range TestServer.ReceivedRequests() {
+				if req.Method == http.MethodDelete && strings.Contains(req.URL.Path, "upgrade_policies/456") {
+					deletedManual = true
+				}
+				Expect(req.Method == http.MethodDelete && strings.Contains(req.URL.Path, "upgrade_policies/789")).To(BeFalse(),
+					"automatic recurring upgrade policy must not be cancelled")
+			}
+			Expect(deletedManual).To(BeTrue(), "stale manual upgrade policy must be cancelled")
+		})
+
 		It("Cancels upgrade if version=current_version", func() {
 			TestServer.AppendHandlers(
 				// Refresh cluster state

--- a/templates/guides/upgrading-classic-cluster.md.tmpl
+++ b/templates/guides/upgrading-classic-cluster.md.tmpl
@@ -31,6 +31,10 @@ To upgrade your ROSA cluster to another version, upgrade your account roles and 
         ```
 4. Run `terraform apply` to upgrade your cluster.
 
+## Coexistence with OCM automatic upgrade schedules
+
+You can configure recurring automatic cluster upgrade schedules in OCM (no pinned target version). On Classic, cluster upgrade policies upgrade the control plane and machine pools together. The provider does not manage those automatic OCM upgrade policies. When you change `version` in Terraform, the provider schedules a manual cluster upgrade to that version. Automatic schedules remain active and do not block `terraform apply`. Pending manual upgrade policies that do not match the Terraform `version` may be removed during apply.
+
 ## OpenShift documentation
 
  - [Upgrading ROSA Classic clusters with STS](https://docs.openshift.com/rosa/upgrading/rosa-upgrading-sts.html)

--- a/templates/guides/upgrading-hcp-cluster.md.tmpl
+++ b/templates/guides/upgrading-hcp-cluster.md.tmpl
@@ -33,6 +33,10 @@ To upgrade your ROSA cluster to another version, export the following variables,
         ```
 3. Run `terraform apply` to upgrade your cluster or machine pool.
 
+## Coexistence with OCM automatic upgrade schedules
+
+You can configure recurring automatic control-plane upgrades in OCM (no pinned target version). The provider does not manage those policies. When you change `version` in Terraform, the provider schedules a manual upgrade to that version. Automatic schedules remain active and do not block `terraform apply`. Pending manual upgrade policies that do not match the Terraform `version` may be removed during apply.
+
 ## OpenShift documentation
 
  - [Upgrading ROSA HCP clusters](https://docs.openshift.com/rosa/upgrading/rosa-hcp-upgrading.html)


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary
Add subsystem tests and upgrade guide documentation for OCM recurring automatic upgrade policies that have no pinned target version (follow-up to #1213).

## Detailed Description of the Issue
PR #1213 fixed `CheckAndCancelUpgrades` so recurring OCM upgrade policies with an empty `version` are skipped instead of failing semver parsing during `terraform apply`. Unit tests cover the helper logic; CodeRabbit follow-ups #1214 and #1215 requested subsystem coverage and operator-facing documentation for coexistence with OCM automatic schedules.

## Related Issues and PRs
- Jira: [ROSAENG-60521](https://redhat.atlassian.net/browse/ROSAENG-60521)
- Fixes: `#1214`, `#1215`
- Related PR(s): #1213
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
The empty-version automatic upgrade policy fix shipped in #1213 with unit tests only. Upgrade guides did not explain how Terraform-managed upgrades coexist with OCM recurring automatic schedules.

## Behavior After This Change
No provider logic changes. Subsystem tests assert `terraform apply` succeeds when OCM returns an automatic upgrade policy with an empty `version`, does not DELETE that policy, and still schedules a manual upgrade when Terraform `version` changes. Upgrade guides document coexistence expectations for HCP and Classic clusters.

## How to Test (Step-by-Step)
### Preconditions
- Clone with hooks installed; provider build available for subsystem tests.

### Test Steps
1. Run `make fmt` and confirm no diff.
2. Run focused subsystem tests:
   ```bash
   go run github.com/onsi/ginkgo/v2/ginkgo run --succinct -focus "recurring automatic" subsystem/hcp subsystem/classic
   ```
3. Run `make pre-push-checks`.

### Expected Results
All commands pass. Four new subsystem specs pass (two HCP, two Classic). Generated upgrade guide docs include the "Coexistence with OCM automatic upgrade schedules" section.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: `make pre-push-checks` passed locally (9/9). CodeRabbit local review (`coderabbit review --agent -t uncommitted`) reported 0 findings before commit.
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [ ] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [x] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on coexistence with OCM recurring automatic upgrade schedules for both Classic and HCP clusters.
  * Clarified that these schedules have no pinned target version, remain active during `terraform apply`, and that changing `version` triggers a manual upgrade; mismatched pending manual upgrade policies may be removed.
* **Bug Fixes**
  * Improved upgrade workflows to ignore/leave untouched recurring automatic policies with an empty version (no cancellation).
* **Tests**
  * Expanded upgrade test coverage for empty-version recurring automatic policies and manual upgrade scheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->