### PR TITLE
ROSAENG-61057 | ci: fix changed-line coverage on Prow

### DIFF
--- a/hack/check-subsystem-registry.sh
+++ b/hack/check-subsystem-registry.sh
@@ -72,15 +72,7 @@ collect_allowlist_types() {
 }
 
 resolve_merge_base_range() {
-  local -a base_refs=()
-
-  if [ -n "$base_ref" ]; then
-    base_refs=("$base_ref")
-  else
-    base_refs=(origin/main upstream/main main)
-  fi
-
-  merge_base_range HEAD "${base_refs[@]}"
+  resolve_changed_go_diff_range "$base_ref" || true
 }
 
 collect_new_types() {

--- a/hack/coverage-changed-files.sh
+++ b/hack/coverage-changed-files.sh
@@ -24,16 +24,9 @@ delta_file="$tmp_dir/delta-cov.txt"
 trap 'rm -rf "$tmp_dir"' EXIT
 
 resolve_diff_args() {
-  local -a base_refs=()
   local diff_range
 
-  if [ -n "$coverage_base_ref" ]; then
-    base_refs=("$coverage_base_ref")
-  else
-    base_refs=(origin/main upstream/main main)
-  fi
-
-  diff_range=$(merge_base_range HEAD "${base_refs[@]}")
+  diff_range=$(resolve_changed_go_diff_range "$coverage_base_ref" || true)
   if [ -n "$diff_range" ]; then
     mapfile -t merge_range_go_files < <(git diff "$diff_range" --name-only --diff-filter=ACMR -- '*.go')
     if [ "${#merge_range_go_files[@]}" -gt 0 ]; then
@@ -46,6 +39,28 @@ resolve_diff_args() {
   mapfile -t candidate_files < <(git diff "${diff_base_args[@]}" --name-only --diff-filter=ACMR -- '*.go')
   if [ "${#candidate_files[@]}" -eq 0 ]; then
     diff_base_args=()
+  fi
+}
+
+fail_if_ci_skipped_required_coverage() {
+  local diff_range provider_changes
+
+  if ! ci_pr_context; then
+    return 0
+  fi
+
+  diff_range=$(resolve_changed_go_diff_range "$coverage_base_ref" || true)
+  if [ -z "$diff_range" ]; then
+    echo "ERROR: changed-files coverage could not resolve a diff range in CI" >&2
+    echo "Set PULL_BASE_SHA/PULL_PULL_SHA or fetch origin/main before running checks." >&2
+    exit 1
+  fi
+
+  provider_changes=$(count_provider_internal_go_changes "$diff_range")
+  if [ "$provider_changes" -gt 0 ]; then
+    echo "ERROR: changed-files coverage did not run for ${provider_changes} provider/internal Go file(s) in CI" >&2
+    echo "Diff range: ${diff_range}" >&2
+    exit 1
   fi
 }
 
@@ -83,15 +98,18 @@ for file_path in "${candidate_files[@]}"; do
 done
 
 if [ "${#coverage_candidate_files[@]}" -eq 0 ]; then
+  fail_if_ci_skipped_required_coverage
   exit 0
 fi
 
 git diff "${diff_base_args[@]}" -U0 -- "${coverage_candidate_files[@]}" > "$diff_file"
 if [ ! -s "$diff_file" ]; then
+  fail_if_ci_skipped_required_coverage
   exit 0
 fi
 
 if [ "${#changed_packages[@]}" -eq 0 ]; then
+  fail_if_ci_skipped_required_coverage
   exit 0
 fi
 

--- a/hack/lib/git.sh
+++ b/hack/lib/git.sh
@@ -2,6 +2,27 @@
 # Copyright Red Hat
 # SPDX-License-Identifier: Apache-2.0
 
+# verify_commit ref
+# Returns 0 when ref resolves to a commit.
+verify_commit() {
+  git rev-parse --verify "${1}^{commit}" >/dev/null 2>&1
+}
+
+# ci_pr_context
+# True when running in automated CI for a pull request.
+ci_pr_context() {
+  if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+    return 0
+  fi
+  if [ -n "${OPENSHIFT_CI:-}" ] && [ "${JOB_TYPE:-}" = "presubmit" ]; then
+    return 0
+  fi
+  if [ -n "${PULL_BASE_SHA:-${BASE_SHA:-}}" ] && [ -n "${PULL_PULL_SHA:-${HEAD_SHA:-}}" ]; then
+    return 0
+  fi
+  return 1
+}
+
 # newest_merge_base HEAD ref...
 # Prints the newest merge-base among merge-base(HEAD, ref) for each reachable ref.
 newest_merge_base() {
@@ -13,7 +34,7 @@ newest_merge_base() {
 
   for ref in "$@"; do
     [ -z "$ref" ] && continue
-    if ! git rev-parse --verify "${ref}^{commit}" >/dev/null 2>&1; then
+    if ! verify_commit "$ref"; then
       continue
     fi
     if ! mb=$(git merge-base "$head" "${ref}" 2>/dev/null); then
@@ -42,4 +63,70 @@ merge_base_range() {
   if [ -n "$mb" ]; then
     printf '%s...%s' "$mb" "$head"
   fi
+}
+
+# resolve_changed_go_diff_range [explicit_base_ref]
+# Prints a git diff range (base...head) for PR changed-file checks.
+# Priority: PULL_BASE_SHA...PULL_PULL_SHA, explicit base ref merge range,
+# then merge range against origin/main, upstream/main, or main.
+resolve_changed_go_diff_range() {
+  local explicit_base_ref=${1:-}
+  local pull_base pull_head diff_range
+
+  pull_base="${PULL_BASE_SHA:-${BASE_SHA:-}}"
+  pull_head="${PULL_PULL_SHA:-${HEAD_SHA:-}}"
+
+  if [ -n "$pull_base" ] && [ -n "$pull_head" ] \
+     && verify_commit "$pull_base" && verify_commit "$pull_head"; then
+    printf '%s...%s' "$pull_base" "$pull_head"
+    return 0
+  fi
+
+  if [ -n "$explicit_base_ref" ] && verify_commit "$explicit_base_ref"; then
+    diff_range=$(merge_base_range HEAD "$explicit_base_ref")
+    if [ -n "$diff_range" ]; then
+      printf '%s' "$diff_range"
+      return 0
+    fi
+  fi
+
+  diff_range=$(merge_base_range HEAD origin/main upstream/main main)
+  if [ -n "$diff_range" ]; then
+    printf '%s' "$diff_range"
+    return 0
+  fi
+
+  return 1
+}
+
+# count_provider_internal_go_changes diff_range
+# Prints the number of changed non-test Go files under provider/ or internal/.
+count_provider_internal_go_changes() {
+  local diff_range=$1
+  local file_path
+
+  if [ -z "$diff_range" ]; then
+    printf '0'
+    return 0
+  fi
+
+  local count=0
+  while IFS= read -r file_path; do
+    [ -z "$file_path" ] && continue
+    case "$file_path" in
+      provider/*|internal/*)
+        ;;
+      *)
+        continue
+        ;;
+    esac
+    case "$file_path" in
+      *_test.go)
+        continue
+        ;;
+    esac
+    count=$((count + 1))
+  done < <(git diff "$diff_range" --name-only --diff-filter=ACMR -- '*.go')
+
+  printf '%s' "$count"
 }


### PR DESCRIPTION
## PR Summary
Fix OpenShift Prow silently skipping changed-files coverage when git cannot resolve `origin/main`, so Prow matches GitHub Actions enforcement for PRs.

## Detailed Description of the Issue
GitHub Actions and OpenShift Prow both run `make pre-push-checks`, which includes `hack/coverage-changed-files.sh`. GHA fetches full git history and `origin/main`, so the merge-base diff runs and enforces the 80% changed-line threshold. Prow often lacks those refs; the script exited 0 with no coverage run, letting PRs pass despite failing on GHA (e.g. terraform-redhat/terraform-provider-rhcs#1204 at 14% coverage).

## Related Issues and PRs
- Jira: [ROSAENG-61057](https://issues.redhat.com/browse/ROSAENG-61057)
- Related PR(s): https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1204 (coverage divergence example)

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
When Prow could not resolve a merge-base against `origin/main` / `upstream/main` / `main`, `coverage-changed-files.sh` and `check-subsystem-registry.sh` fell back to an empty diff and exited 0, skipping changed-line coverage and subsystem registry checks.

## Behavior After This Change
- `resolve_changed_go_diff_range` in `hack/lib/git.sh` prefers `PULL_BASE_SHA...PULL_PULL_SHA` (OpenShift Prow PR env), then explicit base refs, then merge-base against branch refs.
- In PR CI context (`GITHUB_EVENT_NAME=pull_request`, OpenShift `JOB_TYPE=presubmit`, or PR SHAs set), coverage fails with an explicit error instead of silently skipping when provider/internal Go changes would not be measured.
- `check-subsystem-registry.sh` reuses the same diff resolution helper.

## How to Test (Step-by-Step)
### Preconditions
- Clone with `upstream/main` fetched; optional PR branch at `6eedbdd5` (#1204) for regression simulation.

### Test Steps
1. On a PR commit with provider changes and no branch refs:
   ```bash
   git update-ref -d refs/remotes/upstream/main
   OPENSHIFT_CI=true JOB_TYPE=presubmit make coverage-changed-files
   ```
2. With Prow PR SHAs set (replace SHAs for your PR):
   ```bash
   OPENSHIFT_CI=true JOB_TYPE=presubmit \
     PULL_BASE_SHA=<base> PULL_PULL_SHA=<head> \
     make coverage-changed-files
   ```
3. Run `shellcheck -x hack/coverage-changed-files.sh hack/check-subsystem-registry.sh` from `hack/`.

### Expected Results
1. Step 1 exits 1 with `ERROR: changed-files coverage could not resolve a diff range in CI` (not exit 0).
2. Step 2 runs gocovdiff against the PR diff range (same behavior as GHA).
3. Step 3 reports no shellcheck errors.

## Proof of the Fix
- Logs/CLI output:
  - PR #1204 @ `6eedbdd5` with `PULL_BASE_SHA`/`PULL_PULL_SHA`: coverage fails at 14% without Schema/validator tests (matches GHA).
  - Same simulation with upstream script and no branch refs: exit 0 (false green).
  - New script under same conditions: exit 1 with explicit error.
  - `make pre-push-checks` passes on this branch locally.

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not only for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how changed Go files are detected in CI, reducing missed coverage checks on pull requests.
  * Added stricter CI validation so changes in core Go code are flagged even when other test inputs are empty or unavailable.
  * Made diff-range detection more reliable across different branch and merge-base setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->