### PR TITLE
ROSAENG-60113 | test(unit): add clusterrosa/classic validator coverage

### DIFF
--- a/provider/clusterrosa/classic/validators_test.go
+++ b/provider/clusterrosa/classic/validators_test.go
@@ -1,0 +1,301 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package classic
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/gomega"    // nolint
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	rosa "github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterrosa/common"
+	rosaTypes "github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterrosa/common/types"
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
+)
+
+func cloneBasicState() *ClusterRosaClassicState {
+	state := generateBasicRosaClassicClusterState()
+	state.Channel = types.StringNull()
+	state.Version = types.StringValue("4.14.0")
+	state.ExternalID = types.StringNull()
+	state.DisableSCPChecks = types.BoolNull()
+	state.Tags = types.MapNull(types.StringType)
+	state.EtcdEncryption = types.BoolNull()
+	state.BaseDNSDomain = types.StringNull()
+	state.AWSSubnetIDs = types.ListNull(types.StringType)
+	state.FIPS = types.BoolNull()
+	state.AWSPrivateLink = types.BoolNull()
+	state.Private = types.BoolNull()
+	state.MachineCIDR = types.StringNull()
+	state.ServiceCIDR = types.StringNull()
+	state.PodCIDR = types.StringNull()
+	state.HostPrefix = types.Int64Null()
+	state.Ec2MetadataHttpTokens = types.StringNull()
+	state.AWSAdditionalControlPlaneSecurityGroupIds = types.ListNull(types.StringType)
+	state.AWSAdditionalInfraSecurityGroupIds = types.ListNull(types.StringType)
+	state.AWSAdditionalComputeSecurityGroupIds = types.ListNull(types.StringType)
+	state.AutoScalingEnabled = types.BoolNull()
+	state.ComputeMachineType = types.StringNull()
+	state.DefaultMPLabels = types.MapNull(types.StringType)
+	state.MultiAZ = types.BoolNull()
+	state.WorkerDiskSize = types.Int64Null()
+	state.CreateAdminUser = types.BoolNull()
+	state.AdminCredentials = rosaTypes.AdminCredentialsNull()
+	return state
+}
+
+var _ = Describe("Channel and channel_group update validation", func() {
+	DescribeTable("validateChannelAndChannelGroupChanges",
+		func(mutate func(state, plan *ClusterRosaClassicState), expectedErr bool) {
+			state := cloneBasicState()
+			plan := cloneBasicState()
+			mutate(state, plan)
+
+			diags := validateChannelAndChannelGroupChanges(state, plan)
+			Expect(diags.HasError()).To(Equal(expectedErr))
+		},
+		Entry("unchanged -> ok",
+			func(_, _ *ClusterRosaClassicState) {},
+			false,
+		),
+		Entry("channel only -> ok",
+			func(state, plan *ClusterRosaClassicState) {
+				state.Channel = types.StringValue("stable")
+				plan.Channel = types.StringValue("candidate")
+			},
+			false,
+		),
+		Entry("channel_group only -> ok",
+			func(state, plan *ClusterRosaClassicState) {
+				state.ChannelGroup = types.StringValue("stable")
+				plan.ChannelGroup = types.StringValue("fast")
+			},
+			false,
+		),
+		Entry("channel and channel_group together -> error",
+			func(state, plan *ClusterRosaClassicState) {
+				state.Channel = types.StringValue("stable")
+				state.ChannelGroup = types.StringValue("stable")
+				plan.Channel = types.StringValue("candidate")
+				plan.ChannelGroup = types.StringValue("fast")
+			},
+			true,
+		),
+	)
+})
+
+var _ = Describe("Channel group and version update validation", func() {
+	DescribeTable("validateChannelGroupAndVersionChanges",
+		func(mutate func(state, plan *ClusterRosaClassicState), expectedErr bool) {
+			state := cloneBasicState()
+			plan := cloneBasicState()
+			mutate(state, plan)
+
+			diags := validateChannelGroupAndVersionChanges(state, plan)
+			Expect(diags.HasError()).To(Equal(expectedErr))
+		},
+		Entry("unchanged -> ok",
+			func(_, _ *ClusterRosaClassicState) {},
+			false,
+		),
+		Entry("channel_group only -> ok",
+			func(state, plan *ClusterRosaClassicState) {
+				state.ChannelGroup = types.StringValue("stable")
+				plan.ChannelGroup = types.StringValue("fast")
+			},
+			false,
+		),
+		Entry("version only -> ok",
+			func(state, plan *ClusterRosaClassicState) {
+				state.Version = types.StringValue("4.14.0")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			false,
+		),
+		Entry("channel_group and version together -> error",
+			func(state, plan *ClusterRosaClassicState) {
+				state.ChannelGroup = types.StringValue("stable")
+				state.Version = types.StringValue("4.14.0")
+				plan.ChannelGroup = types.StringValue("fast")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			true,
+		),
+		Entry("version set when state version is null -> counts as version change with channel_group",
+			func(state, plan *ClusterRosaClassicState) {
+				state.ChannelGroup = types.StringValue("stable")
+				state.Version = types.StringNull()
+				plan.ChannelGroup = types.StringValue("fast")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			true,
+		),
+	)
+})
+
+var _ = Describe("Channel and version update validation", func() {
+	DescribeTable("validateChannelAndVersionChanges",
+		func(mutate func(state, plan *ClusterRosaClassicState), expectedErr bool) {
+			state := cloneBasicState()
+			plan := cloneBasicState()
+			mutate(state, plan)
+
+			diags := validateChannelAndVersionChanges(state, plan)
+			Expect(diags.HasError()).To(Equal(expectedErr))
+		},
+		Entry("unchanged -> ok",
+			func(_, _ *ClusterRosaClassicState) {},
+			false,
+		),
+		Entry("channel only -> ok",
+			func(state, plan *ClusterRosaClassicState) {
+				state.Channel = types.StringValue("stable")
+				plan.Channel = types.StringValue("candidate")
+			},
+			false,
+		),
+		Entry("version only -> ok",
+			func(state, plan *ClusterRosaClassicState) {
+				state.Version = types.StringValue("4.14.0")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			false,
+		),
+		Entry("channel and version together -> error",
+			func(state, plan *ClusterRosaClassicState) {
+				state.Channel = types.StringValue("stable")
+				state.Version = types.StringValue("4.14.0")
+				plan.Channel = types.StringValue("candidate")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			true,
+		),
+		Entry("version set when state version is null -> counts as version change with channel",
+			func(state, plan *ClusterRosaClassicState) {
+				state.Channel = types.StringValue("stable")
+				state.Version = types.StringNull()
+				plan.Channel = types.StringValue("candidate")
+				plan.Version = types.StringValue("4.15.0")
+			},
+			true,
+		),
+	)
+})
+
+var _ = Describe("Immutable attribute update validation", func() {
+	It("returns no diagnostics when state and plan match", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+
+		diags := validateNoImmutableAttChange(state, plan)
+		Expect(diags.HasError()).To(BeFalse())
+	})
+
+	It("errors when an immutable attribute changes", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+		plan.Name = types.StringValue("renamed-cluster")
+
+		diags := validateNoImmutableAttChange(state, plan)
+		Expect(diags.HasError()).To(BeTrue())
+		Expect(diags.Errors()[0].Summary()).To(Equal(common.AssertionErrorSummaryMessage))
+	})
+
+	It("errors when an immutable STS field changes", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+		plan.Sts.RoleARN = types.StringValue(roleArn)
+
+		diags := validateNoImmutableAttChange(state, plan)
+		Expect(diags.HasError()).To(BeTrue())
+		Expect(diags.Errors()[0].Summary()).To(Equal(common.AssertionErrorSummaryMessage))
+	})
+})
+
+var _ = Describe("HTTP tokens version validation", func() {
+	DescribeTable("validateHttpTokensVersion",
+		func(mutate func(state *ClusterRosaClassicState), version string, expectErr bool) {
+			state := cloneBasicState()
+			mutate(state)
+
+			err := validateHttpTokensVersion(context.Background(), state, version)
+			if expectErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+		},
+		Entry("null ec2_metadata_http_tokens -> ok",
+			func(state *ClusterRosaClassicState) {
+				state.Ec2MetadataHttpTokens = types.StringNull()
+			},
+			"not-a-version",
+			false,
+		),
+		Entry("optional ec2_metadata_http_tokens -> ok",
+			func(state *ClusterRosaClassicState) {
+				state.Ec2MetadataHttpTokens = types.StringValue(string(cmv1.Ec2MetadataHttpTokensOptional))
+			},
+			"not-a-version",
+			false,
+		),
+		Entry("invalid version string -> error",
+			func(state *ClusterRosaClassicState) {
+				state.Ec2MetadataHttpTokens = types.StringValue(string(cmv1.Ec2MetadataHttpTokensRequired))
+			},
+			"not-a-version",
+			true,
+		),
+	)
+})
+
+var _ = Describe("getOcmVersionMinor", func() {
+	DescribeTable("extracts major.minor",
+		func(input, expected string) {
+			Expect(getOcmVersionMinor(input)).To(Equal(expected))
+		},
+		Entry("semver version", "4.14.5", "4.14"),
+		Entry("two-segment version", "4.14", "4.14"),
+		Entry("prefixed version falls back to split", "openshift-v4.14.5", "openshift-v4.14"),
+	)
+})
+
+var _ = Describe("shouldPatchProperties", func() {
+	It("returns true when user properties change", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+		plan.Properties = types.MapValueMust(types.StringType, map[string]attr.Value{
+			"rosa_creator_arn": types.StringValue("arn:aws:iam::123456789012:user/other"),
+		})
+
+		Expect(shouldPatchProperties(state, plan)).To(BeTrue())
+	})
+
+	It("returns false when properties and OCM defaults are unchanged", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+		state.OCMProperties = types.MapValueMust(types.StringType, map[string]attr.Value{
+			rosa.PropertyRosaTfVersion: types.StringValue(rosa.OCMProperties[rosa.PropertyRosaTfVersion]),
+			rosa.PropertyRosaTfCommit:  types.StringValue(rosa.OCMProperties[rosa.PropertyRosaTfCommit]),
+		})
+		plan.OCMProperties = state.OCMProperties
+
+		Expect(shouldPatchProperties(state, plan)).To(BeFalse())
+	})
+
+	It("returns true when OCM default property values drift", func() {
+		state := cloneBasicState()
+		plan := cloneBasicState()
+		state.OCMProperties = types.MapValueMust(types.StringType, map[string]attr.Value{
+			rosa.PropertyRosaTfVersion: types.StringValue("stale-version"),
+			rosa.PropertyRosaTfCommit:  types.StringValue(rosa.OCMProperties[rosa.PropertyRosaTfCommit]),
+		})
+		plan.OCMProperties = state.OCMProperties
+
+		Expect(shouldPatchProperties(state, plan)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
## PR Summary

Add unit tests for Classic cluster update validators and small pure helpers in `provider/clusterrosa/classic`. **PR 5 of 6** in the [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113) unit-test coverage series.

### Planned follow-up PRs
1. `provider/common/attrvalidators` — merged ([#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212))
2. `provider/clusterrosa/common` + `hcp/shared_vpc` — merged ([#1218](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1218))
3. `provider/common` (root) — merged ([#1231](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1231))
4. `provider/clusterrosa/hcp` — merged ([#1243](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1243))
5. `provider/clusterrosa/classic` — untested `validate*` / small pure funcs — **this PR**
6. `provider/proxy` — `Contains` (optional, if still uncovered)

## Detailed Description of the Issue

Classic cluster resource helpers for update-time validation (`validateChannel*`, `validateNoImmutableAttChange`, `validateHttpTokensVersion`) and small pure functions (`getOcmVersionMinor`, `shouldPatchProperties`) had no direct unit tests beyond two `validateHttpTokensVersion` cases in `cluster_rosa_classic_resource_test.go`.

## Related Issues and PRs
- Jira: [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113)
- Related PR(s): [#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212), [#1218](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1218), [#1231](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1231), [#1243](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1243); part 5 of 6 (`ROSAENG-60113-unit-tests-5`).

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

No unit tests covered Classic update validators or the listed pure helpers as a focused suite.

## Behavior After This Change

Table-driven Ginkgo unit tests validate channel/version mutual-exclusion rules, immutability checks, HTTP tokens version early-return and error paths, and property-patch logic. No production code changes.

### Intentional skips (e2e/subsystem checklist)
- **`validateUpgrade` / `scheduleUpgrade`** — require OCM client; defer to subsystem/e2e upgrade flows.
- **HTTP tokens min-version matrix** — required + unsupported/supported version cases remain in `cluster_rosa_classic_resource_test.go`; `validators_test.go` adds null/optional early-return and invalid-version parsing only.
- **Full immutability matrix** — representative unit coverage; subsystem immutability tests cover resource wiring.
- **CRUD paths** — out of scope for this PR series entry.

## How to Test (Step-by-Step)

### Preconditions
- Go toolchain and repo dependencies installed.

### Test Steps
1. `go test ./provider/clusterrosa/classic -count=1`
2. `make pre-push-checks`

### Expected Results
- All `provider/clusterrosa/classic` specs pass.
- Pre-push checks pass.

## Proof of the Fix
- Logs/CLI output: local `make pre-push-checks` (8/8 passed) and CodeRabbit local review (1 minor finding addressed: `AdminCredentialsNull()` fixture).

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [x] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive Go test suite for classic cluster validation scenarios, including update-rule checks (channel/channel group and version interactions), immutable field enforcement, HTTP tokens version validation, major/minor version parsing, and property drift behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->