### PR TITLE
ROSAENG-60885 | ci: Fix id:88409,id:72453 e2e regressions and add autoscaling subsystem coverage

### DIFF
--- a/subsystem/classic/cluster_resource_rosa_create_test.go
+++ b/subsystem/classic/cluster_resource_rosa_create_test.go
@@ -2039,6 +2039,106 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 			runOutput.VerifyErrorContainsSubstring("Invalid root disk size")
 		})
 
+		Context("Autoscaling conflict tests", func() {
+			It("Fails when autoscaling is enabled but replicas is also set", func() {
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+						RespondWithJSON(http.StatusOK, versionListPage1),
+					),
+				)
+
+				Terraform.Source(`
+			  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+				name           = "my-cluster"
+				cloud_region   = "us-west-1"
+				aws_account_id = "123456789012"
+				sts = {
+					operator_role_prefix = "test"
+					role_arn = "",
+					support_role_arn = "",
+					instance_iam_roles = {
+						master_role_arn = "",
+						worker_role_arn = "",
+					}
+				}
+				autoscaling_enabled = true
+				min_replicas        = 2
+				max_replicas        = 6
+				replicas            = 3
+			  }
+			`)
+				runOutput := Terraform.Apply()
+				Expect(runOutput.ExitCode).ToNot(BeZero())
+				runOutput.VerifyErrorContainsSubstring("autoscaling is enabled")
+				runOutput.VerifyErrorContainsSubstring("replicas should not be configured")
+			})
+
+			It("Fails when autoscaling is disabled but min/max replicas are set", func() {
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+						RespondWithJSON(http.StatusOK, versionListPage1),
+					),
+				)
+
+				Terraform.Source(`
+			  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+				name           = "my-cluster"
+				cloud_region   = "us-west-1"
+				aws_account_id = "123456789012"
+				sts = {
+					operator_role_prefix = "test"
+					role_arn = "",
+					support_role_arn = "",
+					instance_iam_roles = {
+						master_role_arn = "",
+						worker_role_arn = "",
+					}
+				}
+				replicas     = 3
+				min_replicas = 2
+				max_replicas = 6
+			  }
+			`)
+				runOutput := Terraform.Apply()
+				Expect(runOutput.ExitCode).ToNot(BeZero())
+				runOutput.VerifyErrorContainsSubstring("Autoscaling must be enabled")
+			})
+
+			It("Fails when min_replicas is greater than max_replicas", func() {
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+						RespondWithJSON(http.StatusOK, versionListPage1),
+					),
+				)
+
+				Terraform.Source(`
+			  resource "rhcs_cluster_rosa_classic" "my_cluster" {
+				name           = "my-cluster"
+				cloud_region   = "us-west-1"
+				aws_account_id = "123456789012"
+				sts = {
+					operator_role_prefix = "test"
+					role_arn = "",
+					support_role_arn = "",
+					instance_iam_roles = {
+						master_role_arn = "",
+						worker_role_arn = "",
+					}
+				}
+				autoscaling_enabled = true
+				min_replicas        = 6
+				max_replicas        = 3
+			  }
+			`)
+				runOutput := Terraform.Apply()
+				Expect(runOutput.ExitCode).ToNot(BeZero())
+				runOutput.VerifyErrorContainsSubstring("greater or equal to min-replicas")
+			})
+		})
+
 		It("Creates basic cluster with properties", func() {
 			prop_key := "my_prop_key"
 			prop_val := "my_prop_val"

--- a/subsystem/hcp/cluster_resource_test.go
+++ b/subsystem/hcp/cluster_resource_test.go
@@ -8361,6 +8361,347 @@ var _ = Describe("HCP Cluster", func() {
 				runOutput.VerifyErrorContainsSubstring("max_replicas")
 				runOutput.VerifyErrorContainsSubstring("cannot be changed")
 			})
+
+			It("Fails when trying to change replicas", func() {
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+						RespondWithJSON(http.StatusOK, versionListPage),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+						RespondWithPatchedJSON(http.StatusCreated, template, `[
+						{
+						  "op": "add",
+						  "path": "/aws",
+						  "value": {
+							  "sts" : {
+								  "oidc_endpoint_url": "https://127.0.0.1",
+								  "thumbprint": "111111",
+								  "role_arn": "",
+								  "support_role_arn": "",
+								  "instance_iam_roles" : {
+									"worker_role_arn" : ""
+								  },
+								  "operator_role_prefix" : "test"
+							  }
+						  }
+						},
+						{
+						  "op": "replace",
+						  "path": "/nodes",
+						  "value": {
+							  "compute": 3,
+							  "availability_zones": ["us-west-1a", "us-west-1b", "us-west-1c"],
+							  "compute_machine_type": {
+								  "id": "r5.xlarge"
+							  }
+						  }
+						}]`),
+					),
+				)
+
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+					replicas = 3
+				}`)
+				runOutput := Terraform.Apply()
+				Expect(runOutput.ExitCode).To(BeZero())
+
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+						  "op": "replace",
+						  "path": "/nodes",
+						  "value": {
+							  "compute": 3,
+							  "availability_zones": ["us-west-1a", "us-west-1b", "us-west-1c"],
+							  "compute_machine_type": {
+								  "id": "r5.xlarge"
+							  }
+						  }
+						}]`),
+					),
+				)
+
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+					replicas = 5
+				}`)
+				runOutput = Terraform.Apply()
+				Expect(runOutput.ExitCode).NotTo(BeZero())
+				runOutput.VerifyErrorContainsSubstring("Attribute replicas, cannot be changed from")
+			})
+
+			It("Fails when trying to change compute_machine_type", func() {
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+						RespondWithJSON(http.StatusOK, versionListPage),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+						RespondWithPatchedJSON(http.StatusCreated, template, `[
+						{
+						  "op": "add",
+						  "path": "/aws",
+						  "value": {
+							  "sts" : {
+								  "oidc_endpoint_url": "https://127.0.0.1",
+								  "thumbprint": "111111",
+								  "role_arn": "",
+								  "support_role_arn": "",
+								  "instance_iam_roles" : {
+									"worker_role_arn" : ""
+								  },
+								  "operator_role_prefix" : "test"
+							  }
+						  }
+						},
+						{
+						  "op": "replace",
+						  "path": "/nodes",
+						  "value": {
+							  "compute": 3,
+							  "availability_zones": ["us-west-1a", "us-west-1b", "us-west-1c"],
+							  "compute_machine_type": {
+								  "id": "r5.xlarge"
+							  }
+						  }
+						}]`),
+					),
+				)
+
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					compute_machine_type = "r5.xlarge"
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+					replicas = 3
+				}`)
+				runOutput := Terraform.Apply()
+				Expect(runOutput.ExitCode).To(BeZero())
+
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+						  "op": "replace",
+						  "path": "/nodes",
+						  "value": {
+							  "compute": 3,
+							  "availability_zones": ["us-west-1a", "us-west-1b", "us-west-1c"],
+							  "compute_machine_type": {
+								  "id": "r5.xlarge"
+							  }
+						  }
+						}]`),
+					),
+				)
+
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					compute_machine_type = "m5.xlarge"
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+					replicas = 3
+				}`)
+				runOutput = Terraform.Apply()
+				Expect(runOutput.ExitCode).NotTo(BeZero())
+				runOutput.VerifyErrorContainsSubstring("Attribute compute_machine_type, cannot be changed from")
+			})
+
+			It("Fails when trying to set replicas below minimum on update", func() {
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+						RespondWithJSON(http.StatusOK, versionListPage),
+					),
+					CombineHandlers(
+						VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+						RespondWithPatchedJSON(http.StatusCreated, template, `[
+						{
+						  "op": "add",
+						  "path": "/aws",
+						  "value": {
+							  "sts" : {
+								  "oidc_endpoint_url": "https://127.0.0.1",
+								  "thumbprint": "111111",
+								  "role_arn": "",
+								  "support_role_arn": "",
+								  "instance_iam_roles" : {
+									"worker_role_arn" : ""
+								  },
+								  "operator_role_prefix" : "test"
+							  }
+						  }
+						},
+						{
+						  "op": "replace",
+						  "path": "/nodes",
+						  "value": {
+							  "compute": 3,
+							  "availability_zones": ["us-west-1a", "us-west-1b", "us-west-1c"],
+							  "compute_machine_type": {
+								  "id": "r5.xlarge"
+							  }
+						  }
+						}]`),
+					),
+				)
+
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+					replicas = 3
+				}`)
+				runOutput := Terraform.Apply()
+				Expect(runOutput.ExitCode).To(BeZero())
+
+				TestServer.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, cluster123Route),
+						RespondWithPatchedJSON(http.StatusOK, template, `[
+						{
+						  "op": "replace",
+						  "path": "/nodes",
+						  "value": {
+							  "compute": 3,
+							  "availability_zones": ["us-west-1a", "us-west-1b", "us-west-1c"],
+							  "compute_machine_type": {
+								  "id": "r5.xlarge"
+							  }
+						  }
+						}]`),
+					),
+				)
+
+				Terraform.Source(`
+				resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+					name           = "my-cluster"
+					cloud_region   = "us-west-1"
+					aws_account_id = "123456789012"
+					aws_billing_account_id = "123456789012"
+					sts = {
+						operator_role_prefix = "test"
+						role_arn = "",
+						support_role_arn = "",
+						instance_iam_roles = {
+							worker_role_arn = "",
+						}
+					}
+					aws_subnet_ids = [
+						"id1", "id2", "id3"
+					]
+					availability_zones = [
+						"us-west-1a",
+						"us-west-1b",
+						"us-west-1c",
+					]
+					replicas = 1
+				}`)
+				runOutput = Terraform.Apply()
+				Expect(runOutput.ExitCode).NotTo(BeZero())
+				runOutput.VerifyErrorContainsSubstring("Attribute replicas value must be at least 2")
+			})
 		})
 
 		Context("Conflict tests", func() {

--- a/tests/e2e/cluster_edit_test.go
+++ b/tests/e2e/cluster_edit_test.go
@@ -303,7 +303,7 @@ var _ = Describe("Edit cluster", ci.Day2, func() {
 			By("Try to edit with replicas < 2")
 			validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {
 				args.Replicas = helper.IntPointer(1)
-			}, "Attribute replicas, cannot be changed from")
+			}, "Attribute replicas value must be at least 2")
 		})
 
 		It("properties - [id:72455]", ci.Medium, ci.FeatureClusterMisc, func() {

--- a/tests/e2e/negative_day_one_test.go
+++ b/tests/e2e/negative_day_one_test.go
@@ -562,24 +562,28 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 				By("autoscaling_enable=true and set min_replicas greater than max_replicas")
 				validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {
 					args.Autoscaling = helper.BoolPointer(true)
+					args.Replicas = nil
 					args.MinReplicas = helper.IntPointer(6)
 					args.MaxReplicas = helper.IntPointer(3)
-				}, "must be less than or equal to")
+				}, "greater or equal to min-replicas")
 				By("min_relicas with negative value")
 				validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {
 					args.Autoscaling = helper.BoolPointer(true)
+					args.Replicas = nil
 					args.MinReplicas = helper.IntPointer(-3)
 					args.MaxReplicas = helper.IntPointer(3)
 				}, "value must be at least 0")
 				By("setting max_replicas to 0")
 				validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {
 					args.Autoscaling = helper.BoolPointer(true)
+					args.Replicas = nil
 					args.MinReplicas = helper.IntPointer(0)
 					args.MaxReplicas = helper.IntPointer(0)
 				}, "must be a integer greater than 0")
 				By("with a number not a multiple of 3")
 				validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {
 					args.Autoscaling = helper.BoolPointer(true)
+					args.Replicas = nil
 					args.MinReplicas = helper.IntPointer(3)
 					args.MaxReplicas = helper.IntPointer(7)
 				}, "require that the compute nodes be a multiple of the private subnets 3")

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -23,7 +23,7 @@ variable "aws_availability_zones" {
 
 variable "replicas" {
   type    = number
-  default = 3
+  default = null
 }
 
 variable "openshift_version" {


### PR DESCRIPTION
## PR Summary
Fix stale e2e assertions and harness setup for autoscaling (`id:88409`) and HCP cluster edit replicas (`id:72453`), and add matching classic/HCP subsystem coverage. No provider logic changes.

## Detailed Description of the Issue
Periodic jobs `e2e-rosa-sts-private-day1-negative-f7` and `e2e-rosa-hcp-private-medium-low-f7` failed because e2e tests did not match current provider validation behavior:

- **`id:88409`**: Autoscaling negative sub-cases inherited `replicas=3` from the profile while testing autoscaling-only scenarios, so the provider correctly returned `"When autoscaling is enabled, replicas should not be configured"` before min/max validation. The classic test manifest also defaulted `replicas = 3`, preventing omission via tfvars.
- **`id:72453`**: Setting `replicas = 1` on HCP cluster update fails schema validation (`value must be at least 2`) before the immutability check the test expected.

## Related Issues and PRs
- Jira: [ROSAENG-60885](https://issues.redhat.com/browse/ROSAENG-60885)
- Fixes: N/A
- Related PR(s): Complements #1225 (day1-negative manifest/username fixes)
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- E2e `[id:88409]` sub-cases 3–6 could fail with the wrong error when `replicas` leaked from profile/manifest defaults.
- E2e `[id:72453]` expected immutability error for `replicas = 1` instead of schema minimum validation.
- Classic cluster autoscaling create conflicts and HCP compute-field update validation were covered mainly by unit tests or e2e only.

## Behavior After This Change
- E2e autoscaling negatives clear `replicas` for autoscaling-only cases; classic manifest `replicas` default is `null` (aligned with HCP; profile still sets replicas for positive paths).
- E2e `[id:72453]` asserts schema min validation for `replicas = 1`.
- Six new subsystem tests document and lock in provider validation for classic autoscaling conflicts and HCP compute-field immutability/min-replica update.

## How to Test (Step-by-Step)
### Preconditions
- Clone with hooks installed (`make install-hooks`).

### Test Steps
1. Run `make pre-push-checks`.
2. Optionally run focused subsystem tests:
   - `bin/ginkgo run --focus "Autoscaling conflict" ./subsystem/classic/`
   - `bin/ginkgo run --focus "Fails when trying to change replicas |Fails when trying to change compute_machine_type|Fails when trying to set replicas below" ./subsystem/hcp/`

### Expected Results
- All local checks pass.
- Periodic jobs `e2e-rosa-sts-private-day1-negative-f7` and `e2e-rosa-hcp-private-medium-low-f7` should pass the affected specs.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: `make pre-push-checks` — 9/9 passed; CodeRabbit local review — 0 findings
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [x] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Terraform validation for autoscaling vs replicas, including clearer errors for conflicting configuration and invalid autoscaling min/max ranges.
  * Strengthened update validations by enforcing immutability for replica count and compute machine type, and preventing replicas from being set below the autoscaling minimum.
* **Tests**
  * Expanded unit and end-to-end negative coverage for autoscaling conflicts, update immutability, and revised error message expectations.
* **Chores**
  * Updated the Rosa Classic `replicas` Terraform variable default to be unset (`null`) unless explicitly provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->