### PR TITLE
ROSAENG-60113 | test(unit): add clusterrosa/hcp validator coverage

### DIFF
--- a/provider/clusterrosa/hcp/validators_test.go
+++ b/provider/clusterrosa/hcp/validators_test.go
@@ -1,0 +1,329 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package hcp
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/gomega"    // nolint
+
+	rosa "github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterrosa/common"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
+)
+
+func cloneBasicState() *ClusterRosaHcpState {
+	state := generateBasicRosaHcpClusterState()
+	state.Channel = types.StringNull()
+	state.Version = types.StringValue("4.14.0")
+	state.ExternalID = types.StringNull()
+	state.Tags = types.MapNull(types.StringType)
+	state.EtcdEncryption = types.BoolNull()
+	state.FIPS = types.BoolNull()
+	state.EtcdKmsKeyArn = types.StringNull()
+	state.Private = types.BoolNull()
+	state.MachineCIDR = types.StringNull()
+	state.ServiceCIDR = types.StringNull()
+	state.PodCIDR = types.StringNull()
+	state.HostPrefix = types.Int64Null()
+	state.AWSAdditionalComputeSecurityGroupIds = types.ListNull(types.StringType)
+	state.AutoScalingEnabled = types.BoolNull()
+	state.MinReplicas = types.Int64Null()
+	state.MaxReplicas = types.Int64Null()
+	state.ComputeMachineType = types.StringNull()
+	state.Ec2MetadataHttpTokens = types.StringNull()
+	state.WorkerDiskSize = types.Int64Null()
+	state.CreateAdminUser = types.BoolNull()
+	state.BaseDNSDomain = types.StringNull()
+	state.ExternalAuthProvidersEnabled = types.BoolNull()
+	state.LogForwardersAtClusterCreation = types.ListNull(types.ObjectType{AttrTypes: map[string]attr.Type{}})
+	return state
+}
+
+var _ = Describe("Channel and channel_group update validation", func() {
+	DescribeTable("validateChannelAndChannelGroupChanges",
+		func(mutate func(state, plan *ClusterRosaHcpState), expectedErr bool) {
+			state := cloneBasicState()
+			plan := cloneBasicState()
+			mutate(state, plan)
+
+			diags := validateChannelAndChannelGroupChanges(state, plan)
+			Expect(diags.HasError()).To(Equal(expectedErr))
+		},
+		Entry("unchanged -> ok",
+			func(_, _ *ClusterRosaHcpState) {},
+			false,
+		),
+		Entry("channel only -> ok",
+			func(state, plan *ClusterRosaHcpState) {
+				state.Channel = types.StringValue("stable")
+				plan.Channel = types.StringValue("candidate")
+			},
+			false,
+		),
+		Entry("channel_group only -> ok",
+			func(state, plan *ClusterRosaHcpState) {
+				state.ChannelGroup = types.StringValue("stable")
+				plan.ChannelGroup = types.StringValue("fast")
+			},
+			false,
+		),
+		Entry("channel and channel_group together -> error",
+			func(state, plan *ClusterRosaHcpState) {
+				state.Channel = types.StringValue("stable")
+				state.ChannelGroup = types.StringValue("stable")
+				plan.Channel = types.StringValue("candidate")
+				plan.ChannelGroup = types.StringValue("fast")
+			},
+			true,
+		),
+	)
+})
+
+var _ = Describe("Channel group and version update validation", func() {
+	DescribeTable("validateChannelGroupAndVersionChanges",
+		func(mutate func(state, plan *ClusterRosaHcpState), expectedErr bool) {
+			state := cloneBasicState()
+			plan := cloneBasicState()
+			mutate(state, plan)
+
+			diags := validateChannelGroupAndVersionChanges(state, plan)
+			Expect(diags.HasError()).To(Equal(expectedErr))
+		},
+		Entry("unchanged -> ok",
+			func(_, _ *ClusterRosaHcpState) {},
+			false,
+		),
+		Entry("channel_group only -> ok",
+			func(state, plan *ClusterRosaHcpState) {
+				state.ChannelGroup = types.StringValue("stable")
+				plan.ChannelGroup = types.StringValue("fast")
+			},
+			false,
+		),
+		Entry("version only -> ok",
+			func(state, plan *ClusterRosaHcpState) {
+				state.Version = types.StringValue("4.14.0")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			false,
+		),
+		Entry("channel_group and version together -> error",
+			func(state, plan *ClusterRosaHcpState) {
+				state.ChannelGroup = types.StringValue("stable")
+				state.Version = types.StringValue("4.14.0")
+				plan.ChannelGroup = types.StringValue("fast")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			true,
+		),
+		Entry("version set when state version is null -> counts as version change with channel_group",
+			func(state, plan *ClusterRosaHcpState) {
+				state.ChannelGroup = types.StringValue("stable")
+				state.Version = types.StringNull()
+				plan.ChannelGroup = types.StringValue("fast")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			true,
+		),
+	)
+})
+
+var _ = Describe("Channel and version update validation", func() {
+	DescribeTable("validateChannelAndVersionChanges",
+		func(mutate func(state, plan *ClusterRosaHcpState), expectedErr bool) {
+			state := cloneBasicState()
+			plan := cloneBasicState()
+			mutate(state, plan)
+
+			diags := validateChannelAndVersionChanges(state, plan)
+			Expect(diags.HasError()).To(Equal(expectedErr))
+		},
+		Entry("unchanged -> ok",
+			func(_, _ *ClusterRosaHcpState) {},
+			false,
+		),
+		Entry("channel only -> ok",
+			func(state, plan *ClusterRosaHcpState) {
+				state.Channel = types.StringValue("stable")
+				plan.Channel = types.StringValue("candidate")
+			},
+			false,
+		),
+		Entry("version only -> ok",
+			func(state, plan *ClusterRosaHcpState) {
+				state.Version = types.StringValue("4.14.0")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			false,
+		),
+		Entry("channel and version together -> error",
+			func(state, plan *ClusterRosaHcpState) {
+				state.Channel = types.StringValue("stable")
+				state.Version = types.StringValue("4.14.0")
+				plan.Channel = types.StringValue("candidate")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			true,
+		),
+		Entry("version set when state version is null -> counts as version change with channel",
+			func(state, plan *ClusterRosaHcpState) {
+				state.Channel = types.StringValue("stable")
+				state.Version = types.StringNull()
+				plan.Channel = types.StringValue("candidate")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			true,
+		),
+	)
+})
+
+var _ = Describe("Immutable attribute update validation", func() {
+	It("returns no diagnostics when state and plan match", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+
+		diags := validateNoImmutableAttChange(state, plan)
+		Expect(diags.HasError()).To(BeFalse())
+	})
+
+	It("errors when an immutable attribute changes", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+		plan.Name = types.StringValue("renamed-cluster")
+
+		diags := validateNoImmutableAttChange(state, plan)
+		Expect(diags.HasError()).To(BeTrue())
+		Expect(diags.Errors()[0].Summary()).To(Equal(common.AssertionErrorSummaryMessage))
+	})
+})
+
+var _ = Describe("Auto node role ARN validator", func() {
+	DescribeTable("should validate correctly",
+		func(request validator.StringRequest, expectedErr bool) {
+			response := validator.StringResponse{}
+			validateAutoNodeRoleARN().ValidateString(context.Background(), request, &response)
+			Expect(response.Diagnostics.HasError()).To(Equal(expectedErr))
+		},
+		Entry("null -> ok",
+			validator.StringRequest{
+				Path:           path.Root("auto_node").AtName("role_arn"),
+				PathExpression: path.MatchRoot("auto_node").AtName("role_arn"),
+				ConfigValue:    types.StringNull(),
+			},
+			false,
+		),
+		Entry("unknown -> ok",
+			validator.StringRequest{
+				Path:           path.Root("auto_node").AtName("role_arn"),
+				PathExpression: path.MatchRoot("auto_node").AtName("role_arn"),
+				ConfigValue:    types.StringUnknown(),
+			},
+			false,
+		),
+		Entry("valid IAM role ARN -> ok",
+			validator.StringRequest{
+				Path:           path.Root("auto_node").AtName("role_arn"),
+				PathExpression: path.MatchRoot("auto_node").AtName("role_arn"),
+				ConfigValue:    types.StringValue(autoNodeRoleArn),
+			},
+			false,
+		),
+		Entry("empty string -> error",
+			validator.StringRequest{
+				Path:           path.Root("auto_node").AtName("role_arn"),
+				PathExpression: path.MatchRoot("auto_node").AtName("role_arn"),
+				ConfigValue:    types.StringValue(""),
+			},
+			true,
+		),
+		Entry("single quote -> error",
+			validator.StringRequest{
+				Path:           path.Root("auto_node").AtName("role_arn"),
+				PathExpression: path.MatchRoot("auto_node").AtName("role_arn"),
+				ConfigValue:    types.StringValue("arn:aws:iam::123456789012:role/karpenter'"),
+			},
+			true,
+		),
+		Entry("non-IAM ARN -> error",
+			validator.StringRequest{
+				Path:           path.Root("auto_node").AtName("role_arn"),
+				PathExpression: path.MatchRoot("auto_node").AtName("role_arn"),
+				ConfigValue:    types.StringValue("arn:aws:s3:::my-bucket"),
+			},
+			true,
+		),
+	)
+})
+
+var _ = Describe("Auto node helpers", func() {
+	It("getAutoNodeMode returns null when auto_node is nil", func() {
+		Expect(getAutoNodeMode(nil)).To(Equal(types.StringNull()))
+	})
+
+	It("getAutoNodeMode returns mode from auto_node", func() {
+		autoNode := &AutoNode{Mode: types.StringValue(autoNodeModeEnabled)}
+		Expect(getAutoNodeMode(autoNode)).To(Equal(types.StringValue(autoNodeModeEnabled)))
+	})
+
+	It("getAutoNodeRoleARN returns null when auto_node is nil", func() {
+		Expect(getAutoNodeRoleARN(nil)).To(Equal(types.StringNull()))
+	})
+
+	It("getAutoNodeRoleARN returns role ARN from auto_node", func() {
+		autoNode := &AutoNode{RoleARN: types.StringValue(autoNodeRoleArn)}
+		Expect(getAutoNodeRoleARN(autoNode)).To(Equal(types.StringValue(autoNodeRoleArn)))
+	})
+})
+
+var _ = Describe("getOcmVersionMinor", func() {
+	DescribeTable("extracts major.minor",
+		func(input, expected string) {
+			Expect(getOcmVersionMinor(input)).To(Equal(expected))
+		},
+		Entry("semver version", "4.14.5", "4.14"),
+		Entry("two-segment version", "4.14", "4.14"),
+		Entry("prefixed version falls back to split", "openshift-v4.14.5", "openshift-v4.14"),
+	)
+})
+
+var _ = Describe("shouldPatchProperties", func() {
+	It("returns true when user properties change", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+		plan.Properties = types.MapValueMust(types.StringType, map[string]attr.Value{
+			"rosa_creator_arn": types.StringValue("arn:aws:iam::123456789012:user/other"),
+		})
+
+		Expect(shouldPatchProperties(state, plan)).To(BeTrue())
+	})
+
+	It("returns false when properties and OCM defaults are unchanged", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+		state.OCMProperties = types.MapValueMust(types.StringType, map[string]attr.Value{
+			rosa.PropertyRosaTfVersion: types.StringValue(rosa.OCMProperties[rosa.PropertyRosaTfVersion]),
+			rosa.PropertyRosaTfCommit:  types.StringValue(rosa.OCMProperties[rosa.PropertyRosaTfCommit]),
+		})
+		plan.OCMProperties = state.OCMProperties
+
+		Expect(shouldPatchProperties(state, plan)).To(BeFalse())
+	})
+
+	It("returns true when OCM default property values drift", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+		state.OCMProperties = types.MapValueMust(types.StringType, map[string]attr.Value{
+			rosa.PropertyRosaTfVersion: types.StringValue("stale-version"),
+			rosa.PropertyRosaTfCommit:  types.StringValue(rosa.OCMProperties[rosa.PropertyRosaTfCommit]),
+		})
+		plan.OCMProperties = state.OCMProperties
+
+		Expect(shouldPatchProperties(state, plan)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
## Summary
- Add unit tests for HCP cluster update validators and small pure helpers in `provider/clusterrosa/hcp`.
- **PR 4 of 6** in the [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113) unit-test coverage series.

### Planned follow-up PRs
1. `provider/common/attrvalidators` — merged ([#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212))
2. `provider/clusterrosa/common` + `hcp/shared_vpc` — merged ([#1218](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1218))
3. `provider/common` (root) — merged ([#1231](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1231))
4. `provider/clusterrosa/hcp` — untested `validate*` / small pure funcs — **this PR**
5. `provider/clusterrosa/classic` — validators only (not CRUD)
6. `provider/proxy` — `Contains` (optional, if still uncovered)

## Detailed Description of the Issue

HCP cluster resource helpers for update-time validation (`validateChannel*`, `validateNoImmutableAttChange`, `validateAutoNodeRoleARN`) and small pure functions (`getOcmVersionMinor`, `getAutoNodeMode`, `getAutoNodeRoleARN`, `shouldPatchProperties`) had no direct unit tests.

## Related Issues and PRs
- Jira: [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113)
- Related PR(s): [#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212), [#1218](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1218), [#1231](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1231); part 4 of 6 (`ROSAENG-60113-unit-tests-4`).

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

No unit tests covered HCP update validators or the listed pure helpers.

## Behavior After This Change

Table-driven Ginkgo unit tests validate channel/version mutual-exclusion rules, immutability checks, auto-node role ARN validation, and property-patch logic. No production code changes.

### Intentional skips (e2e/subsystem checklist)
- **`validateUpgrade`** — requires OCM client; defer to subsystem/e2e upgrade flows.
- **Full immutability matrix** — `validateNoImmutableAttChange` has representative unit coverage; subsystem immutability tests cover resource wiring.
- **CRUD paths** (`Create`/`Read`/`Update`/`Delete`) — out of scope for this PR series entry.

## How to Test (Step-by-Step)

### Preconditions
- Go toolchain and repo dependencies installed.

### Test Steps
1. `go test ./provider/clusterrosa/hcp -count=1`
2. `make pre-push-checks`

### Expected Results
- All `provider/clusterrosa/hcp` specs pass.
- Pre-push checks pass.

## Proof of the Fix
- Logs/CLI output: local `make pre-push-checks` (9/9 passed) and CodeRabbit local review (0 findings).

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [x] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Ginkgo/Go test suite for cluster ROSA HCP validators and helpers.
  * Validates update rules across channel, channel group, and version combinations, including null prior version handling.
  * Confirms immutable-field behavior and verifies error messaging when names change.
  * Adds coverage for auto-node role ARN handling (null/unknown, valid, and invalid inputs).
  * Includes tests for version/minor parsing and property patching decisions, including default drift scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->