### PR TITLE
ROSAENG-60113 | test(unit): add provider/common helper coverage

### DIFF
--- a/provider/common/helpers_test.go
+++ b/provider/common/helpers_test.go
@@ -4,13 +4,17 @@
 package common
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
-	. "github.com/onsi/gomega"             // nolint
+	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/gomega"    // nolint
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+	"github.com/pkg/errors"
 )
 
 var _ = Describe("Helper function tests", func() {
-	Context("ShouldPatchStringMap", func() {
+	Context("ShouldPatchMap", func() {
 		map0 := types.Map{}
 		map1, _ := ConvertStringMapToMapType(map[string]string{
 			"key1": "val1",
@@ -26,7 +30,7 @@ var _ = Describe("Helper function tests", func() {
 			"key2": "val2",
 		})
 
-		It("Should return true when maps are different", func() {
+		It("returns true when maps are different", func() {
 			r, ok := ShouldPatchMap(map0, map1)
 			Expect(ok).To(BeTrue())
 			Expect(r).To(Equal(map1))
@@ -48,9 +52,194 @@ var _ = Describe("Helper function tests", func() {
 			Expect(r).To(Equal(map4))
 		})
 
-		It("Should return false when maps are identical", func() {
+		It("returns false when maps are identical", func() {
 			_, ok := ShouldPatchMap(map1, map1)
-			Expect(ok).ToNot(BeTrue())
+			Expect(ok).To(BeFalse())
 		})
 	})
+
+	DescribeTable("ShouldPatchInt",
+		func(state, plan types.Int64, expectedValue int64, expectedPatch bool) {
+			value, ok := ShouldPatchInt(state, plan)
+			Expect(ok).To(Equal(expectedPatch))
+			if expectedPatch {
+				Expect(value).To(Equal(expectedValue))
+			}
+		},
+		Entry("plan null -> no patch", types.Int64Null(), types.Int64Null(), int64(0), false),
+		Entry("plan unknown -> no patch", types.Int64Unknown(), types.Int64Unknown(), int64(0), false),
+		Entry("state null, plan set -> patch", types.Int64Null(), types.Int64Value(3), int64(3), true),
+		Entry("state unknown, plan set -> patch", types.Int64Unknown(), types.Int64Value(3), int64(3), true),
+		Entry("equal values -> no patch", types.Int64Value(2), types.Int64Value(2), int64(0), false),
+		Entry("changed value -> patch", types.Int64Value(2), types.Int64Value(5), int64(5), true),
+	)
+
+	DescribeTable("ShouldPatchString",
+		func(state, plan types.String, expectedValue string, expectedPatch bool) {
+			value, ok := ShouldPatchString(state, plan)
+			Expect(ok).To(Equal(expectedPatch))
+			if expectedPatch {
+				Expect(value).To(Equal(expectedValue))
+			}
+		},
+		Entry("plan null -> no patch", types.StringNull(), types.StringNull(), "", false),
+		Entry("plan unknown -> no patch", types.StringUnknown(), types.StringUnknown(), "", false),
+		Entry("state null, plan set -> patch", types.StringNull(), types.StringValue("new"), "new", true),
+		Entry("state unknown, plan set -> patch", types.StringUnknown(), types.StringValue("new"), "new", true),
+		Entry("equal values -> no patch", types.StringValue("same"), types.StringValue("same"), "", false),
+		Entry("changed value -> patch", types.StringValue("old"), types.StringValue("new"), "new", true),
+	)
+
+	DescribeTable("ShouldPatchBool",
+		func(state, plan types.Bool, expectedValue bool, expectedPatch bool) {
+			value, ok := ShouldPatchBool(state, plan)
+			Expect(ok).To(Equal(expectedPatch))
+			if expectedPatch {
+				Expect(value).To(Equal(expectedValue))
+			}
+		},
+		Entry("plan null -> no patch", types.BoolNull(), types.BoolNull(), false, false),
+		Entry("plan unknown -> no patch", types.BoolUnknown(), types.BoolUnknown(), false, false),
+		Entry("state null, plan true -> patch", types.BoolNull(), types.BoolValue(true), true, true),
+		Entry("state unknown, plan false -> patch", types.BoolUnknown(), types.BoolValue(false), false, true),
+		Entry("equal values -> no patch", types.BoolValue(true), types.BoolValue(true), false, false),
+		Entry("changed value -> patch", types.BoolValue(true), types.BoolValue(false), false, true),
+	)
+
+	DescribeTable("ShouldPatchList",
+		func(state, plan types.List, expectedPatch bool) {
+			_, ok := ShouldPatchList(state, plan)
+			Expect(ok).To(Equal(expectedPatch))
+		},
+		Entry("identical lists -> no patch",
+			types.ListValueMust(types.StringType, []attr.Value{types.StringValue("a")}),
+			types.ListValueMust(types.StringType, []attr.Value{types.StringValue("a")}),
+			false,
+		),
+		Entry("different lists -> patch",
+			types.ListValueMust(types.StringType, []attr.Value{types.StringValue("a")}),
+			types.ListValueMust(types.StringType, []attr.Value{types.StringValue("b")}),
+			true,
+		),
+	)
+
+	DescribeTable("IsStringAttributeUnknownOrEmpty",
+		func(param types.String, expected bool) {
+			Expect(IsStringAttributeUnknownOrEmpty(param)).To(Equal(expected))
+		},
+		Entry("unknown", types.StringUnknown(), true),
+		Entry("null", types.StringNull(), true),
+		Entry("empty string", types.StringValue(""), true),
+		Entry("non-empty", types.StringValue("value"), false),
+	)
+
+	DescribeTable("IsStringAttributeKnownAndEmpty",
+		func(param types.String, expected bool) {
+			Expect(IsStringAttributeKnownAndEmpty(param)).To(Equal(expected))
+		},
+		Entry("unknown", types.StringUnknown(), false),
+		Entry("null", types.StringNull(), true),
+		Entry("empty string", types.StringValue(""), true),
+		Entry("non-empty", types.StringValue("value"), false),
+	)
+
+	DescribeTable("IsGreaterThanOrEqual",
+		func(version1, version2 string, expected bool, expectErr bool) {
+			result, err := IsGreaterThanOrEqual(version1, version2)
+			if expectErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(expected))
+		},
+		Entry("equal with openshift-v prefix", "openshift-v4.14.0", "4.14.0", true, false),
+		Entry("greater version", "4.15.0", "4.14.0", true, false),
+		Entry("less version", "4.13.0", "4.14.0", false, false),
+		Entry("invalid version", "not-a-version", "4.14.0", false, true),
+	)
+
+	DescribeTable("IsValidDomain",
+		func(candidate string, expected bool) {
+			Expect(IsValidDomain(candidate)).To(Equal(expected))
+		},
+		Entry("valid fqdn", "apps.example.com", true),
+		Entry("valid with trailing dot", "apps.example.com.", true),
+		Entry("single label", "localhost", false),
+		Entry("invalid characters", "bad_domain.com", false),
+	)
+
+	DescribeTable("EmptiableStringToStringType",
+		func(input string, expectNull bool, expectedValue string) {
+			result := EmptiableStringToStringType(input)
+			if expectNull {
+				Expect(result.IsNull()).To(BeTrue())
+				return
+			}
+			Expect(result.ValueString()).To(Equal(expectedValue))
+		},
+		Entry("empty string -> null", "", true, ""),
+		Entry("non-empty -> value", "cluster.example.com", false, "cluster.example.com"),
+	)
+
+	DescribeTable("ValidateTimeout",
+		func(timeOut *int64, defaultTimeout int64, expected *int64, expectErr bool) {
+			result, err := ValidateTimeout(timeOut, defaultTimeout)
+			if expectErr {
+				Expect(err).To(MatchError(ContainSubstring("timeout must be greater than 0 minutes")))
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(*result).To(Equal(*expected))
+		},
+		Entry("nil uses default", nil, int64(45), ptrInt64(45), false),
+		Entry("positive unchanged", ptrInt64(30), int64(45), ptrInt64(30), false),
+		Entry("zero errors", ptrInt64(0), int64(45), nil, true),
+		Entry("negative errors", ptrInt64(-1), int64(45), nil, true),
+	)
+
+	Describe("HandleErr", func() {
+		It("uses OCM reason when set", func() {
+			ocmErr, err := ocmerrors.UnmarshalErrorStatus(`{
+				"kind": "Error",
+				"id": "400",
+				"code": "CLUSTERS-MGMT-400",
+				"reason": "cluster is not ready"
+			}`, 400)
+			Expect(err).NotTo(HaveOccurred())
+
+			result := HandleErr(ocmErr, errors.New("fallback message"))
+			Expect(result.Error()).To(ContainSubstring("cluster is not ready"))
+		})
+
+		It("falls back to err when reason is empty", func() {
+			ocmErr, err := ocmerrors.UnmarshalErrorStatus(`{
+				"kind": "Error",
+				"id": "500",
+				"code": "CLUSTERS-MGMT-500"
+			}`, 500)
+			Expect(err).NotTo(HaveOccurred())
+
+			result := HandleErr(ocmErr, errors.New("underlying transport error"))
+			Expect(result.Error()).To(ContainSubstring("underlying transport error"))
+		})
+	})
+
+	DescribeTable("ValidateStateAndPlanEquals",
+		func(state, plan types.String, expectError bool) {
+			diags := diag.Diagnostics{}
+			ValidateStateAndPlanEquals(state, plan, "test_attr", &diags)
+			Expect(diags.HasError()).To(Equal(expectError))
+			if expectError {
+				Expect(diags.Errors()[0].Summary()).To(Equal(AssertionErrorSummaryMessage))
+			}
+		},
+		Entry("equal attributes -> ok", types.StringValue("same"), types.StringValue("same"), false),
+		Entry("different attributes -> error", types.StringValue("old"), types.StringValue("new"), true),
+	)
 })
+
+func ptrInt64(v int64) *int64 {
+	return &v
+}

--- a/provider/common/tfconversions_test.go
+++ b/provider/common/tfconversions_test.go
@@ -1,0 +1,133 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/gomega"    // nolint
+)
+
+var _ = Describe("Terraform conversion helpers", func() {
+	DescribeTable("BoolWithTrueDefault",
+		func(tfVal types.Bool, expected bool) {
+			Expect(BoolWithTrueDefault(tfVal)).To(Equal(expected))
+		},
+		Entry("null defaults true", types.BoolNull(), true),
+		Entry("unknown defaults true", types.BoolUnknown(), true),
+		Entry("known true", types.BoolValue(true), true),
+		Entry("known false", types.BoolValue(false), false),
+	)
+
+	DescribeTable("BoolWithFalseDefault",
+		func(tfVal types.Bool, expected bool) {
+			Expect(BoolWithFalseDefault(tfVal)).To(Equal(expected))
+		},
+		Entry("null defaults false", types.BoolNull(), false),
+		Entry("unknown defaults false", types.BoolUnknown(), false),
+		Entry("known true", types.BoolValue(true), true),
+		Entry("known false", types.BoolValue(false), false),
+	)
+
+	DescribeTable("OptionalInt64",
+		func(tfVal types.Int64, expectNil bool, expected int64) {
+			result := OptionalInt64(tfVal)
+			if expectNil {
+				Expect(result).To(BeNil())
+				return
+			}
+			Expect(result).NotTo(BeNil())
+			Expect(*result).To(Equal(expected))
+		},
+		Entry("null -> nil", types.Int64Null(), true, int64(0)),
+		Entry("unknown -> nil", types.Int64Unknown(), true, int64(0)),
+		Entry("known value", types.Int64Value(42), false, int64(42)),
+	)
+
+	DescribeTable("OptionalString",
+		func(tfVal types.String, expectNil bool, expected string) {
+			result := OptionalString(tfVal)
+			if expectNil {
+				Expect(result).To(BeNil())
+				return
+			}
+			Expect(result).NotTo(BeNil())
+			Expect(*result).To(Equal(expected))
+		},
+		Entry("null -> nil", types.StringNull(), true, ""),
+		Entry("unknown -> nil", types.StringUnknown(), true, ""),
+		Entry("known value", types.StringValue("value"), false, "value"),
+	)
+
+	DescribeTable("OptionalList",
+		func(tfVal types.List, expectNil bool, expected []string) {
+			result := OptionalList(tfVal)
+			if expectNil {
+				Expect(result).To(BeNil())
+				return
+			}
+			Expect(result).To(Equal(expected))
+		},
+		Entry("null -> nil", types.ListNull(types.StringType), true, nil),
+		Entry("unknown -> nil", types.ListUnknown(types.StringType), true, nil),
+		Entry("known list",
+			types.ListValueMust(types.StringType, []attr.Value{types.StringValue("a"), types.StringValue("b")}),
+			false,
+			[]string{"a", "b"},
+		),
+	)
+
+	It("StringListToArray round-trips string list values", func() {
+		list := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("x"), types.StringValue("y")})
+		result, err := StringListToArray(context.Background(), list)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]string{"x", "y"}))
+	})
+
+	It("StringListToArray returns nil for null list", func() {
+		result, err := StringListToArray(context.Background(), types.ListNull(types.StringType))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("StringListToArray returns nil for unknown list", func() {
+		result, err := StringListToArray(context.Background(), types.ListUnknown(types.StringType))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("StringArrayToList round-trips string slice", func() {
+		list, err := StringArrayToList([]string{"one", "two"})
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := StringListToArray(context.Background(), list)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]string{"one", "two"}))
+	})
+
+	It("ConvertStringMapToMapType round-trips map values", func() {
+		input := map[string]string{"env": "prod", "team": "platform"}
+		tfMap, err := ConvertStringMapToMapType(input)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := OptionalMap(context.Background(), tfMap)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(input))
+	})
+
+	It("OptionalMap returns nil for null map", func() {
+		result, err := OptionalMap(context.Background(), types.MapNull(types.StringType))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("OptionalMap returns nil for unknown map", func() {
+		result, err := OptionalMap(context.Background(), types.MapUnknown(types.StringType))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+})


### PR DESCRIPTION
## PR Summary

Add unit tests for shared helpers and Terraform conversion utilities in `provider/common` (root package). **PR 3 of 6** in the [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113) unit-test coverage series.

### Planned follow-up PRs
1. `provider/common/attrvalidators` — merged ([#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212))
2. `provider/clusterrosa/common` + `hcp/shared_vpc` — merged ([#1218](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1218))
3. `provider/common` (root) — helpers and tfconversions — **this PR**
4. `provider/clusterrosa/hcp` — untested `validate*` / small pure funcs
5. `provider/clusterrosa/classic` — validators only (not CRUD)
6. `provider/proxy` — `Contains` (optional, if still uncovered)

## Detailed Description of the Issue

`provider/common` root helpers (`ShouldPatch*`, version/domain checks, `ValidateTimeout`, `HandleErr`, `tfconversions`) are used across HCP/classic resources and machine pools but had almost no direct unit tests (only `ShouldPatchMap`).

## Related Issues and PRs
- Jira: [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113)
- Related PR(s): [#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212), [#1218](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1218); part 3 of 6 (`ROSAENG-60113-unit-tests-3`).

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

No unit tests covered `ShouldPatchInt`/`String`/`Bool`/`List`, string attribute helpers, `IsGreaterThanOrEqual`, `IsValidDomain`, `ValidateTimeout`, `HandleErr`, or `tfconversions` helpers.

## Behavior After This Change

Table-driven Ginkgo unit tests validate patch decision logic, conversion helpers, and error/timeout paths. No production code changes.

### Intentional skips (e2e/subsystem checklist)
- **HTPasswd validation** — `ValidateHTPasswd*` in `provider/common/validators.go` is unused; live path is `provider/identityprovider/htpasswd.go` (subsystem: `identity_provider_resource_test.go`). Separate follow-up PR to remove dead code.
- **Cluster wait polling** — defer to subsystem/e2e (`DefaultClusterWait`).
- **Immutable attribute messages** — `ValidateStateAndPlanEquals` has lightweight unit coverage; full messages covered by subsystem immutability tests.
- **HasValue** — covered indirectly via tfconversions tests; direct tests optional.
- **GetJsonStringOrNullString** — diagnostic formatting only; defer to subsystem cluster update/immutability tests.

## How to Test (Step-by-Step)

### Preconditions
- Go toolchain and repo dependencies installed.

### Test Steps
1. `go test ./provider/common -count=1`
2. `make pre-push-checks`

### Expected Results
- All `provider/common` root specs pass.
- Pre-push checks pass.

## Proof of the Fix
- Logs/CLI output: local `make pre-push-checks` (9/9 passed) and CodeRabbit local review (0 findings).

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [x] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Expanded helper test coverage for patch/map behavior, refining assertions and expectations for identical maps.
  * Added new test coverage for Terraform-to-Go conversion helpers, including boolean defaults, optional value handling, list/string round-trips, and map conversion behavior for null vs. known/unknown inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->