### PR TITLE
ROSAENG-61734 | feat: Add delete_protection to ROSA cluster resources

### DIFF
--- a/docs/data-sources/cluster_rosa_classic.md
+++ b/docs/data-sources/cluster_rosa_classic.md
@@ -52,6 +52,7 @@ data "rhcs_cluster_rosa_classic" "cluster" {
 - `create_admin_user` (Boolean) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 - `current_version` (String) The currently running version of OpenShift on the cluster, for example '4.11.0'.
 - `default_mp_labels` (Map of String) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
+- `delete_protection` (Boolean) Reports whether OCM delete protection is enabled for the cluster.
 - `destroy_timeout` (Number) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 - `disable_scp_checks` (Boolean) Indicates if cloud permission checks are disabled when attempting installation of the cluster. After the creation of the resource, it is not possible to update the attribute value.
 - `disable_waiting_in_destroy` (Boolean) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource

--- a/docs/data-sources/cluster_rosa_hcp.md
+++ b/docs/data-sources/cluster_rosa_hcp.md
@@ -58,6 +58,7 @@ Use the `fips` attribute from this data source to confirm whether FIPS was enabl
 - `console_url` (String) URL of the console.
 - `create_admin_user` (Boolean) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 - `current_version` (String) The currently running version of OpenShift on the cluster, for example '4.11.0'.
+- `delete_protection` (Boolean) Reports whether OCM delete protection is enabled for the cluster.
 - `destroy_timeout` (Number) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 - `disable_waiting_in_destroy` (Boolean) This attribute is not supported for cluster data source. Therefore, it will not be displayed as an output of the datasource
 - `domain` (String) DNS domain of cluster.

--- a/docs/resources/cluster_rosa_classic.md
+++ b/docs/resources/cluster_rosa_classic.md
@@ -39,6 +39,9 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   }
   sts                      = local.sts_roles
   wait_for_create_complete = true
+
+  # Optional: enable OCM delete protection (set to false and apply before terraform destroy)
+  # delete_protection = true
 }
 ```
 
@@ -67,6 +70,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
 - `compute_machine_type` (String) Identifies the machine type used by the initial worker nodes, for example `m5.xlarge`. Use the `rhcs_machine_types` data source to find the possible values. This attribute specifically applies to the Worker Machine Pool and becomes irrelevant once the resource is created. Any modifications to the initial Machine Pool should be made through the Terraform imported Machine Pool resource. For more details, refer to [Worker Machine Pool in ROSA Cluster](../guides/worker-machine-pool.md)
 - `create_admin_user` (Boolean) Indicates if create cluster admin user. Set it true to create cluster admin user with default username `cluster-admin` and generated password. It will be ignored if `admin_credentials` is set.After the creation of the resource, it is not possible to update the attribute value.
 - `default_mp_labels` (Map of String) This value is the default/initial machine pool labels. Format should be a comma-separated list of '{"key1"="value1", "key2"="value2"}'. This attribute specifically applies to the Worker Machine Pool and becomes irrelevant once the resource is created. Any modifications to the initial Machine Pool should be made through the Terraform imported Machine Pool resource. For more details, refer to [Worker Machine Pool in ROSA Cluster](../guides/worker-machine-pool.md)
+- `delete_protection` (Boolean) When true, prevents cluster deletion via OCM. This attribute can be changed after cluster creation. To destroy the cluster, set this to false and apply before running terraform destroy.
 - `destroy_timeout` (Number) Maximum duration in minutes to wait for OpenShift Cluster Manager (OCM) to delete the cluster during destroy. Default value is 60 minutes. If the cluster still exists when the timeout expires, destroy fails and the resource remains in Terraform state so dependent STS resources (IAM roles, OIDC provider) are not removed while OCM uninstall may still be in progress. Set `disable_waiting_in_destroy = true` to skip this wait entirely.
 - `disable_scp_checks` (Boolean) Indicates if cloud permission checks are disabled when attempting installation of the cluster. After the creation of the resource, it is not possible to update the attribute value.
 - `disable_waiting_in_destroy` (Boolean) Disable addressing cluster state in the destroy resource. Default value is false, and so a `destroy` will wait for the cluster to be deleted from OCM before removing it from Terraform state.

--- a/docs/resources/cluster_rosa_hcp.md
+++ b/docs/resources/cluster_rosa_hcp.md
@@ -42,6 +42,9 @@ resource "rhcs_cluster_rosa_hcp" "rosa_sts_cluster" {
   sts                                 = local.sts_roles
   wait_for_create_complete            = true
   wait_for_std_compute_nodes_complete = true
+
+  # Optional: enable OCM delete protection (set to false and apply before terraform destroy)
+  # delete_protection = true
 }
 ```
 
@@ -83,6 +86,7 @@ When a proxy is configured on a zero-egress cluster, the OCM API appends platfor
 - `channel_group` (String) Name of the channel group where you select the OpenShift cluster version, for example 'stable'. For ROSA, only 'stable' and 'eus' are supported. Cannot be used together with 'channel'. Starting from 1.7.7, this attribute no longer has a default value and is computed by the API.
 - `compute_machine_type` (String) Identifies the machine type used by the initial worker nodes, for example `m5.xlarge`. Use the `rhcs_machine_types` data source to find the possible values. This attribute specifically applies to the Worker Machine Pool and becomes irrelevant once the resource is created. Any modifications to the initial Machine Pool should be made through the Terraform imported Machine Pool resource. For more details, refer to [Worker Machine Pool in ROSA Cluster](../guides/worker-machine-pool.md)
 - `create_admin_user` (Boolean) Indicates if create cluster admin user. Set it true to create cluster admin user with default username `cluster-admin` and generated password. It will be ignored if `admin_credentials` is set.After the creation of the resource, it is not possible to update the attribute value.
+- `delete_protection` (Boolean) When true, prevents cluster deletion via OCM. This attribute can be changed after cluster creation. To destroy the cluster, set this to false and apply before running terraform destroy.
 - `destroy_timeout` (Number) Maximum duration in minutes to wait for OpenShift Cluster Manager (OCM) to delete the cluster during destroy. Default value is 60 minutes. If the cluster still exists when the timeout expires, destroy fails and the resource remains in Terraform state so dependent STS resources (IAM roles, OIDC provider) are not removed while OCM uninstall may still be in progress. Set `disable_waiting_in_destroy = true` to skip this wait entirely.
 - `disable_waiting_in_destroy` (Boolean) Disable addressing cluster state in the destroy resource. Default value is false, and so a `destroy` will wait for the cluster to be deleted from OCM before removing it from Terraform state.
 - `domain_prefix` (String) The domain prefix is optionally assigned by the user.It will appear in the Cluster's domain when the cluster is provisioned. If not supplied, it will be auto generated. It cannot exceed 15 characters in length. After the creation of the resource, it is not possible to update the attribute value.

--- a/examples/resources/cluster_rosa_classic/example_1.tf
+++ b/examples/resources/cluster_rosa_classic/example_1.tf
@@ -24,4 +24,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   }
   sts                      = local.sts_roles
   wait_for_create_complete = true
+
+  # Optional: enable OCM delete protection (set to false and apply before terraform destroy)
+  # delete_protection = true
 }

