### PR TITLE
ROSAENG-60032 | ci: add govulncheck source and binary vulnerability scans

### DIFF
--- a/.govulncheck-ignore.yaml
+++ b/.govulncheck-ignore.yaml
@@ -1,0 +1,15 @@
+# govulncheck ignore configuration
+#
+# This file specifies vulnerabilities that should be ignored when running
+# govulncheck. Prefer fixing or bumping dependencies/toolchain over ignoring.
+# Remove entries once the fix is adopted (for example after a Go toolchain bump).
+#
+# Each entry must specify:
+# - id: The vulnerability ID (GO-XXXX-XXXX format)
+# - module: The exact module path where the vulnerability exists
+# - reason: Why this vulnerability is accepted
+
+ignored_vulnerabilities:
+  - id: GO-2026-5932
+    module: golang.org/x/crypto
+    reason: "No fix available (unmaintained golang.org/x/crypto/openpgp); provider does not import openpgp symbols (transitive dependency only)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,24 @@ When bumping the Go version, update these together so compile, presubmits, E2E b
 
 Sibling checklist for the ROSA CLI: `openshift/rosa` `AGENTS.md`.
 
+`make verify-govulncheck` scans the module for known Go vulnerabilities using the pinned
+[govulncheck](https://go.dev/doc/security/vuln/) tool. It runs two passes:
+
+- **Source mode** (`./...`) for reachable dependency CVEs in the codebase (including tests).
+- **Binary mode** (`terraform-provider-rhcs`) for stdlib/toolchain CVEs in the compiled provider artifact.
+
+The check is enforced by the optional Prow presubmit `govulncheck` (context `ci/prow/govulncheck`) and is **not** part of
+`pre-push-checks`. It complements the optional Snyk `security` presubmit.
+
+When a vulnerability has no fix available, or a fix cannot be adopted yet (for example
+a stdlib fix that requires a newer Go toolchain), add an entry to `.govulncheck-ignore.yaml`
+with the GO ID, exact module path, and reason. Remove entries once the fix is adopted.
+
+The ignore wrapper requires `jq` to parse govulncheck JSON output. Provider Prow jobs use the
+`terraform-provider-rhcs-clients` image (`Dockerfile.clients`), which includes `jq` as a system
+package. For local runs, install `jq` if it is not already available. `yq` is optional; the
+wrapper falls back to awk when `yq` is not installed.
+
 ### 5. Manual testing and debugging using the locally compiled RHCS Provider binary
 Manual testing should be performed before opening a PR to ensure there isn't any regression behavior in the provider. You can find [here an example for that](https://github.com/terraform-redhat/terraform-rhcs-rosa/tree/main/examples/rosa-classic-public-with-unmanaged-oidc)
 After compiling the RHCS provider, debugging terraform provider can be difficult. But here are a some tips to make your life easier.

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ GCI_VERSION ?= v0.14.0
 GOLANGCI_LINT_VERSION ?= v2.12.2
 VALE_VERSION ?= v3.15.1
 ADDLICENSE_VERSION ?= v1.2.0
+GOVULNCHECK_VERSION ?= v1.1.4
 
 GCI := $(LOCALBIN)/gci$(BIN_EXT)
 GINKGO := $(LOCALBIN)/ginkgo$(BIN_EXT)
@@ -48,6 +49,7 @@ MOCKGEN := $(LOCALBIN)/mockgen$(BIN_EXT)
 GOLANGCI_LINT := $(LOCALBIN)/golangci-lint$(BIN_EXT)
 VALE := $(LOCALBIN)/vale$(BIN_EXT)
 ADDLICENSE := $(LOCALBIN)/addlicense$(BIN_EXT)
+GOVULNCHECK := $(LOCALBIN)/govulncheck$(BIN_EXT)
 
 LINT_OUTPUT_FLAGS ?=
 GO_SOURCE_TARGETS := main.go build internal logging provider subsystem tests tools
@@ -91,6 +93,9 @@ $(VALE): | $(LOCALBIN)
 
 $(ADDLICENSE): | $(LOCALBIN)
 	GOBIN="$(LOCALBIN_ABS)" go install github.com/google/addlicense@$(ADDLICENSE_VERSION)
+
+$(GOVULNCHECK): | $(LOCALBIN)
+	GOBIN="$(LOCALBIN_ABS)" go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
 
 .PHONY: build
 build:
@@ -206,7 +211,13 @@ docs:
 
 .PHONY: tools
 tools:
-	@$(MAKE) --no-print-directory $(GCI) $(GINKGO) $(MOCKGEN) $(GOLANGCI_LINT) $(VALE) $(ADDLICENSE)
+	@$(MAKE) --no-print-directory $(GCI) $(GINKGO) $(MOCKGEN) $(GOLANGCI_LINT) $(VALE) $(ADDLICENSE) $(GOVULNCHECK)
+
+.PHONY: verify-govulncheck govulncheck
+verify-govulncheck: $(GOVULNCHECK) build
+	GOVULNCHECK_BIN="$(GOVULNCHECK)" ./hack/govulncheck.sh
+
+govulncheck: verify-govulncheck
 
 .PHONY: e2e-unit-test
 e2e-unit-test: $(GINKGO)

--- a/hack/govulncheck-wrapper.sh
+++ b/hack/govulncheck-wrapper.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+
+# govulncheck-wrapper.sh - Run govulncheck while ignoring specified vulnerabilities.
+#
+# Adapted from openshift/ci-chat-bot hack/govulncheck-wrapper.sh with source/binary
+# mode support and optional yq-less YAML parsing for CI environments.
+#
+# Usage:
+#   ./hack/govulncheck-wrapper.sh --mode source [govulncheck patterns...]
+#   ./hack/govulncheck-wrapper.sh --mode binary <path-to-binary>
+#
+# Configuration file format (YAML):
+#   ignored_vulnerabilities:
+#     - id: GO-2024-12345
+#       module: github.com/example/module
+#       reason: "No fix available - ..."
+
+set -euo pipefail
+
+print_usage() {
+	cat <<'EOF'
+Usage: govulncheck-wrapper.sh --mode <source|binary> [target...]
+
+Options:
+  --mode MODE       Scan mode: source (reachable dependency CVEs) or binary (stdlib/toolchain CVEs)
+  --config FILE     Path to YAML config file (default: .govulncheck-ignore.yaml)
+  --verbose         Enable verbose output
+  -h, --help        Show this help message
+
+Environment:
+  GOVULNCHECK_BIN   Path to the govulncheck binary (default: govulncheck on PATH)
+
+Requires jq to parse govulncheck JSON output. yq is optional; an awk fallback parses
+the ignore file when yq is not installed.
+EOF
+}
+
+CONFIG_FILE=".govulncheck-ignore.yaml"
+MODE=""
+VERBOSE=0
+GOVULNCHECK_BIN="${GOVULNCHECK_BIN:-govulncheck}"
+TARGETS=()
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--mode)
+		MODE="$2"
+		shift 2
+		;;
+	--config)
+		CONFIG_FILE="$2"
+		shift 2
+		;;
+	--verbose)
+		VERBOSE=1
+		shift
+		;;
+	-h | --help)
+		print_usage
+		exit 0
+		;;
+	*)
+		TARGETS+=("$1")
+		shift
+		;;
+	esac
+done
+
+log_info() {
+	echo "[INFO] $*"
+}
+
+log_error() {
+	echo "[ERROR] $*" >&2
+}
+
+if [[ -z "$MODE" ]]; then
+	log_error "--mode is required"
+	print_usage
+	exit 1
+fi
+
+if [[ "$MODE" != "source" && "$MODE" != "binary" ]]; then
+	log_error "unsupported mode: $MODE"
+	exit 1
+fi
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+	if [[ "$MODE" == "source" ]]; then
+		TARGETS=("./...")
+	else
+		log_error "binary mode requires a path to the compiled binary"
+		exit 1
+	fi
+fi
+
+if [[ "$MODE" == "binary" && ${#TARGETS[@]} -ne 1 ]]; then
+	log_error "binary mode supports exactly one binary path"
+	exit 1
+fi
+
+if [[ ! -x "$GOVULNCHECK_BIN" ]] && ! command -v "$GOVULNCHECK_BIN" >/dev/null; then
+	log_error "govulncheck not found: $GOVULNCHECK_BIN"
+	exit 1
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+	log_error "config file not found: $CONFIG_FILE"
+	exit 1
+fi
+
+if ! command -v jq >/dev/null; then
+	log_error "jq not found"
+	exit 1
+fi
+
+load_ignored_list() {
+	if command -v yq >/dev/null 2>&1; then
+		yq -r '.ignored_vulnerabilities[]? | "\(.id)|\(.module)"' "$CONFIG_FILE" 2>/dev/null || true
+		return
+	fi
+
+	log_info "yq not found; parsing $CONFIG_FILE with awk fallback"
+
+	awk '
+		function trim(value) {
+			gsub(/^[ \t]+|[ \t]+$/, "", value)
+			gsub(/^"|"$/, "", value)
+			return value
+		}
+		/^[ \t]*-[ \t]*id:/ {
+			sub(/^[ \t]*-[ \t]*id:[ \t]*/, "")
+			id = trim($0)
+			next
+		}
+		/^[ \t]*module:/ {
+			sub(/^[ \t]*module:[ \t]*/, "")
+			module = trim($0)
+			if (id != "") {
+				print id "|" module
+				id = ""
+			}
+			next
+		}
+	' "$CONFIG_FILE"
+}
+
+run_govulncheck() {
+	local -a cmd=("$GOVULNCHECK_BIN" -json)
+	if [[ "$MODE" == "binary" ]]; then
+		cmd+=(-mode binary)
+	fi
+	cmd+=("${TARGETS[@]}")
+
+	[[ $VERBOSE -eq 1 ]] && log_info "Running: ${cmd[*]}"
+
+	local stdout_file stderr_file
+	stdout_file=$(mktemp)
+	stderr_file=$(mktemp)
+	# shellcheck disable=SC2064
+	trap 'rm -f "$stdout_file" "$stderr_file"' RETURN
+
+	set +e
+	"${cmd[@]}" >"$stdout_file" 2>"$stderr_file"
+	local exit_code=$?
+	set -e
+
+	if [[ -s "$stderr_file" ]]; then
+		cat "$stderr_file" >&2
+	fi
+
+	local output
+	output=$(<"$stdout_file")
+
+	if [[ $exit_code -ne 0 ]]; then
+		log_error "govulncheck failed (exit $exit_code)"
+		[[ -n "$output" ]] && echo "$output" >&2
+		return 1
+	fi
+
+	if grep -qE '^govulncheck:' <<<"$output"; then
+		log_error "govulncheck reported errors"
+		echo "$output" >&2
+		return 1
+	fi
+
+	if [[ -n "$output" ]]; then
+		if ! jq_stderr=$(echo "$output" | jq -e -n 'inputs' 2>&1 >/dev/null); then
+			log_error "govulncheck output is not valid JSON"
+			log_error "$jq_stderr"
+			echo "$output" >&2
+			return 1
+		fi
+	fi
+
+	printf '%s' "$output"
+}
+
+extract_findings() {
+	local vuln_json="$1"
+	local jq_filter
+
+	if [[ "$MODE" == "source" ]]; then
+		jq_filter='select(.finding) | select(.finding.trace | length > 1) | {id: .finding.osv, module: .finding.trace[0].module, fixed: .finding.fixed_version}'
+	else
+		jq_filter='select(.finding) | {id: .finding.osv, module: (.finding.trace[0].module // "stdlib"), fixed: .finding.fixed_version}'
+	fi
+
+	echo "$vuln_json" | jq -c "$jq_filter"
+}
+
+warn_stale_ignore_entries() {
+	local matched_ignored="$1"
+	local scan_label="$2"
+
+	[[ $VERBOSE -eq 1 ]] || return 0
+
+	local ignored_list entry
+	ignored_list=$(load_ignored_list)
+
+	while IFS= read -r entry; do
+		[[ -z "$entry" ]] && continue
+		if ! grep -qxF "$entry" <<<"$matched_ignored"; then
+			log_info "$scan_label: stale ignore entry ${entry%%|*} in ${entry#*|} (not reported by govulncheck)"
+		fi
+	done <<<"$ignored_list"
+}
+
+evaluate_findings() {
+	local findings="$1"
+	local scan_label="$2"
+
+	if [[ -z "$findings" ]]; then
+		log_info "$scan_label: no vulnerabilities found"
+		warn_stale_ignore_entries "" "$scan_label"
+		return 0
+	fi
+
+	local unique_vulns
+	unique_vulns=$(echo "$findings" | jq -c -s 'unique_by(.id + .module)' | jq -c '.[]')
+
+	local ignored_list
+	ignored_list=$(load_ignored_list)
+
+	local ignored_count=0
+	local unignored_count=0
+	local unignored_vulns=""
+	local matched_ignored=""
+
+	while IFS= read -r vuln; do
+		[[ -z "$vuln" ]] && continue
+
+		local vuln_id module fixed
+		vuln_id=$(echo "$vuln" | jq -r '.id')
+		module=$(echo "$vuln" | jq -r '.module')
+		fixed=$(echo "$vuln" | jq -r '.fixed // "N/A"')
+
+		if grep -qxF "${vuln_id}|${module}" <<<"$ignored_list"; then
+			((ignored_count++)) || true
+			matched_ignored="${matched_ignored}${vuln_id}|${module}"$'\n'
+			[[ $VERBOSE -eq 1 ]] && log_info "$scan_label: ignored $vuln_id in $module (listed in $CONFIG_FILE)"
+		else
+			((unignored_count++)) || true
+			unignored_vulns="${unignored_vulns} - $vuln_id in $module (fixed: $fixed)\n"
+			[[ $VERBOSE -eq 1 ]] && log_error "$scan_label: found $vuln_id in $module (fixed: $fixed)"
+		fi
+	done <<<"$unique_vulns"
+
+	log_info "$scan_label: $unignored_count unignored, $ignored_count ignored"
+	warn_stale_ignore_entries "$matched_ignored" "$scan_label"
+
+	if [[ $unignored_count -gt 0 ]]; then
+		log_error "$scan_label: unignored vulnerabilities found:"
+		echo -e "$unignored_vulns" >&2
+		return 1
+	fi
+
+	return 0
+}
+
+[[ $VERBOSE -eq 1 ]] && log_info "Using config file: $CONFIG_FILE"
+
+vuln_json=$(run_govulncheck)
+findings=$(extract_findings "$vuln_json")
+scan_label="govulncheck ($MODE)"
+evaluate_findings "$findings" "$scan_label"

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+
+# govulncheck.sh - Run source and binary vulnerability scans for the RHCS provider.
+#
+# Source mode scans ./... for reachable dependency CVEs.
+# Binary mode scans the compiled terraform-provider-rhcs binary for stdlib/toolchain CVEs.
+
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=jqlang/jq extractVersion=^jq-(?<version>.+)$
+readonly jq_version="1.8.2"
+
+verify_jq_checksum() {
+	local jq_dir=$1
+	local jq_asset=$2
+	local jq_bin=$3
+	local sha256_file="${jq_dir}/sha256sum.txt"
+	local expected actual
+
+	curl -fsSL --retry 5 --retry-delay 2 \
+		-o "$sha256_file" \
+		"https://github.com/jqlang/jq/releases/download/jq-${jq_version}/sha256sum.txt"
+
+	expected=$(grep -F " ${jq_asset}" "$sha256_file" | awk '{print $1}')
+	if [[ -z "$expected" ]]; then
+		echo "jq checksum not found in upstream sha256sum.txt for ${jq_asset}" >&2
+		return 1
+	fi
+
+	actual=$(sha256sum "$jq_bin" | awk '{print $1}')
+	if [[ "$expected" != "$actual" ]]; then
+		echo "jq checksum mismatch for ${jq_asset}" >&2
+		rm -f "$jq_bin"
+		return 1
+	fi
+}
+
+ensure_jq() {
+	if command -v jq >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if [[ "$(uname -s)" != "Linux" ]]; then
+		echo "jq not found; install jq locally (automatic bootstrap is Linux-only)" >&2
+		return 1
+	fi
+
+	if ! command -v curl >/dev/null 2>&1; then
+		echo "jq not found and curl is unavailable to download a static binary" >&2
+		return 1
+	fi
+
+	local jq_dir jq_bin jq_asset arch
+	# Use a private temp dir so a pre-seeded predictable /tmp path cannot
+	# supply an untrusted jq binary that skips checksum verification.
+	jq_dir=$(mktemp -d "${TMPDIR:-/tmp}/rosa-govulncheck-jq.XXXXXX")
+	# shellcheck disable=SC2064
+	trap 'rm -rf -- "'"$jq_dir"'"' EXIT
+	jq_bin="${jq_dir}/jq"
+
+	case "$(uname -m)" in
+	x86_64 | amd64) arch=amd64 ;;
+	aarch64 | arm64) arch=arm64 ;;
+	s390x) arch=s390x ;;
+	ppc64le) arch=ppc64el ;;
+	*)
+		echo "unsupported architecture for jq bootstrap: $(uname -m)" >&2
+		return 1
+		;;
+	esac
+
+	jq_asset="jq-linux-${arch}"
+
+	echo "jq not found; downloading jq ${jq_version} for ${arch}..."
+	curl -fsSL --retry 5 --retry-delay 2 \
+		-o "$jq_bin" \
+		"https://github.com/jqlang/jq/releases/download/jq-${jq_version}/${jq_asset}"
+	chmod +x "$jq_bin"
+	verify_jq_checksum "$jq_dir" "$jq_asset" "$jq_bin"
+
+	export PATH="${jq_dir}:${PATH}"
+}
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+ensure_jq
+
+wrapper="$repo_root/hack/govulncheck-wrapper.sh"
+provider_binary="$repo_root/terraform-provider-rhcs"
+
+if [[ ! -x "$wrapper" ]]; then
+	echo "govulncheck wrapper not executable: $wrapper" >&2
+	exit 1
+fi
+
+echo "Running govulncheck source scan (./...)..."
+"$wrapper" --mode source ./...
+
+if [[ ! -f "$provider_binary" ]]; then
+	echo "terraform-provider-rhcs binary not found at $provider_binary; build it with 'make build' before running govulncheck" >&2
+	exit 1
+fi
+
+echo "Running govulncheck binary scan ($provider_binary)..."
+"$wrapper" --mode binary "$provider_binary"
+
+echo "govulncheck passed (source and binary scans)"


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary
Add `make verify-govulncheck` for the RHCS Terraform provider using pinned govulncheck v1.1.4, with source (`./...`) and binary (`terraform-provider-rhcs`) scans, ignore-file support for deferred stdlib findings, and contributor documentation for the optional Prow presubmit.

