### PR TITLE
ROSAENG-60113 | test(unit): add proxy Contains helper coverage

### DIFF
--- a/provider/proxy/utils_test.go
+++ b/provider/proxy/utils_test.go
@@ -152,3 +152,25 @@ var _ = Describe("RemoveNoProxyZeroEgressDefaultDomains", func() {
 		Expect(result).To(Equal("999888777666.dkr.ecr.us-east-1.amazonaws.com")) // Should NOT be filtered
 	})
 })
+
+var _ = Describe("Contains", func() {
+	It("returns false for an empty slice", func() {
+		Expect(Contains([]string{}, "a")).To(BeFalse())
+	})
+
+	It("returns true when the element is present", func() {
+		Expect(Contains([]string{"a", "b", "c"}, "b")).To(BeTrue())
+	})
+
+	It("returns false when the element is absent", func() {
+		Expect(Contains([]string{"a", "b", "c"}, "d")).To(BeFalse())
+	})
+
+	It("returns true for a single matching element", func() {
+		Expect(Contains([]string{"only"}, "only")).To(BeTrue())
+	})
+
+	It("returns false for a single non-matching element", func() {
+		Expect(Contains([]string{"only"}, "other")).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## PR Summary

Add unit tests for `Contains` in `provider/proxy`. **PR 6 of 6** (final) in the [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113) unit-test coverage series.

### Series status
1. `provider/common/attrvalidators` — merged ([#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212))
2. `provider/clusterrosa/common` + `hcp/shared_vpc` — merged ([#1218](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1218))
3. `provider/common` (root) — merged ([#1231](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1231))
4. `provider/clusterrosa/hcp` — merged ([#1243](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1243))
5. `provider/clusterrosa/classic` — merged ([#1251](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1251))
6. `provider/proxy` — `Contains` — **this PR**

## Detailed Description of the Issue

`proxy.Contains` had no direct unit coverage. Existing `utils_test.go` covered only `RemoveNoProxyZeroEgressDefaultDomains`.

## Related Issues and PRs
- Jira: [ROSAENG-60113](https://redhat.atlassian.net/browse/ROSAENG-60113)
- Related PR(s): [#1212](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1212), [#1218](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1218), [#1231](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1231), [#1243](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1243), [#1251](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1251); part 6 of 6 (`ROSAENG-60113-unit-tests-6`).

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

No unit tests exercised `Contains` match/miss/empty-slice paths.

## Behavior After This Change

Ginkgo specs cover empty slice, present element, absent element, and single-element match/miss. Statement coverage for `Contains` is 100%. No production code changes.

### Intentional notes
- **`Contains` callers** — helper is currently unused outside `provider/proxy/utils.go`; this PR adds coverage as planned for the series. Removing unused code is a separate follow-up if desired.
- Style matches existing `utils_test.go` (`It` blocks with `dsl/core` imports).

## How to Test (Step-by-Step)

### Preconditions
- Go toolchain and repo dependencies installed.

### Test Steps
1. `go test ./provider/proxy -count=1`
2. `make pre-push-checks`

### Expected Results
- All `provider/proxy` specs pass.
- Pre-push checks pass.

## Proof of the Fix
- Logs/CLI output: local `make pre-push-checks` (8/8 passed) and CodeRabbit local review (0 findings).

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [x] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [x] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [x] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the `Contains` helper, including empty collections, single-item matches, and present or absent values in multi-item collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->