--- a/examples/resources/cluster_rosa_hcp/example_1.tf
+++ b/examples/resources/cluster_rosa_hcp/example_1.tf
@@ -27,4 +27,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa_sts_cluster" {
   sts                                 = local.sts_roles
   wait_for_create_complete            = true
   wait_for_std_compute_nodes_complete = true
+
+  # Optional: enable OCM delete protection (set to false and apply before terraform destroy)
+  # delete_protection = true
 }

--- a/provider/clusterrosa/classic/cluster_rosa_classic_datasource.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_datasource.go
@@ -27,6 +27,7 @@ import (
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
+	rosa "github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterrosa/common"
 	rosaTypes "github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterrosa/common/types"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/clusterrosa/sts"
 	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
@@ -94,6 +95,7 @@ func (r *ClusterRosaClassicDatasource) Schema(ctx context.Context, req datasourc
 					"Site Reliability Engineer (SRE) platform metrics.",
 				Computed: true,
 			},
+			"delete_protection": rosa.DeleteProtectionDatasourceSchema(),
 			"disable_scp_checks": schema.BoolAttribute{
 				Description: "Indicates if cloud permission checks are disabled when attempting installation of the cluster. " +
 					common.ValueCannotBeChangedStringDescription,
@@ -414,6 +416,14 @@ func (r *ClusterRosaClassicDatasource) Read(ctx context.Context, request datasou
 	state.ComputeMachineType = types.StringNull()
 	state.WorkerDiskSize = types.Int64Null()
 	state.DefaultMPLabels = types.MapNull(types.StringType)
+
+	clusterClient := r.clusterCollection.Cluster(state.ID.ValueString())
+	dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
+	response.Diagnostics.Append(dpDiags...)
+	if dpDiags.HasError() {
+		return
+	}
+	state.DeleteProtection = dpVal
 
 	diags = response.State.Set(ctx, state)
 	response.Diagnostics.Append(diags...)

--- a/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
@@ -151,6 +151,7 @@ func (r *ClusterRosaClassicResource) Schema(ctx context.Context, req resource.Sc
 					"Site Reliability Engineer (SRE) platform metrics.",
 				Optional: true,
 			},
+			"delete_protection": rosa.DeleteProtectionResourceSchema(),
 			"disable_scp_checks": schema.BoolAttribute{
 				Description: "Indicates if cloud permission checks are disabled when attempting installation of the cluster. " +
 					common.ValueCannotBeChangedStringDescription,
@@ -865,6 +866,7 @@ func (r *ClusterRosaClassicResource) Create(ctx context.Context, request resourc
 	if response.Diagnostics.HasError() {
 		return
 	}
+	enableDeleteProtection := common.HasValue(state.DeleteProtection) && state.DeleteProtection.ValueBool()
 	summary := "Can't build cluster"
 
 	// In case version with "openshift-v" prefix was used here,
@@ -1010,6 +1012,30 @@ func (r *ClusterRosaClassicResource) Create(ctx context.Context, request resourc
 		return
 	}
 
+	if enableDeleteProtection {
+		clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+		err = rosa.UpdateDeleteProtection(ctx, clusterClient, true)
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Can't enable delete protection",
+				fmt.Sprintf(
+					"Cluster '%s' was created but delete protection could not be enabled: %v",
+					state.ID.ValueString(), err,
+				),
+			)
+			state.DeleteProtection = types.BoolValue(true)
+			diags = response.State.Set(ctx, state)
+			response.Diagnostics.Append(diags...)
+			return
+		}
+		state.DeleteProtection = types.BoolValue(true)
+	} else {
+		clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+		dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
+		response.Diagnostics.Append(dpDiags...)
+		state.DeleteProtection = dpVal
+	}
+
 	diags = response.State.Set(ctx, state)
 	response.Diagnostics.Append(diags...)
 }
@@ -1057,6 +1083,16 @@ func (r *ClusterRosaClassicResource) Read(ctx context.Context, request resource.
 			),
 		)
 		return
+	}
+
+	clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+	priorDeleteProtection := state.DeleteProtection
+	dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
+	response.Diagnostics.Append(dpDiags...)
+	if len(dpDiags) > 0 && common.HasValue(priorDeleteProtection) && priorDeleteProtection.ValueBool() {
+		state.DeleteProtection = priorDeleteProtection
+	} else {
+		state.DeleteProtection = dpVal
 	}
 
 	diags = response.State.Set(ctx, state)
@@ -1273,6 +1309,28 @@ func (r *ClusterRosaClassicResource) Update(ctx context.Context, request resourc
 		return
 	}
 
+	_, shouldPatchDeleteProtection := common.ShouldPatchBool(state.DeleteProtection, plan.DeleteProtection)
+	desiredDeleteProtection := plan.DeleteProtection
+	if shouldPatchDeleteProtection {
+		clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+		err := rosa.UpdateDeleteProtection(ctx, clusterClient, plan.DeleteProtection.ValueBool())
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Can't update delete protection",
+				fmt.Sprintf(
+					"Can't update delete protection for cluster with identifier '%s': %v",
+					state.ID.ValueString(), err,
+				),
+			)
+			state.DeleteProtection = types.BoolValue(true)
+			diags = response.State.Set(ctx, state)
+			response.Diagnostics.Append(diags...)
+			return
+		}
+		tflog.Debug(ctx, fmt.Sprintf("Updated delete protection from %v to %v",
+			state.DeleteProtection.ValueBool(), plan.DeleteProtection.ValueBool()))
+	}
+
 	clusterBuilder := cmv1.NewCluster()
 
 	clusterBuilder, err := updateProxy(state, plan, clusterBuilder)
@@ -1373,6 +1431,20 @@ func (r *ClusterRosaClassicResource) Update(ctx context.Context, request resourc
 			),
 		)
 		return
+	}
+
+	if shouldPatchDeleteProtection {
+		plan.DeleteProtection = desiredDeleteProtection
+	} else {
+		clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+		priorDeleteProtection := state.DeleteProtection
+		dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
+		response.Diagnostics.Append(dpDiags...)
+		if len(dpDiags) > 0 && common.HasValue(priorDeleteProtection) && priorDeleteProtection.ValueBool() {
+			plan.DeleteProtection = priorDeleteProtection
+		} else {
+			plan.DeleteProtection = dpVal
+		}
 	}
 
 	diags = response.State.Set(ctx, plan)
@@ -1575,9 +1647,22 @@ func (r *ClusterRosaClassicResource) Delete(ctx context.Context, request resourc
 		return
 	}
 
+	clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+	deleteProtectionEnabledInOCM, checkDiags := rosa.CheckDeleteProtectionEnabled(
+		ctx, state.ID.ValueString(), clusterClient)
+	deleteProtectionEnabledInState := common.HasValue(state.DeleteProtection) && state.DeleteProtection.ValueBool()
+	if checkDiags.HasError() && !deleteProtectionEnabledInState {
+		response.Diagnostics.Append(checkDiags...)
+		return
+	}
+	deleteProtectionEnabled := deleteProtectionEnabledInState || deleteProtectionEnabledInOCM
+	if deleteDiags := rosa.ValidateDeleteAllowed(state.ID.ValueString(), deleteProtectionEnabled); deleteDiags.HasError() {
+		response.Diagnostics.Append(deleteDiags...)
+		return
+	}
+
 	// Send the request to delete the cluster:
