### PR TITLE
ROSAENG-60521 | ci: Fix id:65961,id:88409 day1-negative e2e regressions

### DIFF
--- a/tests/e2e/negative_day_one_test.go
+++ b/tests/e2e/negative_day_one_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 				By("Edit cluster admin user name to not valid")
 				validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {
 					(*args.AdminCredentials)["username"] = "one:two"
-				}, "Attribute admin_credentials.username username may not contain the characters: '/:%!'")
+				}, "Attribute admin_credentials.username username may not contain the characters: '/:%'")
 
 				By("Edit cluster admin user name to empty")
 				validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -64,9 +64,9 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   sts                                             = local.sts_roles
   replicas                                        = var.replicas
   proxy                                           = var.proxy
-  autoscaling_enabled                             = var.autoscaling.autoscaling_enabled
-  min_replicas                                    = var.autoscaling.min_replicas
-  max_replicas                                    = var.autoscaling.max_replicas
+  autoscaling_enabled                             = var.autoscaling_enabled
+  min_replicas                                    = var.min_replicas
+  max_replicas                                    = var.max_replicas
   ec2_metadata_http_tokens                        = var.ec2_metadata_http_tokens
   aws_private_link                                = var.private_link
   private                                         = var.private

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -38,15 +38,19 @@ variable "product" {
   default = "rosa"
 }
 
-variable "autoscaling" {
-  type = object({
-    autoscaling_enabled = bool
-    min_replicas        = optional(number)
-    max_replicas        = optional(number)
-  })
-  default = {
-    autoscaling_enabled = false
-  }
+variable "autoscaling_enabled" {
+  type    = bool
+  default = null
+}
+
+variable "min_replicas" {
+  type    = number
+  default = null
+}
+
+variable "max_replicas" {
+  type    = number
+  default = null
 }
 
 variable "ec2_metadata_http_tokens" {


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.
-->

## PR Summary

Fix recurring failures in `periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-sts-advanced-day1-negative` caused by [OCM-20157](https://redhat.atlassian.net/browse/OCM-20157) e2e harness regressions, not provider autoscaling validation changes.

## Detailed Description of the Issue

Since 2026-04-01, the `rosa-sts-advanced-day1-negative` job has failed weekly on two cases in `negative_day_one_test.go`:

- **`id:65961`** — admin username negative test expected error substring `'/:%!'`, but `HTPasswdUsernameValidators` reports `'/:%'`. The test started running after [OCM-20157](https://redhat.atlassian.net/browse/OCM-20157) fixed `IsAdminEnabled()` to use `admin_enabled` instead of the autoscaling profile flag.
- **`id:88409`** — autoscaling negative test wrote flat `autoscaling_enabled` / `min_replicas` / `max_replicas` tfvars (via `ClusterArgs`), but the classic cluster manifest still consumed a nested `autoscaling` object. Terraform ignored the undeclared top-level keys, applied a valid `autoscaling_enabled=false` + `replicas=3` config, and the test timed out creating a cluster instead of failing fast at validation.

Provider `CreateNodes` autoscaling conflict checks were unchanged.

## Related Issues and PRs

- Jira: [ROSAENG-60521](https://issues.redhat.com/browse/ROSAENG-60521)
- Introduced by: [OCM-20157](https://redhat.atlassian.net/browse/OCM-20157) (`14496302`)
- Failing job example: [Prow #2071483404276207616](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-sts-advanced-day1-negative-f7/2071483404276207616)

## Type of Change

- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- `id:65961` failed on substring mismatch (`'/:%!'` vs `'/:%'`).
- `id:88409` first sub-case (`autoscaling_enabled=true` + `replicas=3`) did not reach provider validation on classic profiles; apply succeeded and ran for ~60 minutes.

## Behavior After This Change

- Classic cluster e2e manifest accepts flat autoscaling tfvars matching `ClusterArgs` and HCP manifest wiring.
- `id:65961` expects the provider's actual username validation message.
- Negative autoscaling cases fail fast at plan/apply with the expected provider errors.

## How to Test (Step-by-Step)

### Preconditions

- RHCS e2e environment with `rosa-sts-ad` profile (or run the periodic job).

### Test Steps

1. Run day1-negative e2e filter against classic STS advanced profile.
2. Confirm `validate user name policy - [id:65961]` passes on the invalid username sub-case.
3. Confirm `validate autoscaling setting - [id:88409]` fails fast on `autoscaling_enabled=true` + `replicas=3` without creating a cluster.

### Expected Results

- Both cases pass without multi-hour cluster create attempts.

## Proof of the Fix

- Logs/CLI output: [Prow failure analysis](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-sts-advanced-day1-negative-f7/2071483404276207616)
- Local: `make pre-push-checks` passed on this branch.

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)

- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cluster validation expectations for the admin username policy to match the current allowed/disallowed character rules.
* **Chores**
  * Simplified autoscaling configuration inputs for cluster setup, making the settings easier to provide and align across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->