### PR TITLE
ROSAENG-60113 | ci: drop changed-files coverage merge gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -87,5 +87,6 @@ For details, see: ./CONTRIBUTING.md
 - [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
 - [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
 - [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
+- [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
 - [ ] `make check-subsystem-registry` passes.
 - [ ] I manually tested the change when behavior is user-visible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Reference sources:
 
 ## Expectations for agent-produced changes
 
-These are **review and design expectations**. They are not all enforced by automation; contributors and reviewers still apply them. Concrete commands and gates are in `CONTRIBUTING.md` (for example hooks, `make pre-push-checks`, coverage rules).
+These are **review and design expectations**. They are not all enforced by automation; contributors and reviewers still apply them. Concrete commands and gates are in `CONTRIBUTING.md` (for example hooks, `make pre-push-checks`, subsystem registry, and the full test suite). Optional local coverage targets exist but are not merge gates.
 
 - Do not hard code secrets, API keys, tokens, kubeconfigs, AWS credentials, or customer identifiers in code, tests, docs, examples, or logs.
 - Do not document bypassing local hooks or verification gates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ The hooks are configured in `.pre-commit-config.yaml` and perform:
 
 - `pre-commit`: formats staged Go files with `gci` + `gofmt` plus staged Terraform files under `examples/` and `tests/`, adds Apache 2.0 license headers to staged files missing them, and blocks the commit if files were rewritten so you can review and stage the updates
 - `commit-msg`: validates the commit message format (JIRA-123 | type(scope): message)
-- `pre-push`: runs the same steps as `make pre-push-checks` (format-check, build, generated-files check, lint, docs-lint, license-check, changed-files coverage, subsystem registry check, and `make test`)
+- `pre-push`: runs the same steps as `make pre-push-checks` (format-check, build, generated-files check, lint, docs-lint, license-check, subsystem registry check, and `make test`)
 - `pre-push` runs against committed content and blocks when staged or unstaged tracked changes are present
 - check runs are fail-fast: execution stops at the first failing step
 
@@ -99,7 +99,6 @@ make test
 `make pre-push-checks` (also run by the pre-push git hook and GitHub Actions) verifies:
 
 - Formatting, build, generated files, lint, docs-lint, and license headers
-- **`make coverage-changed-files`** — at least 80% of changed lines in `provider/` and `internal/` (non-test `.go` files) must be covered by unit tests, compared to the merge base with `main`
 - **`make check-subsystem-registry`** — every registered resource and data source type must be referenced in `subsystem/` tests, or listed in `hack/subsystem-registry-allowlist.yaml` with a ticket and reason; **new types** added on the branch must include a subsystem test
 - **`make test`** — unit, subsystem, and utils suites pass
 
@@ -113,7 +112,18 @@ See `AGENTS.md` for when to add unit versus subsystem tests.
 | New or changed **validation, plan modifiers, or helpers** (Go code) | **Unit** test in the same package (`*_test.go`) |
 | **Schema / ConfigValidators** (plan-time errors) | **Unit** and/or **one** subsystem test expecting plan/apply failure — avoid duplicating the same cases in both layers |
 
-`make unit-test-coverage` is optional for local debugging (`go tool cover -html=coverage.out`); it is **not** a merge gate.
+Unit tests for validators and helpers are required by review policy and the PR testing checklist; they are **not** enforced by an automated coverage percentage gate.
+
+#### Optional coverage tools (not merge gates)
+
+These commands help locally; CI and pre-push do not enforce them:
+
+| Command | Purpose |
+|---------|---------|
+| `make unit-test-coverage` | Package-level unit coverage for `provider/` and `internal/`; produces `coverage.out` for `go tool cover -html=coverage.out` |
+| `make coverage-changed-files` | Changed-line unit coverage compared to merge base with `main` (gocovdiff, 80% threshold). **Does not include subsystem tests.** Useful before large refactors; not required to merge |
+
+Pre-merge quality for provider behavior relies on **`make test`** (unit + subsystem + utils) and **`make check-subsystem-registry`** for registered types.
 
 Use these commands before pushing:
 
@@ -122,10 +132,9 @@ make basic-checks      # convenience flow: starts with make fmt and may stop aft
 make pre-push-checks   # exact non-mutating verification used by the pre-push hook
 ```
 
-`make basic-checks` runs format, format-check, build, generated-files verification, lint, docs-lint (Vale), changed-files coverage, subsystem registry check, and unit/subsystem/utils tests.
+`make basic-checks` runs format, format-check, build, generated-files verification, lint, docs-lint (Vale), subsystem registry check, and unit/subsystem/utils tests.
 `make lint` uses the repo's pinned `golangci-lint` v2 configuration.
 `make docs-lint` runs the pinned [Vale](https://docs.vale.sh/) CLI with only the custom inclusive-language rules under `styles/InclusiveLanguage/` (general Vale styles and packages are not used). Building Vale uses `CGO_ENABLED=1` and requires a C compiler toolchain on the first install.
-Changed-files coverage is enforced through `make coverage-changed-files` using `gocovdiff` with an 80% threshold for changed Go files under `provider/` and `internal/`, diffed against the merge base with `main`.
 
 ### 5. Manual testing and debugging using the locally compiled RHCS Provider binary
 Manual testing should be performed before opening a PR to ensure there isn't any regression behavior in the provider. You can find [here an example for that](https://github.com/terraform-redhat/terraform-rhcs-rosa/tree/main/examples/rosa-classic-public-with-unmanaged-oidc)

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ unit-test: $(GINKGO)
 		-ldflags="$(ldflags)" \
 		-r provider internal/...
 
+# Optional local diagnostics — not run by pre-push-checks or CI.
 .PHONY: unit-test-coverage
 unit-test-coverage: $(GINKGO)
 	$(GINKGO) run \
@@ -263,6 +264,7 @@ e2e_test: $(GINKGO) install
         --focus-file tests/e2e/.* \
 		$(NULL)
 
+# Optional local diagnostic (gocovdiff on changed provider/internal lines vs main).
 .PHONY: coverage-changed-files
 coverage-changed-files:
 	./hack/coverage-changed-files.sh

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ make basic-checks      # convenience flow: starts with make fmt and may stop aft
 make pre-push-checks   # exact non-mutating verification used by the pre-push hook
 ```
 
-Changed-files coverage is enforced through `make coverage-changed-files` using `gocovdiff` with an 80% threshold for changed Go files under `provider/` and `internal/`, compared to the merge base with `main`.
+Pre-merge checks run formatting, build, lint, subsystem registry verification, and the full test suite (`make test`). Optional local coverage reports: `make unit-test-coverage` (package-level) and `make coverage-changed-files` (changed lines compared to `main`; unit tests only). See `CONTRIBUTING.md`.
 
 Subsystem coverage is checked with `make check-subsystem-registry`. See `CONTRIBUTING.md` and `AGENTS.md`.
 

--- a/hack/coverage-changed-files.sh
+++ b/hack/coverage-changed-files.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Copyright Red Hat
 # SPDX-License-Identifier: Apache-2.0
-
+#
+# Optional local diagnostic: changed-line unit coverage for provider/ and internal/
+# (gocovdiff vs merge base with main). Not run by make pre-push-checks or CI.
+# Subsystem tests do not count toward the score. Invoke via: make coverage-changed-files
 
 set -euo pipefail
 

--- a/hack/run-checks.sh
+++ b/hack/run-checks.sh
@@ -18,8 +18,8 @@ Usage:
   make run-checks -- <mode> [--dry-run] [--list-steps]
 
 Modes:
-  pre-push                 Steps: format-check, build, generated-files, lint, docs-lint, license-check, coverage, subsystem-registry, tests
-  basic                    Steps: format, format-check, build, generated-files, lint, docs-lint, license-check, coverage, subsystem-registry, tests
+  pre-push                 Steps: format-check, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests
+  basic                    Steps: format, format-check, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests
 
 Flags:
   --dry-run                Print planned steps and commands without executing
@@ -83,7 +83,6 @@ case "$mode" in
     append_step "Lint" "make --no-print-directory lint"
     append_step "Documentation lint (Vale)" "make --no-print-directory docs-lint"
     append_step "License header check" "make --no-print-directory license-check"
-    append_step "Coverage (changed files)" "make --no-print-directory coverage-changed-files"
     append_step "Subsystem registry" "make --no-print-directory check-subsystem-registry"
     append_step "Unit and subsystem tests" "make --no-print-directory test"
     ;;
@@ -95,7 +94,6 @@ case "$mode" in
     append_step "Lint" "make --no-print-directory lint"
     append_step "Documentation lint (Vale)" "make --no-print-directory docs-lint"
     append_step "License header check" "make --no-print-directory license-check"
-    append_step "Coverage (changed files)" "make --no-print-directory coverage-changed-files"
     append_step "Subsystem registry" "make --no-print-directory check-subsystem-registry"
     append_step "Unit and subsystem tests" "make --no-print-directory test"
     ;;


### PR DESCRIPTION
## PR Summary

Remove `make coverage-changed-files` from pre-merge automation (`pre-push-checks`, pre-push hook, GitHub Actions). Keep `make coverage-changed-files` and `make unit-test-coverage` as optional local diagnostics. Update documentation to match subsystem-first pre-merge requirements.

## Detailed Description of the Issue

The repository enforced an 80% **changed-line unit coverage** gate (`gocovdiff` via `make coverage-changed-files`) on every PR that touches production Go under `provider/` and `internal/`.

That gate:

- Measures only **in-package unit tests**. Subsystem tests (Terraform + mock OCM), which are the primary behavioral gate for resources, do **not** count toward the score.
- Conflicts with documented policy: new/changed resources → **subsystem** tests; validators/helpers → **unit** tests. A PR with only subsystem coverage for a new resource still fails the gate.
- Blocks mechanical, behavior-neutral changes (for example Go bump + `go fix` on CRUD paths in #1240) at low changed-line coverage, forcing maintainer waivers and hook skips.
- Is **not** used as a merge blocker by [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws) and [terraform-provider-ibm](https://github.com/IBM-Cloud/terraform-provider-ibm)

Pre-merge quality is already enforced through `make test` (unit + subsystem + utils), `make check-subsystem-registry`, and review policy for unit tests on validators/helpers.

## Related Issues and PRs
- Jira: [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113)
- Related PR(s): #1240 (Go bump; coverage exception can be removed after this merges)

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [x] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

`make pre-push-checks` (9 steps) failed if changed production lines in `provider/`/`internal/` were below 80% unit coverage compared to `main`.

## Behavior After This Change

`make pre-push-checks` (8 steps) no longer runs `coverage-changed-files`. Contributors may still run `make coverage-changed-files` or `make unit-test-coverage` locally. Pre-merge requirements unchanged: format, build, gen, lint, docs-lint, license, subsystem registry, full test suite.

## How to Test (Step-by-Step)
### Preconditions
Clone with hooks installed; branch checked out.

### Test Steps
1. `make run-checks -- pre-push --list-steps` — confirm 8 steps, no “Coverage (changed files)”.
2. `make pre-push-checks` — passes on this branch.
3. `make coverage-changed-files` — still runs when invoked manually.

### Expected Results
Pre-push is 8/8 without coverage gate; optional coverage targets remain available.

## Proof of the Fix
- Logs/CLI output: `make pre-push-checks` → `Result: PASSED (8/8 checks passed)` locally; pre-push hook passed on push.
- CodeRabbit review vs `upstream/main`: 0 findings.
- Shellcheck on `hack/run-checks.sh` and `hack/coverage-changed-files.sh`: clean.

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A. Contributors no longer need coverage waivers for resource-only or mechanical PRs. Validators/helpers still require unit tests per CONTRIBUTING and review.

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance and README to remove changed-files coverage as a merge gate and clarify what quality checks are required vs optional.
  * Expanded the pull request template checklist to better cover validators/helpers with guidance to add unit tests where applicable.

* **Chores**
  * Removed coverage-related checks from the default pre-push/basic verification flow.
  * Added optional local diagnostic notes for coverage comparison, for manual use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->