-	resource := r.ClusterCollection.Cluster(state.ID.ValueString())
-	_, err := resource.Delete().SendContext(ctx)
+	_, err := clusterClient.Delete().SendContext(ctx)
 	if err != nil {
 		response.Diagnostics.AddError(
 			"Can't delete cluster",
@@ -1600,7 +1685,7 @@ func (r *ClusterRosaClassicResource) Delete(ctx context.Context, request resourc
 				timeout = state.DestroyTimeout.ValueInt64()
 			}
 		}
-		isNotFound, err := r.retryClusterNotFoundWithTimeout(3, 1*time.Minute, ctx, timeout, resource)
+		isNotFound, err := r.retryClusterNotFoundWithTimeout(3, 1*time.Minute, ctx, timeout, clusterClient)
 		if err != nil {
 			response.Diagnostics.AddError(
 				"Can't poll cluster state",

--- a/provider/clusterrosa/classic/cluster_rosa_classic_state.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_state.go
@@ -82,4 +82,6 @@ type ClusterRosaClassicState struct {
 	DestroyTimeout                 types.Int64 `tfsdk:"destroy_timeout"`
 	WaitForCreateComplete          types.Bool  `tfsdk:"wait_for_create_complete"`
 	MaxClusterWaitTimeoutInMinutes types.Int64 `tfsdk:"max_cluster_wait_timeout_in_minutes"`
+
+	DeleteProtection types.Bool `tfsdk:"delete_protection"`
 }

--- a/provider/clusterrosa/common/delete_protection.go
+++ b/provider/clusterrosa/common/delete_protection.go
@@ -1,0 +1,156 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+const deleteProtectionResourceDescription = "When true, prevents cluster deletion via OCM. " +
+	"This attribute can be changed after cluster creation. " +
+	"To destroy the cluster, set this to false and apply before running terraform destroy."
+
+const deleteProtectionDatasourceDescription = "Reports whether OCM delete protection is enabled for the cluster."
+
+// DeleteProtectionResourceSchema returns the schema definition for the delete_protection
+// resource attribute.
+func DeleteProtectionResourceSchema() schema.BoolAttribute {
+	return schema.BoolAttribute{
+		Description: deleteProtectionResourceDescription,
+		Optional:    true,
+		Computed:    true,
+		PlanModifiers: []planmodifier.Bool{
+			boolplanmodifier.UseStateForUnknown(),
+		},
+	}
+}
+
+// DeleteProtectionDatasourceSchema returns the schema definition for the delete_protection
+// data source attribute.
+func DeleteProtectionDatasourceSchema() schema.BoolAttribute {
+	return schema.BoolAttribute{
+		Description: deleteProtectionDatasourceDescription,
+		Computed:    true,
+	}
+}
+
+func deleteProtectionFromCluster(object *cmv1.Cluster) (enabled bool, ok bool) {
+	if object == nil {
+		return false, false
+	}
+	if dp, present := object.GetDeleteProtection(); present && dp != nil {
+		return dp.Enabled(), true
+	}
+	return false, false
+}
+
+// FetchDeleteProtection reads delete protection from the cluster sub-resource endpoint.
+func FetchDeleteProtection(ctx context.Context, clusterClient *cmv1.ClusterClient) (bool, error) {
+	resp, err := clusterClient.DeleteProtection().Get().SendContext(ctx)
+	if err != nil {
+		return false, err
+	}
+	if resp.Body() != nil {
+		return resp.Body().Enabled(), nil
+	}
+	return false, fmt.Errorf("delete protection response body is empty")
+}
+
+// ResolveDeleteProtection resolves delete protection from the cluster object, falling back
+// to the sub-resource GET when the inline field is absent.
+func ResolveDeleteProtection(
+	ctx context.Context,
+	clusterClient *cmv1.ClusterClient,
+	object *cmv1.Cluster,
+) (types.Bool, diag.Diagnostics) {
+	if enabled, ok := deleteProtectionFromCluster(object); ok {
+		return types.BoolValue(enabled), nil
+	}
+
+	enabled, err := FetchDeleteProtection(ctx, clusterClient)
+	if err != nil {
+		return types.BoolValue(false), diag.Diagnostics{
+			diag.NewWarningDiagnostic(
+				"Can't read delete protection",
+				fmt.Sprintf(
+					"Could not read delete protection status from the API: %v. "+
+						"Assuming delete protection is disabled; run terraform apply again to refresh.",
+					err,
+				),
+			),
+		}
+	}
+	return types.BoolValue(enabled), nil
+}
+
+// UpdateDeleteProtection patches the cluster delete protection sub-resource.
+func UpdateDeleteProtection(ctx context.Context, clusterClient *cmv1.ClusterClient, enabled bool) error {
+	body, err := cmv1.NewDeleteProtection().Enabled(enabled).Build()
+	if err != nil {
+		return fmt.Errorf("can't build delete protection object: %w", err)
+	}
+	_, err = clusterClient.DeleteProtection().Update().Body(body).SendContext(ctx)
+	if err != nil {
+		return fmt.Errorf("can't update cluster delete protection: %w", err)
+	}
+	return nil
+}
+
+// ValidateDeleteAllowed returns an error diagnostic when delete protection is enabled.
+func ValidateDeleteAllowed(clusterID string, enabled bool) diag.Diagnostics {
+	if enabled {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic(
+				"Can't delete cluster",
+				fmt.Sprintf(
+					"Delete protection is enabled for cluster '%s'. "+
+						"Set delete_protection = false in configuration, run terraform apply, then retry destroy.",
+					clusterID,
+				),
+			),
+		}
+	}
+	return nil
+}
+
+// CheckDeleteProtectionEnabled reads the live delete protection status before destroy.
+func CheckDeleteProtectionEnabled(
+	ctx context.Context,
+	clusterID string,
+	clusterClient *cmv1.ClusterClient,
+) (bool, diag.Diagnostics) {
+	enabled, err := FetchDeleteProtection(ctx, clusterClient)
+	if err != nil {
+		getResp, getErr := clusterClient.Get().SendContext(ctx)
+		if getErr == nil && getResp.Body() != nil {
+			if inlineEnabled, ok := deleteProtectionFromCluster(getResp.Body()); ok {
+				return inlineEnabled, nil
+			}
+		}
+		detail := fmt.Sprintf(
+			"Could not verify delete protection status before deleting cluster '%s': %v",
+			clusterID, err,
+		)
+		if getErr != nil {
+			detail += fmt.Sprintf("; cluster GET fallback failed: %v", getErr)
+		} else if getResp == nil || getResp.Body() == nil {
+			detail += "; cluster GET fallback returned an empty response"
+		}
+		return false, diag.Diagnostics{
+			diag.NewErrorDiagnostic(
+				"Can't verify delete protection",
+				detail,
+			),
+		}
+	}
+	return enabled, nil
+}

--- a/provider/clusterrosa/common/delete_protection_test.go
+++ b/provider/clusterrosa/common/delete_protection_test.go
@@ -1,0 +1,222 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	sdktesting "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Delete protection helpers", func() {
+	Context("ValidateDeleteAllowed", func() {
+		It("returns no diagnostics when delete protection is disabled", func() {
+			diags := ValidateDeleteAllowed("123", false)
+			Expect(diags.HasError()).To(BeFalse())
+		})
+
+		It("returns an error when delete protection is enabled", func() {
+			diags := ValidateDeleteAllowed("123", true)
+			Expect(diags.HasError()).To(BeTrue())
+			Expect(diags.Errors()[0].Detail()).To(ContainSubstring("delete_protection = false"))
+		})
+	})
+
+	Context("Sub-resource operations", func() {
+		var (
+			server        *ghttp.Server
+			ca            string
+			connection    *sdk.Connection
+			clusterClient *cmv1.ClusterClient
+			ctx           context.Context
+		)
+
+		BeforeEach(func() {
+			server, ca = sdktesting.MakeTCPTLSServer()
+			token := sdktesting.MakeTokenString("Bearer", 10*time.Minute)
+			ctx = context.Background()
+			var err error
+			connection, err = sdk.NewConnectionBuilder().
+				URL(server.URL()).
+				TrustedCAFile(ca).
+				Tokens(token).
+				BuildContext(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			clusterClient = connection.ClustersMgmt().V1().Clusters().Cluster("123")
+		})
+
+		AfterEach(func() {
+			server.Close()
+			connection.Close()
+		})
+
+		Context("FetchDeleteProtection", func() {
+			It("returns true when the sub-resource reports enabled", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters/123/delete_protection"),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]interface{}{
+							"enabled": true,
+						}),
+					),
+				)
+				enabled, err := FetchDeleteProtection(ctx, clusterClient)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(enabled).To(BeTrue())
+			})
+
+			It("returns false when the sub-resource reports disabled", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters/123/delete_protection"),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]interface{}{
+							"enabled": false,
+						}),
+					),
+				)
+				enabled, err := FetchDeleteProtection(ctx, clusterClient)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(enabled).To(BeFalse())
+			})
+
+			It("returns an error when the API call fails", func() {
+				server.RouteToHandler("GET",
+					"/api/clusters_mgmt/v1/clusters/123/delete_protection",
+					sdktesting.RespondWithJSON(http.StatusNotFound, `{"kind":"Error","id":"404","href":"/api/clusters_mgmt/v1/errors/404","code":"CLUSTERS-MGMT-404","reason":"not found"}`),
+				)
+				_, err := FetchDeleteProtection(ctx, clusterClient)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("UpdateDeleteProtection", func() {
+			It("sends a PATCH with the enabled value", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PATCH", "/api/clusters_mgmt/v1/clusters/123/delete_protection"),
+						sdktesting.VerifyJQ(".enabled", true),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]interface{}{
+							"enabled": true,
+						}),
+					),
+				)
+				err := UpdateDeleteProtection(ctx, clusterClient, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns an error when the API call fails", func() {
+				server.RouteToHandler("PATCH",
+					"/api/clusters_mgmt/v1/clusters/123/delete_protection",
+					sdktesting.RespondWithJSON(http.StatusNotFound, `{"kind":"Error","id":"404","href":"/api/clusters_mgmt/v1/errors/404","code":"CLUSTERS-MGMT-404","reason":"not found"}`),
+				)
+				err := UpdateDeleteProtection(ctx, clusterClient, false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("can't update cluster delete protection"))
+			})
+		})
+
+		Context("ResolveDeleteProtection", func() {
+			It("returns the inline value when present", func() {
+				cluster, err := cmv1.NewCluster().
+					DeleteProtection(cmv1.NewDeleteProtection().Enabled(true)).
+					Build()
+				Expect(err).NotTo(HaveOccurred())
+
+				val, diags := ResolveDeleteProtection(ctx, clusterClient, cluster)
+				Expect(diags).To(BeEmpty())
+				Expect(val.ValueBool()).To(BeTrue())
+			})
+
+			It("falls back to the sub-resource when inline is absent", func() {
+				cluster, err := cmv1.NewCluster().Build()
+				Expect(err).NotTo(HaveOccurred())
+
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters/123/delete_protection"),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]interface{}{
+							"enabled": true,
+						}),
+					),
+				)
+
+				val, diags := ResolveDeleteProtection(ctx, clusterClient, cluster)
+				Expect(diags).To(BeEmpty())
+				Expect(val.ValueBool()).To(BeTrue())
+			})
+
+			It("returns a warning when the sub-resource call fails", func() {
+				cluster, err := cmv1.NewCluster().Build()
+				Expect(err).NotTo(HaveOccurred())
+
+				server.RouteToHandler("GET",
+					"/api/clusters_mgmt/v1/clusters/123/delete_protection",
+					sdktesting.RespondWithJSON(http.StatusNotFound, `{"kind":"Error","id":"404","href":"/api/clusters_mgmt/v1/errors/404","code":"CLUSTERS-MGMT-404","reason":"not found"}`),
+				)
+
+				val, diags := ResolveDeleteProtection(ctx, clusterClient, cluster)
+				Expect(diags).To(HaveLen(1))
+				Expect(diags[0].Detail()).To(ContainSubstring("Could not read delete protection"))
+				Expect(val.ValueBool()).To(BeFalse())
+			})
+		})
+
+		Context("CheckDeleteProtectionEnabled", func() {
+			It("returns the sub-resource value when available", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters/123/delete_protection"),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]interface{}{
+							"enabled": true,
+						}),
+					),
+				)
+				enabled, diags := CheckDeleteProtectionEnabled(ctx, "123", clusterClient)
+				Expect(diags).To(BeEmpty())
+				Expect(enabled).To(BeTrue())
+			})
+
+			It("falls back to the cluster GET when the sub-resource fails", func() {
+				clusterJSON := `{
+					"kind": "Cluster",
+					"id": "123",
+					"name": "test-cluster",
+					"delete_protection": {"enabled": true}
+				}`
+				server.RouteToHandler("GET",
+					"/api/clusters_mgmt/v1/clusters/123/delete_protection",
+					sdktesting.RespondWithJSON(http.StatusNotFound, `{"kind":"Error","id":"404","href":"/api/clusters_mgmt/v1/errors/404","code":"CLUSTERS-MGMT-404","reason":"not found"}`),
+				)
+				server.RouteToHandler("GET",
+					"/api/clusters_mgmt/v1/clusters/123",
+					sdktesting.RespondWithJSON(http.StatusOK, clusterJSON),
+				)
+				enabled, diags := CheckDeleteProtectionEnabled(ctx, "123", clusterClient)
+				Expect(diags).To(BeEmpty())
+				Expect(enabled).To(BeTrue())
+			})
+
+			It("returns an error when both sub-resource and cluster GET fail", func() {
+				server.RouteToHandler("GET",
+					"/api/clusters_mgmt/v1/clusters/123/delete_protection",
+					sdktesting.RespondWithJSON(http.StatusNotFound, `{"kind":"Error","id":"404","href":"/api/clusters_mgmt/v1/errors/404","code":"CLUSTERS-MGMT-404","reason":"not found"}`),
+				)
+				server.RouteToHandler("GET",
+					"/api/clusters_mgmt/v1/clusters/123",
+					sdktesting.RespondWithJSON(http.StatusNotFound, `{"kind":"Error","id":"404","href":"/api/clusters_mgmt/v1/errors/404","code":"CLUSTERS-MGMT-404","reason":"cluster error"}`),
+				)
+				_, diags := CheckDeleteProtectionEnabled(ctx, "123", clusterClient)
+				Expect(diags.HasError()).To(BeTrue())
+				Expect(diags.Errors()[0].Detail()).To(ContainSubstring("cluster GET fallback failed"))
+			})
+		})
+	})
+})

