### PR TITLE
ROSAENG-61201 | test: Fix id:63825,id:88409 day1-negative assertions

### DIFF
--- a/tests/e2e/negative_day_one_test.go
+++ b/tests/e2e/negative_day_one_test.go
@@ -572,21 +572,29 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 					args.Replicas = nil
 					args.MinReplicas = new(-3)
 					args.MaxReplicas = new(3)
-				}, "value must be at least 0")
+				}, "The value for the number of cluster nodes must be non-negative")
 				By("setting max_replicas to 0")
+				maxReplicasZeroErr := "must be a integer greater than 0"
+				if profileHandler.Profile().IsMultiAZ() {
+					maxReplicasZeroErr = "Multi AZ cluster requires at least 3 compute nodes"
+				}
 				validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {
 					args.Autoscaling = new(true)
 					args.Replicas = nil
 					args.MinReplicas = new(0)
 					args.MaxReplicas = new(0)
-				}, "must be a integer greater than 0")
+				}, maxReplicasZeroErr)
 				By("with a number not a multiple of 3")
+				multipleOfThreeErr := "require that the compute nodes be a multiple of the private subnets 3"
+				if profileHandler.Profile().IsMultiAZ() {
+					multipleOfThreeErr = "Multi AZ clusters require that the number of compute nodes be a multiple of 3"
+				}
 				validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {
 					args.Autoscaling = new(true)
 					args.Replicas = nil
 					args.MinReplicas = new(3)
 					args.MaxReplicas = new(7)
-				}, "require that the compute nodes be a multiple of the private subnets 3")
+				}, multipleOfThreeErr)
 			})
 		It("validate worker disk size - [id:76344]", ci.Low, func() {
 			maxDiskSize := constants.MaxDiskSize
@@ -629,7 +637,7 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 				}
 				args.AWSRegion = &region
 				args.AWSAvailabilityZones = &azs
-			}, "Failed to find subnets")
+			}, "Failed to find subnet")
 		})
 	})
 


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary
Fix stale e2e assertions for `[id:88409]` autoscaling negatives and `[id:63825]` BYOVPC region mismatch in Classic STS day1-negative jobs.

## Detailed Description of the Issue
Periodic jobs `e2e-rosa-sts-advanced-day1-negative-f7` and `e2e-rosa-sts-private-day1-negative-f7` fail on negative day-one tests with assertion mismatches, not provider regressions.

**`[id:88409]`** (after #1230 / [ROSAENG-60885](https://redhat.atlassian.net/browse/ROSAENG-60885)):
- Sub-case 4 (`min_replicas = -3`): expected Terraform schema `"value must be at least 0"`; provider returns `"The value for the number of cluster nodes must be non-negative"`.
- Sub-case 5 (`max_replicas = 0`): multi-AZ profiles return `"Multi AZ cluster requires at least 3 compute nodes"` instead of `"must be a integer greater than 0"`.
- Sub-case 6 (not multiple of 3): multi-AZ profiles return `"Multi AZ clusters require that the number of compute nodes be a multiple of 3"` instead of the private-subnets message.

**`[id:63825]`** ([build 2072208190161817600](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-sts-advanced-day1-negative-f7/2072208190161817600)):
- Test expected `"Failed to find subnets"`; OCM now returns `"Failed to find subnet with ID 'subnet-…'"` when deployment region/AZ do not match BYOVPC subnets.

## Related Issues and PRs
- Jira: [ROSAENG-61201](https://issues.redhat.com/browse/ROSAENG-61201)
- Related: [ROSAENG-60885](https://issues.redhat.com/browse/ROSAENG-60885), terraform-redhat/terraform-provider-rhcs#1230
- Follow-up: [ROSAENG-6359](https://redhat.atlassian.net/browse/ROSAENG-6359) (classic vs HCP day1-negative split, if needed later)
- Related PR(s): #1230
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
`[id:88409]` sub-cases 4–6 and `[id:63825]` used legacy or outdated error substrings for all profiles.

## Behavior After This Change
`[id:88409]` sub-case 4 uses the current non-negative nodes message; sub-cases 5–6 select expected text via `IsMultiAZ()`. `[id:63825]` matches current OCM subnet lookup errors via `"Failed to find subnet"`. No provider behavior change.

## How to Test (Step-by-Step)
### Preconditions
N/A — e2e test assertion only.

### Test Steps
1. Run `make pre-push-checks` locally.
2. (Optional) Run `[id:63825]` and `[id:88409]` in Classic STS advanced or private day1-negative profiles.

### Expected Results
`make pre-push-checks` passes. Both test IDs match provider/OCM errors for the active profile.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: Prow logs for `e2e-rosa-sts-advanced-day1-negative-f7` (builds [2074744887613329408](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-sts-advanced-day1-negative-f7/2074744887613329408), [2072208190161817600](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-sts-advanced-day1-negative-f7/2072208190161817600)) and `e2e-rosa-sts-private-day1-negative-f7`.
- Other artifacts: `make pre-push-checks` passed 8/8 locally.

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated autoscaling validation checks to reflect current cluster-node requirements.
  * Improved error handling expectations for Multi-AZ configurations.
  * Corrected network validation messaging for missing subnet detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->