## Detailed Description of the Issue
The provider needs a Go-native vulnerability gate that detects reachable dependency CVEs and stdlib/toolchain CVEs in the shipped provider binary. This PR adds the local check and documentation; the optional Prow presubmit lands in a companion openshift/release change.

## Related Issues and PRs
- Jira: [ROSAENG-60032](https://redhat.atlassian.net/browse/ROSAENG-60032)
- Fixes: N/A
- Related PR(s): [openshift/release#81873](https://github.com/openshift/release/pull/81873)
- Related design/docs: https://go.dev/doc/security/vuln/
- Reference implementation: [openshift/rosa#3330](https://github.com/openshift/rosa/pull/3330)

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
No govulncheck tooling, Makefile target, or ignore workflow existed in the provider repository.

## Behavior After This Change
- `make verify-govulncheck` (alias `make govulncheck`) builds `terraform-provider-rhcs` and runs source and binary vulnerability scans.
- `.govulncheck-ignore.yaml` documents deferred stdlib findings until Go 1.26.5 is available, plus a transitive `golang.org/x/crypto` openpgp finding with no fix.
- `CONTRIBUTING.md` documents usage, `jq`/`yq` expectations, and the optional Prow presubmit.
- The check is **not** part of `pre-push-checks` (matches OpenShift rollout pattern).

## How to Test (Step-by-Step)
### Preconditions
- Go 1.26.3 (matches `go.mod`; `mise exec -- go version` recommended)
- Network access for the Go vulnerability database
- `jq` installed locally (required by wrapper)

### Test Steps
1. `mise exec -- make verify-govulncheck`
2. Review output for source (`./...`) and binary (`terraform-provider-rhcs`) scans
3. Optional: `GOVULNCHECK_BIN=./bin/govulncheck ./hack/govulncheck-wrapper.sh --verbose --mode binary ./terraform-provider-rhcs`

### Expected Results
- Command exits 0
- Source and binary scans report deferred stdlib findings as ignored
- No unignored dependency vulnerabilities

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output:
```
Running govulncheck source scan (./...)...
[INFO] govulncheck (source): 0 unignored, 3 ignored
Running govulncheck binary scan (.../terraform-provider-rhcs)...
[INFO] govulncheck (binary): 0 unignored, 6 ignored
govulncheck passed (source and binary scans)
```
- Other artifacts: `shellcheck` on wrapper scripts; CodeRabbit review (2 major findings, kept to match ROSA reference)

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [ ] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two-phase vulnerability scanning (source dependencies and the compiled provider artifact).
  * Introduced make targets to install and run the vulnerability checking tool.
  * Added configurable ignoring for specific unfixed findings via `.govulncheck-ignore.yaml`.
* **Bug Fixes**
  * Improved scan robustness by validating required tools and ensuring results are well-formed JSON; fails when unignored vulnerabilities are found.
* **Documentation**
  * Documented the verification workflow and how to handle ignored findings and tool setup in contributing guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->