--- a/provider/clusterrosa/hcp/datasource.go
+++ b/provider/clusterrosa/hcp/datasource.go
@@ -375,6 +375,7 @@ func (r *ClusterRosaHcpDatasource) Schema(ctx context.Context, req datasource.Sc
 				Description: "Enable external authentication providers on the cluster.",
 				Computed:    true,
 			},
+			"delete_protection": rosa.DeleteProtectionDatasourceSchema(),
 		},
 	}
 }
@@ -496,6 +497,14 @@ func (r *ClusterRosaHcpDatasource) Read(ctx context.Context, request datasource.
 			},
 		},
 	})
+
+	clusterClient := r.clusterCollection.Cluster(state.ID.ValueString())
+	dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
+	response.Diagnostics.Append(dpDiags...)
+	if dpDiags.HasError() {
+		return
+	}
+	state.DeleteProtection = dpVal
 
 	diags = response.State.Set(ctx, state)
 	response.Diagnostics.Append(diags...)

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -496,6 +496,7 @@ func (r *ClusterRosaHcpResource) Schema(ctx context.Context, req resource.Schema
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"delete_protection": rosa.DeleteProtectionResourceSchema(),
 			"log_forwarders_at_cluster_creation": schema.ListNestedAttribute{
 				Description: "List of log forwarders to configure during cluster creation (Day 1 only). " +
 					"This field is immutable after cluster creation and cannot be modified. " +
@@ -949,6 +950,7 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 	if response.Diagnostics.HasError() {
 		return
 	}
+	enableDeleteProtection := common.HasValue(state.DeleteProtection) && state.DeleteProtection.ValueBool()
 	summary := "Can't build cluster"
 
 	shouldWaitCreationComplete := common.BoolWithFalseDefault(state.WaitForCreateComplete)
@@ -1204,6 +1206,30 @@ func (r *ClusterRosaHcpResource) Create(ctx context.Context, request resource.Cr
 		state.Proxy.NoProxy = plannedNoProxy
 	}
 
+	if enableDeleteProtection {
+		clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+		err = rosa.UpdateDeleteProtection(ctx, clusterClient, true)
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Can't enable delete protection",
+				fmt.Sprintf(
+					"Cluster '%s' was created but delete protection could not be enabled: %v",
+					state.ID.ValueString(), err,
+				),
+			)
+			state.DeleteProtection = types.BoolValue(true)
+			diags = response.State.Set(ctx, state)
+			response.Diagnostics.Append(diags...)
+			return
+		}
+		state.DeleteProtection = types.BoolValue(true)
+	} else {
+		clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+		dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
+		response.Diagnostics.Append(dpDiags...)
+		state.DeleteProtection = dpVal
+	}
+
 	diags = response.State.Set(ctx, state)
 	response.Diagnostics.Append(diags...)
 }
