### PR TITLE
OCM-00000 | docs: add communication channels and feature process to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,14 @@ It was targeted to developers who want to help improve the provider, and does no
 
 Please read this document and follow this guide to ensure your contribution will be accepted as fast as possible.
 
+## Communication
+
+For internal Red Hat contributors: post your PR link and Jira story in `#forum-rosa-service-engineering` and ping `@rosa-cli-tf-devs` on Red Hat Slack.
+
+## Feature process
+
+For all new features and changes, the CLI serves as our design source of truth, meaning any corresponding provider PRs will be placed on hold until the CLI PR is approved and merged. Use the existing `/hold` mechanism on your PR and reference the upstream CLI PR it depends on.
+
 ## Contributing Code Guidelines
 To begin with, we appreciate your enthusiasm for contributing to RHCS Provider.
 If you have any questions or uncertainties, feel free to reach out for help.


### PR DESCRIPTION
## Summary

- Adds a **Communication** section directing internal contributors to `#forum-rosa-service-engineering` and `@rosa-cli-tf-devs`
- Adds a **Feature process** section clarifying that provider PRs are held until the corresponding CLI PR is approved and merged

## Test plan

- [x] Docs-only change, no code impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for communication and feature development workflows.
  * Documented the required sequencing and approval process for related CLI and provider changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->