### PR TITLE
ROSAENG-61208 | test: Fix id:88409 single-AZ autoscaling assertions

### DIFF
--- a/tests/e2e/negative_day_one_test.go
+++ b/tests/e2e/negative_day_one_test.go
@@ -574,7 +574,7 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 					args.MaxReplicas = new(3)
 				}, "The value for the number of cluster nodes must be non-negative")
 				By("setting max_replicas to 0")
-				maxReplicasZeroErr := "must be a integer greater than 0"
+				maxReplicasZeroErr := "Cluster requires at least 2 compute nodes"
 				if profileHandler.Profile().IsMultiAZ() {
 					maxReplicasZeroErr = "Multi AZ cluster requires at least 3 compute nodes"
 				}
@@ -585,16 +585,15 @@ var _ = Describe("Negative Tests", Ordered, ContinueOnFailure, func() {
 					args.MaxReplicas = new(0)
 				}, maxReplicasZeroErr)
 				By("with a number not a multiple of 3")
-				multipleOfThreeErr := "require that the compute nodes be a multiple of the private subnets 3"
-				if profileHandler.Profile().IsMultiAZ() {
-					multipleOfThreeErr = "Multi AZ clusters require that the number of compute nodes be a multiple of 3"
+				if !profileHandler.Profile().IsMultiAZ() {
+					Skip("Multiple-of-3 autoscaling bounds are enforced only for multi-AZ classic clusters")
 				}
 				validateClusterArgAgainstErrorSubstrings(func(args *exec.ClusterArgs) {
 					args.Autoscaling = new(true)
 					args.Replicas = nil
 					args.MinReplicas = new(3)
 					args.MaxReplicas = new(7)
-				}, multipleOfThreeErr)
+				}, "Multi AZ clusters require that the number of compute nodes be a multiple of 3")
 			})
 		It("validate worker disk size - [id:76344]", ci.Low, func() {
 			maxDiskSize := constants.MaxDiskSize


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary
Fix `[id:88409]` autoscaling negative e2e assertions for single-AZ classic (`rosa-sts-pl`) so they match current `CreateNodes` validation. No provider logic changes.

## Detailed Description of the Issue
`e2e-rosa-sts-private-day1-negative-f7` failed on `[id:88409]` sub-case 5 while `e2e-rosa-sts-advanced-day1-negative-f7` passed the same test on the same `main` SHA.

The provider returned correct errors from `ocm-common` `MinReplicasValidator` / `MaxReplicasValidator`. The e2e test used outdated expectations for single-AZ:
- Sub-case 5 expected `must be a integer greater than 0` (machine-pool OCM wording) but provider returns `Cluster requires at least 2 compute nodes`.
- Sub-case 6 expected HCP private-subnet multiple-of-3 text, but classic single-AZ does not enforce multiple-of-3 bounds (`maxReplicas=7` with `minReplicas=3` is valid).

Jul 15 private log (build `2077371068728741888`) confirmed failure at **STEP: setting max_replicas to 0**, not sub-case 1.

## Related Issues and PRs
- Jira: [ROSAENG-61208](https://issues.redhat.com/browse/ROSAENG-61208)
- Related PR(s): #1250, #1230 (partial prior fixes for other sub-cases / multi-AZ path)
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- `rosa-sts-pl` (single-AZ): sub-case 5 failed assertion; sub-case 6 would not match provider rules.
- `rosa-sts-ad` (multi-AZ): sub-cases 5–6 already matched provider messages.

## Behavior After This Change
- Single-AZ sub-case 5 expects `Cluster requires at least 2 compute nodes`.
- Single-AZ sub-case 6 is skipped with an explicit reason (no multiple-of-3 rule for classic single-AZ).
- Multi-AZ behavior unchanged.

## How to Test (Step-by-Step)
### Preconditions
- Branch `ROSAENG-61208` checked out; `make pre-push-checks` passes locally.

### Test Steps
1. Run `make pre-push-checks`.
2. After merge, watch `periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-sts-private-day1-negative-f7` for `[id:88409]` green.

### Expected Results
- Local gates pass.
- Private day1-negative job passes `[id:88409]`; advanced job remains green.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: Jul 15 private failure expected `must be a integer greater than 0`, actual `Cluster requires at least 2 compute nodes`.
- Other artifacts: `make pre-push-checks` 8/8; CodeRabbit 0 findings on uncommitted diff.

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated autoscaling validation checks to reflect minimum compute-node requirements.
  * Added multi-availability-zone-specific validation coverage for replica counts and compute-node multiples.
  * Adjusted test conditions and expected error messages for greater accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->