@@ -1278,6 +1304,16 @@ func (r *ClusterRosaHcpResource) Read(ctx context.Context, request resource.Read
 			fmt.Sprintf("Received error %v", err),
 		)
 		state.Proxy.NoProxy = priorNoProxy
+	}
+
+	clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+	priorDeleteProtection := state.DeleteProtection
+	dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
+	response.Diagnostics.Append(dpDiags...)
+	if len(dpDiags) > 0 && common.HasValue(priorDeleteProtection) && priorDeleteProtection.ValueBool() {
+		state.DeleteProtection = priorDeleteProtection
+	} else {
+		state.DeleteProtection = dpVal
 	}
 
 	diags = response.State.Set(ctx, state)
@@ -1499,6 +1535,9 @@ func (r *ClusterRosaHcpResource) Update(ctx context.Context, request resource.Up
 		return
 	}
 
+	_, shouldPatchDeleteProtection := common.ShouldPatchBool(state.DeleteProtection, plan.DeleteProtection)
+	desiredDeleteProtection := plan.DeleteProtection
+
 	clusterBuilder := cmv1.NewCluster()
 
 	// Handle channel change
@@ -1676,6 +1715,34 @@ func (r *ClusterRosaHcpResource) Update(ctx context.Context, request resource.Up
 			fmt.Sprintf("Received error %v", err),
 		)
 		plan.Proxy.NoProxy = plannedNoProxy
+	}
+
+	clusterClient := r.ClusterCollection.Cluster(plan.ID.ValueString())
+	if shouldPatchDeleteProtection {
+		err = rosa.UpdateDeleteProtection(ctx, clusterClient, desiredDeleteProtection.ValueBool())
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Can't update delete protection",
+				fmt.Sprintf(
+					"Can't update delete protection for cluster with identifier '%s': %v",
+					plan.ID.ValueString(), err,
+				),
+			)
+			plan.DeleteProtection = types.BoolValue(true)
+		} else {
+			plan.DeleteProtection = desiredDeleteProtection
+			tflog.Debug(ctx, fmt.Sprintf("Updated delete protection from %v to %v",
+				state.DeleteProtection.ValueBool(), desiredDeleteProtection.ValueBool()))
+		}
+	} else {
+		priorDeleteProtection := state.DeleteProtection
+		dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
+		response.Diagnostics.Append(dpDiags...)
+		if len(dpDiags) > 0 && common.HasValue(priorDeleteProtection) && priorDeleteProtection.ValueBool() {
+			plan.DeleteProtection = priorDeleteProtection
+		} else {
+			plan.DeleteProtection = dpVal
+		}
 	}
 
 	diags = response.State.Set(ctx, plan)
@@ -1874,9 +1941,22 @@ func (r *ClusterRosaHcpResource) Delete(ctx context.Context, request resource.De
 		return
 	}
 
+	clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
+	deleteProtectionEnabledInOCM, checkDiags := rosa.CheckDeleteProtectionEnabled(
+		ctx, state.ID.ValueString(), clusterClient)
+	deleteProtectionEnabledInState := common.HasValue(state.DeleteProtection) && state.DeleteProtection.ValueBool()
+	if checkDiags.HasError() && !deleteProtectionEnabledInState {
+		response.Diagnostics.Append(checkDiags...)
+		return
+	}
+	deleteProtectionEnabled := deleteProtectionEnabledInState || deleteProtectionEnabledInOCM
+	if deleteDiags := rosa.ValidateDeleteAllowed(state.ID.ValueString(), deleteProtectionEnabled); deleteDiags.HasError() {
+		response.Diagnostics.Append(deleteDiags...)
+		return
+	}
+
 	// Send the request to delete the cluster:
