### PR TITLE
ROSAENG-61449 | ci: align CI images on go-toolset 1.26.5

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -24,25 +24,3 @@ ignore:
           msgpack/v5 v5.4.1 is latest; transitive via HashiCorp plugin stack with
           no upstream fix. Revisit when msgpack or plugins release a fix.
         expires: 2026-09-30T00:00:00.000Z
-
-  # Temporary stdlib ignores (ROSAENG-61054): remove when CI image ships Go 1.26.4.
-  SNYK-GOLANG-STDNETTEXTPROTO-17135843:
-    - "*":
-        reason: >-
-          Go stdlib fix requires 1.26.4; CI builder is still 1.26.3.
-          Remove when CI runs Go >= 1.26.4.
-        expires: 2026-08-01T00:00:00.000Z
-
-  SNYK-GOLANG-STDMIME-17135844:
-    - "*":
-        reason: >-
-          Go stdlib fix requires 1.26.4; CI builder is still 1.26.3.
-          Remove when CI runs Go >= 1.26.4.
-        expires: 2026-08-01T00:00:00.000Z
-
-  SNYK-GOLANG-STDCRYPTOX509-17135840:
-    - "*":
-        reason: >-
-          Go stdlib fix requires 1.26.4; CI builder is still 1.26.3.
-          Remove when CI runs Go >= 1.26.4.
-        expires: 2026-08-01T00:00:00.000Z

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Do **not** duplicate checklists or command lists here. Use one source per concer
 | `README.md` | Project overview, prerequisites, contributor setup summary, limitations, and links to deeper docs — **read this** for context before changing behavior or docs. |
 | `docs/` | Published provider documentation (often **generated** from `templates/` and schema); do not edit generated pages by hand when the workflow requires regeneration — follow `CONTRIBUTING.md`. |
 | `examples/` | Runnable Terraform under `examples/` (resources, data sources, guides paths); use for manual checks and as references for HCL style — align with provider schema and HashiCorp Terraform style. |
-| `CONTRIBUTING.md` | Commands, hooks, tests, formatting, release — **procedural authority**. |
+| `CONTRIBUTING.md` | Commands, hooks, tests, formatting, release, and **Go version bump checklist** — **procedural authority**. |
 | `.github/pull_request_template.md` | What to complete on a PR and the **Developer Verification Checklist** — **submission checklist**. |
 | `.cursor/rules/` | Code style and Terraform Plugin Framework guardrails. |
 | **`AGENTS.md` (this file)** | ROSA/OCM boundaries, escalation triggers, and **high-level** implementation flow — not step-by-step commands. |
@@ -23,6 +23,24 @@ Thin entrypoints `CLAUDE.md` and `GEMINI.md` should only point here to avoid dri
 **Precedence:** If anything here conflicts with `CONTRIBUTING.md` or `.cursor/rules/`, follow `CONTRIBUTING.md` first, then `.cursor/rules/`.
 
 **Before opening a PR:** Complete the checklist in `.github/pull_request_template.md`.
+
+## CI Container Images
+
+This repo uses **OpenShift ci-operator** (config in `openshift/release`) and **Konflux** (`.tekton/`). Each Dockerfile serves a different job type.
+
+| Dockerfile | Built by | Used for |
+|------------|----------|----------|
+| `Dockerfile` | Konflux | Shipping provider binary (product) |
+| `Dockerfile.clients` | Prow (main config) | Presubmit: `make pre-push-checks` |
+| `build/ci-tf-e2e.Dockerfile` | Prow (e2e variants) | E2E runner; image `rhcs-tf-e2e` |
+
+- Presubmit jobs run inside **`terraform-provider-rhcs-clients`** (from `Dockerfile.clients`).
+- Prow E2E runs inside **`rhcs-tf-e2e`** (from `build/ci-tf-e2e.Dockerfile`); step scripts expect `/root/terraform-provider-rhcs`.
+- **`.ci-operator.yaml`** pins ci-operator `build_root` (`ocp/builder`) for pipeline plumbing (clone and image builds), not presubmit execution. Release configs under `openshift/release` use `build_root: from_repository: true`.
+
+### Bumping the Go version
+
+See [CI container images and Go version bumps](CONTRIBUTING.md#ci-container-images-and-go-version-bumps) in `CONTRIBUTING.md`.
 
 ## HashiCorp Terraform Skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,20 @@ make pre-push-checks   # exact non-mutating verification used by the pre-push ho
 `make lint` uses the repo's pinned `golangci-lint` v2 configuration.
 `make docs-lint` runs the pinned [Vale](https://docs.vale.sh/) CLI with only the custom inclusive-language rules under `styles/InclusiveLanguage/` (general Vale styles and packages are not used). Building Vale uses `CGO_ENABLED=1` and requires a C compiler toolchain on the first install.
 
+#### CI container images and Go version bumps
+
+This repository uses **OpenShift ci-operator** (config in `openshift/release`) and **Konflux** (`.tekton/`). See `AGENTS.md` for which Dockerfile maps to which job type.
+
+When bumping the Go version, update these together so compile, presubmits, E2E builds, and product images stay aligned:
+
+- `go.mod` (`go` directive)
+- `renovate.json` — `gomod.constraints.go` (must match `go.mod` so Renovate `gomodTidy` PRs succeed)
+- `Dockerfile`, `Dockerfile.clients`, `build/ci-tf-e2e.Dockerfile` — `ubi9/go-toolset` image tag
+- `.ci-operator.yaml` — `build_root_image.tag` (match an available `ocp/builder:rhel-9-golang-*` tag for pipeline plumbing; presubmit compile runs in `Dockerfile.clients`)
+- `TERRAFORM_VERSION` in `Dockerfile.clients` when `terraform fmt` checks need a newer Terraform CLI
+
+Sibling checklist for the ROSA CLI: `openshift/rosa` `AGENTS.md`.
+
 ### 5. Manual testing and debugging using the locally compiled RHCS Provider binary
 Manual testing should be performed before opening a PR to ensure there isn't any regression behavior in the provider. You can find [here an example for that](https://github.com/terraform-redhat/terraform-rhcs-rosa/tree/main/examples/rosa-classic-public-with-unmanaged-oidc)
 After compiling the RHCS provider, debugging terraform provider can be difficult. But here are a some tips to make your life easier.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515 AS builder
 COPY . .
 
 ENV GOFLAGS=-buildvcs=false

--- a/Dockerfile.clients
+++ b/Dockerfile.clients
@@ -1,32 +1,23 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.8-1782841664
-WORKDIR /app
-COPY . /app
-RUN curl -fsSL -o /tmp/epel-release.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    yum install -y /tmp/epel-release.rpm && \
-    yum install -y yum-utils shadow-utils unzip tar make git gcc gcc-c++ jq diffutils rubygem-asciidoctor && \
-    asciidoctor --version && \
-    yum clean all && \
-    rm -rf /var/cache/yum /tmp/epel-release.rpm
-# Prow / integration client image: Go toolchain follows go.mod; Terraform pinned below for fmt-check on examples/ and tests/.
-RUN GO_VER=$(awk '/^go / { print $2; exit }' go.mod) && \
-    GO_TAR="go${GO_VER}.linux-amd64.tar.gz" && \
-    curl -fsSL "https://dl.google.com/go/${GO_TAR}" -o "/tmp/${GO_TAR}" && \
-    curl -fsSL "https://dl.google.com/go/${GO_TAR}.sha256" -o /tmp/go.sha256 && \
-    printf '%s  %s\n' "$(tr -d '\n' < /tmp/go.sha256)" "${GO_TAR}" | (cd /tmp && sha256sum -c -) && \
-    tar -C /usr/local -xzf "/tmp/${GO_TAR}" && \
-    rm -f "/tmp/${GO_TAR}" /tmp/go.sha256 && \
-    /usr/local/go/bin/go version
+# Prow presubmit client image: make pre-push-checks.
+# Source is copied at image build (ci-operator builds this image from the PR tree).
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515
+USER root
+WORKDIR /opt/app-root/src
+RUN dnf install -y --setopt=install_weak_deps=False --nodocs \
+        yum-utils jq make git gcc gcc-c++ diffutils && \
+    dnf clean all
 # renovate: datasource=github-releases depName=hashicorp/terraform
 ARG TERRAFORM_VERSION=1.15.4
 RUN yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
-    yum -y install "terraform-${TERRAFORM_VERSION}" && \
-    yum clean all && \
-    rm -rf /var/cache/yum && \
+    dnf -y install "terraform-${TERRAFORM_VERSION}" && \
+    dnf clean all && \
     terraform version
-# OpenShift Prow: arbitrary UID runs with GID 0; group-writable /app for make pre-push-checks (bin/, Go/Vale caches).
-RUN mkdir -p /app/bin && \
-    chgrp -R 0 /app && \
-    chmod -R g+rwX /app
-ENV PATH="/usr/local/go/bin:/usr/local/bin:${PATH}" \
-    HOME="/app" \
-    GOMODCACHE="/tmp/gomodcache"
+RUN git config --global --add safe.directory '*'
+COPY . .
+# OpenShift Prow: arbitrary UID runs with GID 0; group-writable workdir and Go caches.
+RUN mkdir -p /opt/app-root/src/bin /tmp/gomodcache /tmp/.cache && \
+    chgrp -R 0 /opt/app-root/src /tmp/gomodcache /tmp/.cache && \
+    chmod -R g+rwX /opt/app-root/src /tmp/gomodcache /tmp/.cache
+ENV HOME="/opt/app-root/src" \
+    GOMODCACHE="/tmp/gomodcache" \
+    GOLANGCI_LINT_CACHE="/tmp/.cache"

--- a/build/ci-tf-e2e-requirements.txt
+++ b/build/ci-tf-e2e-requirements.txt
@@ -1,0 +1,3 @@
+# Pin E2E image Python deps (installed in build/ci-tf-e2e.Dockerfile).
+PyYAML==6.0.3
+Jinja2==3.1.6

--- a/build/ci-tf-e2e.Dockerfile
+++ b/build/ci-tf-e2e.Dockerfile
@@ -1,42 +1,86 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.8-1782841664
+# Prow E2E runner image (rhcs-tf-e2e). Steps expect /root/terraform-provider-rhcs.
+#
+# Pinned versions below are Renovate-managed (see renovate.json). oc checksums are
+# verified against the versioned mirror sha256sum.txt at build time.
+
+# renovate: datasource=github-releases depName=hashicorp/terraform
+ARG TERRAFORM_VERSION=1.15.4
+# renovate: datasource=github-releases depName=openshift-online/ocm-cli
+ARG OCM_VERSION=0.1.66
+# Pin OpenShift client release (no first-class Renovate datasource for mirror.openshift.com).
+# When bumping, pick a version under .../clients/ocp/<version>/; build verifies sha256sum.txt.
+ARG OC_VERSION=4.22.3
+
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515 AS builder
+ARG TERRAFORM_VERSION
+USER root
+# Configure safe.directory before COPY: a worktree .git file is invalid inside the image build.
+RUN git config --global --add safe.directory /root/terraform-provider-rhcs
+WORKDIR /root/terraform-provider-rhcs
+ENV GOBIN=/go/bin \
+    HOME=/root \
+    GOFLAGS=-buildvcs=false \
+    PATH="/go/bin:${PATH}"
+RUN mkdir -p /go/bin
+RUN dnf install -y --setopt=install_weak_deps=False --nodocs \
+        yum-utils jq make git gcc-c++ && \
+    yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
+    dnf -y install "terraform-${TERRAFORM_VERSION}" && \
+    dnf clean all && \
+    terraform version
+COPY . .
+RUN go env -w GO111MODULE=on && \
+    go mod download && go mod verify && \
+    go install -mod=readonly github.com/onsi/ginkgo/v2/ginkgo && \
+    go install -mod=readonly go.uber.org/mock/mockgen && \
+    make install
+
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515
+ARG TERRAFORM_VERSION
+ARG OCM_VERSION
+ARG OC_VERSION
+USER root
 WORKDIR /root
-
-# oc
-RUN curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz |tar -C /usr/local/bin -xzf - oc
-
-# ocm
-RUN yum install -y wget &&\
-    wget https://github.com/openshift-online/ocm-cli/releases/download/v0.1.66/ocm-linux-amd64 -O /usr/local/bin/ocm && \
-    chmod +x /usr/local/bin/ocm
-
-# go — toolchain version follows the `go` line in go.mod (no separate pin to drift)
-COPY go.mod /tmp/go.mod
-RUN GO_VER=$(awk '/^go / { print $2; exit }' /tmp/go.mod) && \
-    GO_TAR="go${GO_VER}.linux-amd64.tar.gz" && \
-    curl -fsSL "https://dl.google.com/go/${GO_TAR}" -o "/tmp/${GO_TAR}" && \
-    curl -fsSL "https://dl.google.com/go/${GO_TAR}.sha256" -o /tmp/go.sha256 && \
-    printf '%s  %s\n' "$(tr -d '\n' < /tmp/go.sha256)" "${GO_TAR}" | (cd /tmp && sha256sum -c -) && \
-    tar -C /usr/local -xzf "/tmp/${GO_TAR}" && \
-    rm -f "/tmp/${GO_TAR}" /tmp/go.sha256 /tmp/go.mod && \
-    /usr/local/go/bin/go version
-ENV PATH="/usr/local/go/bin:${PATH}"
-ENV GOPATH=/usr/local/go
-ENV TEST_OFFLINE_TOKEN=""
-
-# terraform-provider-rhcs repo
-COPY . ./terraform-provider-rhcs
-
-RUN yum install -y yum-utils && \
-    yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo &&\
-    yum -y install terraform python3 python3-pip make jq httpd-tools git gcc-c++ &&\
-    yum clean all && \
-    pip3 install PyYAML jinja2 &&\
-    cd terraform-provider-rhcs && \
-    go env -w GO111MODULE=on && \
-    # Keep tool installs aligned with go.mod resolution.
-    go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo && \
-    go install -mod=mod go.uber.org/mock/mockgen && \
-    # Do not mutate module state during image build.
-    go mod download && go mod verify && make install &&\
-    chmod -R 777 $GOPATH &&\
-    echo 'RUN done'
+# E2E steps copy /root/terraform-provider-rhcs to ~/terraform-provider-rhcs; HOME must
+# not be /root or cp treats source and destination as the same path.
+ENV HOME=/home/ci \
+    GOBIN=/go/bin \
+    PATH="/go/bin:/usr/local/bin:${PATH}" \
+    TEST_OFFLINE_TOKEN=""
+RUN mkdir -p /home/ci/.terraform.d/plugins/terraform.local/local/rhcs /tmp/cache && \
+    chgrp -R 0 /home/ci /tmp/cache && \
+    chmod -R g+rwX /home/ci /tmp/cache && \
+    chmod g+s /home/ci /home/ci/.terraform.d
+# oc — pin release; verify against published sha256sum.txt for that version
+RUN OC_TAR=openshift-client-linux.tar.gz && \
+    OC_BASE="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC_VERSION}" && \
+    curl -fsSL "${OC_BASE}/sha256sum.txt" -o /tmp/sha256sum.txt && \
+    curl -fsSL "${OC_BASE}/${OC_TAR}" -o "/tmp/${OC_TAR}" && \
+    grep " ${OC_TAR}$" /tmp/sha256sum.txt | (cd /tmp && sha256sum -c -) && \
+    tar -C /usr/local/bin -xzf "/tmp/${OC_TAR}" oc && \
+    rm -f "/tmp/${OC_TAR}" /tmp/sha256sum.txt && \
+    oc version --client
+# ocm — pin release; verify published .sha256 asset
+RUN curl -fsSL "https://github.com/openshift-online/ocm-cli/releases/download/v${OCM_VERSION}/ocm-linux-amd64" \
+        -o /tmp/ocm-linux-amd64 && \
+    curl -fsSL "https://github.com/openshift-online/ocm-cli/releases/download/v${OCM_VERSION}/ocm-linux-amd64.sha256" \
+        -o /tmp/ocm-linux-amd64.sha256 && \
+    (cd /tmp && sha256sum -c ocm-linux-amd64.sha256) && \
+    install -m 0755 /tmp/ocm-linux-amd64 /usr/local/bin/ocm && \
+    rm -f /tmp/ocm-linux-amd64 /tmp/ocm-linux-amd64.sha256 && \
+    ocm version
+COPY build/ci-tf-e2e-requirements.txt /tmp/ci-tf-e2e-requirements.txt
+RUN dnf install -y --setopt=install_weak_deps=False --nodocs \
+        yum-utils python3 python3-pip make jq httpd-tools git gcc-c++ && \
+    yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
+    dnf -y install "terraform-${TERRAFORM_VERSION}" && \
+    dnf clean all && \
+    terraform version && \
+    pip3 install --no-cache-dir -r /tmp/ci-tf-e2e-requirements.txt && \
+    rm -f /tmp/ci-tf-e2e-requirements.txt
+COPY --from=builder /go/bin/ginkgo /go/bin/mockgen /go/bin/
+COPY --from=builder /root/terraform-provider-rhcs /root/terraform-provider-rhcs
+COPY --from=builder /root/.terraform.d /root/.terraform.d
+RUN git config --global --add safe.directory /root/terraform-provider-rhcs && \
+    chgrp -R 0 /root /go /home/ci /tmp/cache && \
+    chmod -R g+rwX /root /go /home/ci /tmp/cache

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-redhat/terraform-provider-rhcs
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
   },
   "gomod": {
     "constraints": {
-      "go": "1.26.3"
+      "go": "1.26.5"
     },
     "postUpdateOptions": [
       "gomodUpdateImportPaths",
@@ -95,6 +95,11 @@
       "depNameTemplate": "github.com/errata-ai/vale/v3"
     }
   ],
+  "pip_requirements": {
+    "managerFilePatterns": [
+      "/^build\\/ci-tf-e2e-requirements\\.txt$/"
+    ]
+  },
   "labels": [
     "ok-to-test"
   ],


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary

- Refactor Prow CI Dockerfiles off manual Go downloads to `ubi9/go-toolset:1.26.5-1783931515`.
- Bump `go.mod` and product `Dockerfile` to Go 1.26.5; document CI images and Go bump checklist in `AGENTS.md`.
- Remove stdlib Snyk ignores fixed in Go >= 1.26.4.
- Fix E2E image layout for Prow step scripts: `HOME=/home/ci` (avoids `cp` collision) and pre-create group-writable `~/.terraform.d/plugins` for `make install` under arbitrary UID.

## Known CI limitation (security / Snyk)

The OpenShift CI **security/Snyk dependencies** job runs `go list` on the shared `src`/`ocp/builder` image with **Go 1.26.3** and `GOTOOLCHAIN=local`. That environment does not yet offer Go **1.26.5**, and **we do not own that job/image**. Expect Snyk deps to fail with `go.mod requires go >= 1.26.5 (running go 1.26.3)` until the builder used by security scans is updated. Presubmit `pre-push-checks` runs in `Dockerfile.clients` (go-toolset 1.26.5) and is unaffected by that mismatch.

## Detailed Description of the Issue

Provider CI images (`Dockerfile.clients`, `build/ci-tf-e2e.Dockerfile`) installed Go by parsing `go.mod` and downloading from `dl.google.com`. That diverged from the product `Dockerfile` (already on go-toolset) and from the ROSA CLI pattern, and made Go bumps hard to track. Align CI images on go-toolset, bump to 1.26.5, and document what to update on future Go bumps.

E2E step scripts copy `/root/terraform-provider-rhcs` to `~/terraform-provider-rhcs` and run `make install` (writes to `$HOME/.terraform.d`). The first go-toolset E2E image set `HOME=/root`, which made `cp` source and destination identical. Setting `HOME=/home/ci` fixed `cp`, but Prow arbitrary UID then could not create `/home/ci/.terraform.d/plugins` until that tree is pre-created with `chgrp 0` / `g+rwX`.

## Related Issues and PRs

- Jira: [ROSAENG-61449](https://redhat.atlassian.net/browse/ROSAENG-61449)
- Fixes: N/A
- Related PR(s): [openshift/rosa#3366](https://github.com/openshift/rosa/pull/3366) ([ROSAENG-61450](https://redhat.atlassian.net/browse/ROSAENG-61450) sibling)
- Related design/docs: `AGENTS.md` CI Container Images section

## Type of Change

- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- `Dockerfile.clients` and `build/ci-tf-e2e.Dockerfile` used plain UBI plus a manual Go tarball from `go.mod`.
- `go.mod` / product image on Go 1.26.3 / go-toolset 1.26.3.
- `.snyk` ignored three stdlib findings pending Go >= 1.26.4.

## Behavior After This Change

- `Dockerfile.clients` is go-toolset with `COPY .` at image build (Prow runs `make pre-push-checks` inside the built image); keeps Terraform RPM pin for `fmt-check`.
- `build/ci-tf-e2e.Dockerfile` is multi-stage go-toolset; preserves `/root/terraform-provider-rhcs` for existing e2e step scripts, sets `HOME=/home/ci`, and pre-creates group-writable `~/.terraform.d/plugins` for `make install`.
- `go.mod` and all go-toolset Dockerfiles on **1.26.5** / `1.26.5-1783931515`.
- `AGENTS.md` documents CI images and the Go bump checklist.
- Stdlib Snyk ignores removed; msgpack ignore retained.
- No `openshift/release` change (main config already uses these Dockerfiles).

## How to Test (Step-by-Step)

### Preconditions

- podman (or docker)

### Test Steps

1. `podman build -f Dockerfile.clients -t rhcs-clients:test .`
2. `podman run --rm -u 100099:0 -e HOME=/opt/app-root/src -e GOMODCACHE=/tmp/gomodcache rhcs-clients:test make pre-push-checks`
3. `podman build -f build/ci-tf-e2e.Dockerfile -t rhcs-tf-e2e:test .`
4. `podman run --rm -u 100099:0 rhcs-tf-e2e:test bash -c 'cp -r /root/terraform-provider-rhcs ~/ && cd ~/terraform-provider-rhcs && make install'`
5. After merge: `/test pre-push-checks` and `/test images` (e2e variant)

### Expected Results

- Both images build successfully.
- `make pre-push-checks` passes in the client image.
- E2E image `cp` and `make install` succeed under arbitrary UID.
- Prow rebuilds `terraform-provider-rhcs-clients` and `rhcs-tf-e2e` on the new Dockerfiles.

## Proof of the Fix

- Screenshots: N/A
- Videos: N/A
- Logs/CLI output:
  - local client image: `make pre-push-checks` 8/8 PASS
  - local E2E image: `cp` OK and `make install` OK under UID 100099 with `HOME=/home/ci`
- Other artifacts: N/A

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan

N/A

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)

- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Updates**
  * Upgraded the Go toolchain to 1.26.5 across the build and E2E pipeline.
  * Refreshed builder/client/E2E container images, including a new multi-stage E2E build and updated runtime/tooling layout and permissions.
  * Pinned E2E Python test dependencies to fixed versions.

* **Security**
  * Updated the security policy by removing temporary Go standard-library exceptions.

* **Documentation**
  * Added CI guidance mapping container images/Dockerfiles to job types and a coordinated Go version bump checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->