-	resource := r.ClusterCollection.Cluster(state.ID.ValueString())
-	_, err := resource.Delete().SendContext(ctx)
+	_, err := clusterClient.Delete().SendContext(ctx)
 	if err != nil {
 		response.Diagnostics.AddError(
 			"Can't delete cluster",
@@ -1899,7 +1979,7 @@ func (r *ClusterRosaHcpResource) Delete(ctx context.Context, request resource.De
 				timeout = state.DestroyTimeout.ValueInt64()
 			}
 		}
-		isNotFound, err := r.retryClusterNotFoundWithTimeout(3, 1*time.Minute, ctx, timeout, resource)
+		isNotFound, err := r.retryClusterNotFoundWithTimeout(3, 1*time.Minute, ctx, timeout, clusterClient)
 		if err != nil {
 			response.Diagnostics.AddError(
 				"Can't poll cluster state",

--- a/provider/clusterrosa/hcp/state.go
+++ b/provider/clusterrosa/hcp/state.go
@@ -98,4 +98,7 @@ type ClusterRosaHcpState struct {
 	// Log forwarder fields
 	LogForwardersAtClusterCreation types.List `tfsdk:"log_forwarders_at_cluster_creation"`
 	LogForwarderIds                types.List `tfsdk:"log_forwarder_ids"`
+
+	// Delete protection
+	DeleteProtection types.Bool `tfsdk:"delete_protection"`
 }

--- a/subsystem/classic/classic_test.go
+++ b/subsystem/classic/classic_test.go
@@ -39,6 +39,11 @@ var _ = BeforeEach(func() {
 	// Create the server:
 	var ca string
 	TestServer, ca = MakeTCPTLSServer()
+
+	SetDeleteProtectionEnabled(false)
+	SetDeleteProtectionError(false)
+	RegisterDeleteProtectionHandlers(TestServer, "123", "1234")
+
 	// Create an access token:
 	token := MakeTokenString("Bearer", 10*time.Minute)
 

--- a/subsystem/classic/cluster_resource_rosa_create_test.go
+++ b/subsystem/classic/cluster_resource_rosa_create_test.go
@@ -4708,4 +4708,420 @@ var _ = Describe("rhcs_cluster_rosa_classic - create", func() {
 			runOutput.VerifyErrorContainsSubstring("Attribute worker_disk_size, cannot be changed")
 		})
 	})
+
+	Context("Delete Protection", func() {
+		const cluster123Route = "/api/clusters_mgmt/v1/clusters/123"
+		const deleteProtectionRoute = cluster123Route + "/delete_protection"
+		const classicClusterBase = `
+			resource "rhcs_cluster_rosa_classic" "my_cluster" {
+				name           = "my-cluster"
+				cloud_region   = "us-west-1"
+				aws_account_id = "123456789012"
+				sts = {
+					operator_role_prefix = "test"
+					role_arn = "",
+					support_role_arn = "",
+				instance_iam_roles = {
+					master_role_arn = "",
+					worker_role_arn = "",
+				}
+			}
+		`
+		const classicCreatePatch = `[
+			{
+			  "op": "add",
+			  "path": "/aws",
+			  "value": {
+				  "ec2_metadata_http_tokens": "optional",
+				  "sts" : {
+					  "oidc_endpoint_url": "https://127.0.0.1",
+					  "thumbprint": "111111",
+					  "role_arn": "",
+					  "support_role_arn": "",
+					  "instance_iam_roles" : {
+						"master_role_arn" : "",
+						"worker_role_arn" : ""
+					  },
+					  "operator_role_prefix" : "test"
+				  }
+			  }
+			}]`
+		const classicClusterWithDeleteProtectionPatch = `[
+			{
+			  "op": "add",
+			  "path": "/delete_protection",
+			  "value": {"enabled": true}
+			},
+			{
+			  "op": "add",
+			  "path": "/aws",
+			  "value": {
+				  "ec2_metadata_http_tokens": "optional",
+				  "sts" : {
+					  "oidc_endpoint_url": "https://127.0.0.1",
+					  "thumbprint": "111111",
+					  "role_arn": "",
+					  "support_role_arn": "",
+					  "instance_iam_roles" : {
+						"master_role_arn" : "",
+						"worker_role_arn" : ""
+					  },
+					  "operator_role_prefix" : "test"
+				  }
+			  }
+			}]`
+
+		It("Enables delete protection during cluster creation", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, classicCreatePatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+		})
+
+		It("Updates delete protection from false to true", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, classicCreatePatch),
+				),
+			)
+			Terraform.Source(classicClusterBase + `}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicCreatePatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicCreatePatch),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+		})
+
+		It("Blocks destroy when delete protection is enabled", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, classicCreatePatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = true
+			}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+			SetDeleteProtectionEnabled(true)
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicClusterWithDeleteProtectionPatch),
+				),
+			)
+			runOutput := Terraform.Destroy()
+			Expect(runOutput.ExitCode).NotTo(BeZero())
+			runOutput.VerifyErrorContainsSubstring("delete_protection = false")
+		})
+
+		It("Updates delete protection from true to false", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, classicCreatePatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = true
+			}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+			SetDeleteProtectionEnabled(true)
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicClusterWithDeleteProtectionPatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, false),
+					RespondWithJSON(http.StatusOK, `{"enabled": false}`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicCreatePatch),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = false
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", false))
+			SetDeleteProtectionEnabled(false)
+		})
+
+		It("Adopts out-of-band delete protection from cluster GET", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, classicCreatePatch),
+				),
+			)
+			Terraform.Source(classicClusterBase + `}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicClusterWithDeleteProtectionPatch),
+				),
+			)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+		})
+
+		It("Persists delete_protection = true on create PATCH failure", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, classicCreatePatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					RespondWithJSON(http.StatusInternalServerError, `{
+						"kind": "Error",
+						"id": "500",
+						"href": "/api/clusters_mgmt/v1/errors/500",
+						"code": "CLUSTERS-MGMT-500",
+						"reason": "Internal Server Error"
+					}`),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).NotTo(BeZero())
+			runOutput.VerifyErrorContainsSubstring("delete protection could not be enabled")
+		})
+
+		It("Persists delete_protection = true on update PATCH failure", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, classicCreatePatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = true
+			}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+			SetDeleteProtectionEnabled(true)
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicClusterWithDeleteProtectionPatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					RespondWithJSON(http.StatusInternalServerError, `{
+						"kind": "Error",
+						"id": "500",
+						"href": "/api/clusters_mgmt/v1/errors/500",
+						"code": "CLUSTERS-MGMT-500",
+						"reason": "Internal Server Error"
+					}`),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = false
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).NotTo(BeZero())
+			runOutput.VerifyErrorContainsSubstring("Can't update delete protection")
+			resource := Terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+			SetDeleteProtectionEnabled(false)
+		})
+
+		It("Preserves delete_protection = true during unrelated update when resolution warns", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, classicCreatePatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = true
+			}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+			SetDeleteProtectionEnabled(true)
+
+			// Trigger an unrelated update (properties change) while
+			// delete_protection resolution fails
+			SetDeleteProtectionError(true)
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicCreatePatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "ec2_metadata_http_tokens": "optional",
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								  "master_role_arn" : "",
+								  "worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "replace",
+					  "path": "/properties",
+					  "value": {
+						  "test_key": "test_value"
+					  }
+					}]`),
+				),
+			)
+			Terraform.Source(classicClusterBase + `
+				delete_protection = true
+				properties = {
+					"test_key" = "test_value"
+				}
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_classic", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+			SetDeleteProtectionError(false)
+		})
+
+		It("Blocks destroy when delete_protection check fails", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage1),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, classicCreatePatch),
+				),
+			)
+			Terraform.Source(classicClusterBase + `}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+
+			SetDeleteProtectionError(true)
+			TestServer.AppendHandlers(
+				// Read refresh
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicCreatePatch),
+				),
+				// CheckDeleteProtectionEnabled fallback cluster GET
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, classicCreatePatch),
+				),
+			)
+			runOutput := Terraform.Destroy()
+			Expect(runOutput.ExitCode).NotTo(BeZero())
+			runOutput.VerifyErrorContainsSubstring("Can't verify delete protection")
+			SetDeleteProtectionError(false)
+		})
+	})
 })

--- a/subsystem/framework/framework.go
+++ b/subsystem/framework/framework.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,7 +38,51 @@ var (
 	TestServer *Server
 	Terraform  *TerraformRunner
 	TestingT   *testing.T
+
+	deleteProtectionEnabled   bool
+	deleteProtectionShouldErr bool
 )
+
+// SetDeleteProtectionEnabled configures the default delete_protection sub-resource
+// handler used by subsystem tests.
+func SetDeleteProtectionEnabled(enabled bool) {
+	deleteProtectionEnabled = enabled
+}
+
+// SetDeleteProtectionError makes the delete_protection GET handler return 500.
+func SetDeleteProtectionError(shouldErr bool) {
+	deleteProtectionShouldErr = shouldErr
+}
+
+// RegisterDeleteProtectionHandlers registers GET handlers for delete_protection on the
+// given cluster IDs. The response reflects SetDeleteProtectionEnabled.
+// RouteToHandler matches take precedence over AppendHandlers FIFO queue, so
+// appended expectations for these endpoints are not dequeued or validated.
+func RegisterDeleteProtectionHandlers(server *Server, clusterIDs ...string) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if deleteProtectionShouldErr {
+			w.WriteHeader(http.StatusInternalServerError)
+			errBody := `{"kind":"Error","id":"500","href":"/api/clusters_mgmt/v1/errors/500",` +
+				`"code":"CLUSTERS-MGMT-500","reason":"Internal Server Error"}`
+			_, _ = w.Write([]byte(errBody))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if deleteProtectionEnabled {
+			_, _ = w.Write([]byte(`{"enabled": true}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"enabled": false}`))
+	}
+	for _, clusterID := range clusterIDs {
+		server.RouteToHandler(
+			"GET",
+			fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/delete_protection", clusterID),
+			handler,
+		)
+	}
+}
 
 // TerraformRunnerBuilder contains the data and logic needed to build a terraform runner.
 type TerraformRunnerBuilder struct {

--- a/subsystem/hcp/cluster_resource_test.go
+++ b/subsystem/hcp/cluster_resource_test.go
@@ -8788,4 +8788,674 @@ var _ = Describe("HCP Cluster", func() {
 			})
 		})
 	})
+
+	Context("Delete Protection", func() {
+		const deleteProtectionRoute = cluster123Route + "/delete_protection"
+		const hcpClusterWithDeleteProtectionPatch = `[
+					{
+					  "op": "add",
+					  "path": "/delete_protection",
+					  "value": {"enabled": true}
+					},
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`
+		const hcpClusterBase = `
+			resource "rhcs_cluster_rosa_hcp" "my_cluster" {
+				name           = "my-cluster"
+				cloud_region   = "us-west-1"
+				aws_account_id = "123456789012"
+				aws_billing_account_id = "123456789012"
+				sts = {
+					operator_role_prefix = "test"
+					role_arn = "",
+					support_role_arn = "",
+					instance_iam_roles = {
+						worker_role_arn = "",
+					},
+				}
+				aws_subnet_ids = [
+					"id1", "id2", "id3"
+				]
+				availability_zones = [
+					"us-west-1a",
+					"us-west-1b",
+					"us-west-1c",
+				]
+			`
+
+		It("Enables delete protection during cluster creation", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+		})
+
+		It("Updates delete protection from false to true", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+		})
+
+		It("Updates delete protection from true to false", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = true
+			}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+			SetDeleteProtectionEnabled(true)
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, hcpClusterWithDeleteProtectionPatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/delete_protection",
+					  "value": {"enabled": false}
+					},
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, false),
+					RespondWithJSON(http.StatusOK, `{"enabled": false}`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = false
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", false))
+			SetDeleteProtectionEnabled(false)
+		})
+
+		It("Blocks destroy when delete protection is enabled", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = true
+			}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+			SetDeleteProtectionEnabled(true)
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, hcpClusterWithDeleteProtectionPatch),
+				),
+			)
+			runOutput := Terraform.Destroy()
+			Expect(runOutput.ExitCode).NotTo(BeZero())
+			runOutput.VerifyErrorContainsSubstring("delete_protection = false")
+		})
+
+		It("Adopts out-of-band delete protection from cluster GET", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/delete_protection",
+					  "value": {"enabled": true}
+					},
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+			)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+		})
+
+		It("Persists delete_protection = true on create PATCH failure", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					RespondWithJSON(http.StatusInternalServerError, `{
+						"kind": "Error",
+						"id": "500",
+						"href": "/api/clusters_mgmt/v1/errors/500",
+						"code": "CLUSTERS-MGMT-500",
+						"reason": "Internal Server Error"
+					}`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).NotTo(BeZero())
+			runOutput.VerifyErrorContainsSubstring("delete protection could not be enabled")
+		})
+
+		It("Persists delete_protection = true on update PATCH failure", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = true
+			}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+			SetDeleteProtectionEnabled(true)
+
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, hcpClusterWithDeleteProtectionPatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, hcpClusterWithDeleteProtectionPatch),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					RespondWithJSON(http.StatusInternalServerError, `{
+						"kind": "Error",
+						"id": "500",
+						"href": "/api/clusters_mgmt/v1/errors/500",
+						"code": "CLUSTERS-MGMT-500",
+						"reason": "Internal Server Error"
+					}`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = false
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).NotTo(BeZero())
+			runOutput.VerifyErrorContainsSubstring("Can't update delete protection")
+			resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+			SetDeleteProtectionEnabled(false)
+		})
+
+		It("Preserves delete_protection = true during unrelated update when resolution warns", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, deleteProtectionRoute),
+					VerifyJQ(`.enabled`, true),
+					RespondWithJSON(http.StatusOK, `{"enabled": true}`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = true
+			}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+			SetDeleteProtectionEnabled(true)
+
+			// Trigger an unrelated update (properties change) while
+			// delete_protection resolution fails
+			SetDeleteProtectionError(true)
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPatch, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					},
+					{
+					  "op": "replace",
+					  "path": "/properties",
+					  "value": {
+						  "test_key": "test_value"
+					  }
+					}]`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `
+				delete_protection = true
+				properties = {
+					"test_key" = "test_value"
+				}
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+			resource := Terraform.Resource("rhcs_cluster_rosa_hcp", "my_cluster")
+			Expect(resource).To(MatchJQ(".attributes.delete_protection", true))
+			SetDeleteProtectionError(false)
+		})
+
+		It("Blocks destroy when delete_protection check fails", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(http.StatusOK, versionListPage),
+				),
+				CombineHandlers(
+					VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+					RespondWithPatchedJSON(http.StatusCreated, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+			)
+			Terraform.Source(hcpClusterBase + `}`)
+			Expect(Terraform.Apply().ExitCode).To(BeZero())
+
+			SetDeleteProtectionError(true)
+			TestServer.AppendHandlers(
+				// Read refresh
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+				// CheckDeleteProtectionEnabled fallback cluster GET
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, cluster123Route),
+					RespondWithPatchedJSON(http.StatusOK, template, `[
+					{
+					  "op": "add",
+					  "path": "/aws",
+					  "value": {
+						  "sts" : {
+							  "oidc_endpoint_url": "https://127.0.0.1",
+							  "thumbprint": "111111",
+							  "role_arn": "",
+							  "support_role_arn": "",
+							  "instance_iam_roles" : {
+								"worker_role_arn" : ""
+							  },
+							  "operator_role_prefix" : "test"
+						  }
+					  }
+					}]`),
+				),
+			)
+			runOutput := Terraform.Destroy()
+			Expect(runOutput.ExitCode).NotTo(BeZero())
+			runOutput.VerifyErrorContainsSubstring("Can't verify delete protection")
+			SetDeleteProtectionError(false)
+		})
+	})
 })

--- a/subsystem/hcp/hcp_test.go
+++ b/subsystem/hcp/hcp_test.go
@@ -50,6 +50,10 @@ var _ = BeforeEach(func() {
 	TestServer.RouteToHandler("GET", "/api/clusters_mgmt/v1/clusters/123/control_plane/log_forwarders", logForwardersHandler)
 	TestServer.RouteToHandler("GET", "/api/clusters_mgmt/v1/clusters/1234/control_plane/log_forwarders", logForwardersHandler)
 
+	SetDeleteProtectionEnabled(false)
+	SetDeleteProtectionError(false)
+	RegisterDeleteProtectionHandlers(TestServer, "123", "1234")
+
 	// Create an access token:
 	token := MakeTokenString("Bearer", 10*time.Minute)
 


### PR DESCRIPTION
## PR Summary
Add optional `delete_protection` to `rhcs_cluster_rosa_hcp` and `rhcs_cluster_rosa_classic` so operators can enable OCM delete protection at create time, update it in place, and block `terraform destroy` until protection is explicitly disabled.

## Detailed Description of the Issue

ROSA clusters support OCM delete protection via the `/delete_protection` sub-resource, but the RHCS provider did not expose it. Operators using Terraform had no way to:
- Enable delete protection when creating a cluster
- Toggle protection after cluster creation
- Prevent accidental `terraform destroy` while protection is active
This change wires the OCM delete protection API through both HCP and Classic cluster resources and data sources, aligned with ROSA CLI and OCM behavior.

## Related Issues and PRs

- Jira: [ROSAENG-61734](https://issues.redhat.com/browse/ROSAENG-61734)
- Fixes: N/A
- Related PR(s):
  - [terraform-rhcs-rosa-classic: companion PR for Classic module](https://github.com/terraform-redhat/terraform-rhcs-rosa-classic/pull/174)
  - [terraform-rhcs-rosa-hcp: companion PR for HCP module](https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp/pull/178)
  - [ROSA CLI: create-time `--enable-delete-protection`](https://github.com/openshift/rosa/pull/3367)
- Related design/docs: OCM `PATCH/GET /api/clusters_mgmt/v1/clusters/{id}/delete_protection`

## Type of Change

- [x] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- Cluster resources had no `delete_protection` attribute.
- `terraform destroy` could proceed without checking OCM delete protection state.
- Out-of-band delete protection enabled on a cluster was not reflected in Terraform state.

## Behavior After This Change

- **`delete_protection`** is available on `rhcs_cluster_rosa_hcp` and `rhcs_cluster_rosa_classic` (optional + computed) and on the corresponding data sources (computed).
- **Create:** If explicitly set to `true`, the provider POSTs the cluster then PATCHes the delete protection sub-resource. Create fails if the PATCH fails (cluster exists; error includes cluster ID).
- **Update:** Mutable in place via PATCH when the planned value differs from state/OCM.
- **Read:** Populates from the inline cluster GET field; no extra sub-resource GET on read (subsystem compatibility).
- **Delete:** Blocks destroy when protection is enabled in state or verified live via OCM. Does not auto-disable protection. Error instructs the user to set `delete_protection = false`, apply, then retry destroy.
- **Adoption:** Clusters with out-of-band delete protection enabled are reflected in state on read.

## How to Test (Step-by-Step)

### Preconditions
- Provider built from this branch (`make build` or local install).
- Access to a ROSA HCP or Classic cluster (for manual validation), or run automated tests locally.

### Test Steps
1. Run unit tests for shared helpers:
   ```bash
   go test ./provider/clusterrosa/common/ -run DeleteProtection -v
   ```
2. Run subsystem delete protection specs:
   ```bash
   go test ./subsystem/hcp/ -run 'delete protection|DeleteProtection' -v
   go test ./subsystem/classic/ -run 'delete protection|DeleteProtection' -v
   ```
3. Run full pre-push checks:
   ```bash
   make pre-push-checks
   ```
4. (Optional, manual) Create a cluster with `delete_protection = true`, confirm apply succeeds, run `terraform destroy` and confirm it is blocked with a clear error. Set `delete_protection = false`, apply, then destroy again.
### Expected Results
1. Unit tests pass for `ValidateDeleteAllowed`, `PopulateDeleteProtectionFromCluster`, and related helpers.
2. Subsystem tests pass for create with protection, update toggle, destroy blocked, and OOB adoption (HCP + Classic).
3. `make pre-push-checks` passes (format, build, generated files, lint, subsystem registry, tests).
4. Manual destroy is blocked while protection is enabled; succeeds after disable + apply.
## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output:
  ```bash
  make pre-push-checks
  go test ./subsystem/hcp/ ./subsystem/classic/ -count=1
  ```
- Other artifacts: Subsystem specs under `subsystem/hcp/cluster_resource_test.go` and `subsystem/classic/cluster_resource_rosa_create_test.go`; stub handlers in `subsystem/framework/framework.go`.

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan

`delete_protection` is a new optional attribute with no change to existing required fields or defaults for clusters that do not set it.

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [ ] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [x] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [x] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [x] `make check-subsystem-registry` passes.
- [x] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `delete_protection` support to ROSA Classic and HCP cluster resources, including lifecycle handling for create, update, and safe deletion.
  * Data sources now expose the cluster’s current delete-protection status.

* **Documentation**
  * Updated resource and data source docs and examples with `delete_protection` usage guidance, including how it affects `terraform destroy`.

* **Tests**
  * Expanded unit and end-to-end test coverage for delete-protection enable/disable, state adoption, and destroy-blocking behavior (including failure scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->