### PR TITLE
OCM-00000 | ci: stage build/ CI Dockerfiles for release follow-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,16 @@ This repo uses **OpenShift ci-operator** (config in `openshift/release`) and **K
 | Dockerfile | Built by | Used for |
 |------------|----------|----------|
 | `Dockerfile` | Konflux | Shipping provider binary (product) |
-| `Dockerfile.clients` | Prow (main config) | Presubmit: `make pre-push-checks` |
+| `Dockerfile.clients` | Prow (main config, active) | Presubmit: `make pre-push-checks` → image `terraform-provider-rhcs-clients` |
+| `build/Dockerfile.ci` | Prow (after release follow-up) | Same presubmit image; staged rename/move under `build/` |
 | `build/ci-tf-e2e.Dockerfile` | Prow (e2e variants) | E2E runner; image `rhcs-tf-e2e` |
+| `build/custom-ci-build-root.Dockerfile` | Prow (`project_image`, after release follow-up) | ci-operator `build_root` / src image (clone, image builds, Snyk) |
 
-- Presubmit jobs run inside **`terraform-provider-rhcs-clients`** (from `Dockerfile.clients`).
+- Presubmit jobs run inside **`terraform-provider-rhcs-clients`** (from `Dockerfile.clients` today).
 - Prow E2E runs inside **`rhcs-tf-e2e`** (from `build/ci-tf-e2e.Dockerfile`); step scripts expect `/root/terraform-provider-rhcs`.
-- **`.ci-operator.yaml`** pins ci-operator `build_root` (`ocp/builder`) for pipeline plumbing (clone and image builds), not presubmit execution. Release configs under `openshift/release` use `build_root: from_repository: true`.
+- **`.ci-operator.yaml`** still pins ci-operator `build_root` to an `ocp/builder` imagestream while `openshift/release` uses `build_root: from_repository: true`.
+- **`build/custom-ci-build-root.Dockerfile`** (`ubi9/go-toolset`) is the intended build root. After it is on `main`, change the terraform-provider-rhcs configs in `openshift/release` from `from_repository: true` to `build_root.project_image.dockerfile_path: build/custom-ci-build-root.Dockerfile` (common pattern across many OpenShift CI projects). Goal: bump Go on our schedule and give the Snyk `security` job a matching toolchain.
+- **`build/Dockerfile.ci`** is a staged copy of `Dockerfile.clients` for layout consistency (`Dockerfile.ci` is a common OpenShift CI name). In the same release follow-up (or a small companion change), set `images.items[].dockerfile_path: build/Dockerfile.ci` and delete root `Dockerfile.clients`. No technical behavior change—naming/path only.
 
 ### Bumping the Go version
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,59 +1,180 @@
-# Agent guide — terraform-provider-rhcs
+# Agent Guide — terraform-provider-rhcs
 
-Source of truth for AI assistants and review tooling (including CodeRabbit). Rules live in **`developer-docs/`**; commands in **`CONTRIBUTING.md`**.
+This repository contains the Terraform provider for Red Hat Cloud Services (RHCS), with primary focus on ROSA APIs exposed through OCM.
 
-Terraform provider for Red Hat Cloud Services (RHCS), focused on ROSA APIs via OCM.
+This guide defines how coding agents should make decisions, implement changes, and decide when to escalate to a human reviewer.
 
-## Where to look
+## Where rules live (avoid drift)
 
-| Topic | When to read | Doc |
-|-------|--------------|-----|
-| Architecture | Any change; Classic versus HCP; ROSA/OCM boundaries | [`developer-docs/architecture.md`](developer-docs/architecture.md) |
-| Resources and data sources | Adding or changing provider types | [`developer-docs/resources-and-datasources.md`](developer-docs/resources-and-datasources.md) |
-| Testing | Unit, subsystem, e2e, registry | [`developer-docs/testing.md`](developer-docs/testing.md) |
-| Security | Secrets, Sensitive, Trivy | [`developer-docs/security.md`](developer-docs/security.md) |
-| Breaking changes | Schema/behavior/deps; human review | [`developer-docs/breaking-changes.md`](developer-docs/breaking-changes.md) |
-| Docs and examples | Generated docs, templates, examples | [`developer-docs/docs-and-examples.md`](developer-docs/docs-and-examples.md) |
-| Commands and PR checks | Before opening a PR | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
-| PR submission checklist | Before opening a PR | [`.github/pull_request_template.md`](.github/pull_request_template.md) |
+Do **not** duplicate checklists or command lists here. Use one source per concern:
 
-Entrypoints [`CLAUDE.md`](CLAUDE.md) and [`GEMINI.md`](GEMINI.md) point here.
+| Source | Use it for |
+|--------|------------|
+| `README.md` | Project overview, prerequisites, contributor setup summary, limitations, and links to deeper docs — **read this** for context before changing behavior or docs. |
+| `docs/` | Published provider documentation (often **generated** from `templates/` and schema); do not edit generated pages by hand when the workflow requires regeneration — follow `CONTRIBUTING.md`. |
+| `examples/` | Runnable Terraform under `examples/` (resources, data sources, guides paths); use for manual checks and as references for HCL style — align with provider schema and HashiCorp Terraform style. |
+| `CONTRIBUTING.md` | Commands, hooks, tests, formatting, release, and **Go version bump checklist** — **procedural authority**. |
+| `.github/pull_request_template.md` | What to complete on a PR and the **Developer Verification Checklist** — **submission checklist**. |
+| `.cursor/rules/` | Code style and Terraform Plugin Framework guardrails. |
+| **`AGENTS.md` (this file)** | ROSA/OCM boundaries, escalation triggers, and **high-level** implementation flow — not step-by-step commands. |
 
-**Precedence:** `CONTRIBUTING.md` (commands) > `developer-docs/` (rules) > this file (routing). HashiCorp skills lose to `CONTRIBUTING.md` / `developer-docs/` on conflict.
+Thin entrypoints `CLAUDE.md` and `GEMINI.md` should only point here to avoid drift.
 
-## Skills
+**Precedence:** If anything here conflicts with `CONTRIBUTING.md` or `.cursor/rules/`, follow `CONTRIBUTING.md` first, then `.cursor/rules/`.
 
-[HashiCorp terraform skills](https://github.com/hashicorp/agent-skills/tree/main/terraform) — **`CONTRIBUTING.md` / `developer-docs/` win** on conflict.
+**Before opening a PR:** Complete the checklist in `.github/pull_request_template.md`.
 
-| Skill | When |
-|-------|------|
-| **terraform-provider-development** | Plugin Framework CRUD/schema mechanics |
-| **terraform-test** | Acceptance / test patterns |
-| **terraform-style-guide** | HCL in `examples/` and test manifests |
+## CI Container Images
 
-## Workflow
-
-1. Confirm ROSA/OCM support — [`developer-docs/architecture.md`](developer-docs/architecture.md).
-2. Resource or data source? — [`developer-docs/resources-and-datasources.md`](developer-docs/resources-and-datasources.md); follow an analogous package under `provider/`.
-3. Tests — [`developer-docs/testing.md`](developer-docs/testing.md); commands in [`CONTRIBUTING.md`](CONTRIBUTING.md).
-4. Docs/examples — [`developer-docs/docs-and-examples.md`](developer-docs/docs-and-examples.md).
-5. Security — [`developer-docs/security.md`](developer-docs/security.md).
-6. Breaking or high-risk? — [`developer-docs/breaking-changes.md`](developer-docs/breaking-changes.md).
-7. Before PR — [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`.github/pull_request_template.md`](.github/pull_request_template.md).
-
-## Guardrails
-
-- MUST NOT: Document bypassing local hooks or verification gates.
-- MUST: Prefer existing patterns; keep commits small and reviewable.
-- MUST: Keep PR descriptions concrete with reproducible validation steps.
-- MUST NOT: Speculate refactors while implementing functional changes.
-
-## CI container images
-
-Dockerfiles and Go bumps: [CI container images and Go version bumps](CONTRIBUTING.md#ci-container-images-and-go-version-bumps) in **`CONTRIBUTING.md`**.
+This repo uses **OpenShift ci-operator** (config in `openshift/release`) and **Konflux** (`.tekton/`). Each Dockerfile serves a different job type.
 
 | Dockerfile | Built by | Used for |
 |------------|----------|----------|
-| `Dockerfile` | Konflux | Shipping provider binary |
-| `Dockerfile.clients` | Prow | Presubmit: `make pre-push-checks` |
-| `build/ci-tf-e2e.Dockerfile` | Prow | E2E runner (`rhcs-tf-e2e`) |
+| `Dockerfile` | Konflux | Shipping provider binary (product) |
+| `Dockerfile.clients` | Prow (main config, active) | Presubmit: `make pre-push-checks` → image `terraform-provider-rhcs-clients` |
+| `build/Dockerfile.ci` | Prow (after release follow-up) | Same presubmit image; staged rename/move under `build/` |
+| `build/ci-tf-e2e.Dockerfile` | Prow (e2e variants) | E2E runner; image `rhcs-tf-e2e` |
+| `build/custom-ci-build-root.Dockerfile` | Prow (`project_image`, after release follow-up) | ci-operator `build_root` / src image (clone, image builds, Snyk) |
+
+- Presubmit jobs run inside **`terraform-provider-rhcs-clients`** (from `Dockerfile.clients` today).
+- Prow E2E runs inside **`rhcs-tf-e2e`** (from `build/ci-tf-e2e.Dockerfile`); step scripts expect `/root/terraform-provider-rhcs`.
+- **`.ci-operator.yaml`** still pins ci-operator `build_root` to an `ocp/builder` imagestream while `openshift/release` uses `build_root: from_repository: true`.
+- **`build/custom-ci-build-root.Dockerfile`** (`ubi9/go-toolset`) is the intended build root. After it is on `main`, change the terraform-provider-rhcs configs in `openshift/release` from `from_repository: true` to `build_root.project_image.dockerfile_path: build/custom-ci-build-root.Dockerfile` (common pattern across many OpenShift CI projects). Goal: bump Go on our schedule and give the Snyk `security` job a matching toolchain.
+- **`build/Dockerfile.ci`** is a staged copy of `Dockerfile.clients` for layout consistency (`Dockerfile.ci` is a common OpenShift CI name). In the same release follow-up (or a small companion change), set `images.items[].dockerfile_path: build/Dockerfile.ci` and delete root `Dockerfile.clients`. No technical behavior change—naming/path only.
+
+### Bumping the Go version
+
+See [CI container images and Go version bumps](CONTRIBUTING.md#ci-container-images-and-go-version-bumps) in `CONTRIBUTING.md`.
+
+## HashiCorp Terraform Skills
+
+Upstream skills: https://github.com/hashicorp/agent-skills/tree/main/terraform
+
+Recommended for this provider: `terraform-provider-development`, `terraform-test`, `terraform-style-guide` (open each skill’s `SKILL.md`). Treat `CONTRIBUTING.md` and `.cursor/rules/` as overriding generic skill text when they disagree.
+
+## Product boundaries (ROSA + OCM)
+
+- Do not implement provider support for capabilities that are not available in ROSA.
+- Validate feature availability against ROSA documentation and the official OCM API behavior before implementing resource or data source code.
+- When unsure whether support is ROSA HCP versus Classic (or both), stop and verify before implementation.
+
+Reference sources:
+
+- ROSA docs: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/
+- OCM API model (API specification): https://github.com/openshift-online/ocm-api-model
+
+## Expectations for agent-produced changes
+
+These are **review and design expectations**. They are not all enforced by automation; contributors and reviewers still apply them. Concrete commands and gates are in `CONTRIBUTING.md` (for example hooks, `make pre-push-checks`, subsystem registry, and the full test suite). Optional local coverage targets exist but are not merge gates.
+
+- Do not hard code secrets, API keys, tokens, kubeconfigs, AWS credentials, or customer identifiers in code, tests, docs, examples, or logs.
+- Do not document bypassing local hooks or verification gates.
+- Do not ship silent breaking changes: call out impact and migration in the PR (see **Breaking Changes** in the PR template).
+- Do not edit generated provider docs by hand when the workflow requires regeneration; edit sources and regenerate per `CONTRIBUTING.md`.
+- Prefer existing patterns in this repo over new architecture or naming.
+- Keep error messages actionable and consistent with project standards.
+
+## Common implementation flows
+
+### Add or change a resource
+
+1. Confirm capability exists in ROSA and OCM API.
+2. Inspect analogous resource implementations in `provider/` and follow schema/state/CRUD conventions.
+3. Add or update schema and state structs using existing package patterns.
+4. Implement create/read/update/delete behavior and diagnostics.
+5. Add/update unit tests in `provider/.../*_test.go`.
+6. Add/update subsystem coverage under `subsystem/` for behavior changes.
+7. Update docs source (`templates/` and schema descriptions), regenerate docs, and verify generated files.
+
+### Add or change a data source
+
+1. Confirm capability exists and is queryable through OCM APIs used by the provider.
+2. Follow existing data source patterns for schema, read behavior, and diagnostics.
+3. Validate shape and computed attributes against analogous data sources.
+4. Add/update unit tests and subsystem tests for the primary query flow.
+5. Regenerate and validate docs for the new/changed data source.
+
+## Review tests when behavior changes
+
+When provider behavior, validation, error messages, schema, or test harness wiring changes, review **all layers** that can exercise it — not only the package you edited. Concrete test commands are in `CONTRIBUTING.md`.
+
+| Layer | Where to look |
+|-------|----------------|
+| Unit | `provider/.../*_test.go`, `internal/.../*_test.go` — validators, state mapping, diagnostics text |
+| Subsystem | `subsystem/classic/`, `subsystem/hcp/` — plan/apply and negative cases against stubbed OCM |
+| E2E | `tests/e2e/` — full Terraform apply against CI profiles; error substring and side-effect assertions |
+| Harness | `tests/utils/exec/`, `tests/utils/profilehandler/`, `tests/tf-manifests/`, `tests/ci/profiles/` — how args and profiles map to Terraform variables and provider attributes |
+
+Apply these checks when the change fits:
+
+- **Config wiring** — If how values reach Terraform changes (flat versus nested variables, renamed tfvars keys, or `ClusterArgs` HCL tags), verify **Classic and HCP manifests** under `tests/tf-manifests/` stay aligned unless divergence is intentional.
+- **Validation and errors** — If rules or error messages change, update matching subsystem and e2e assertions; do not assume stale substring checks still pass.
+- **Profile gating** — If profile fields or skip conditions change (for example `IsAdminEnabled()`), confirm newly enabled e2e cases have correct fixtures and expectations.
+- **Subsystem is not enough** — Adding subsystem coverage does not replace reviewing e2e harness wiring when the change touches `tests/utils/exec` or tf-manifests.
+
+## Subsystem registry check
+
+`make check-subsystem-registry` (script: `hack/check-subsystem-registry.sh`) verifies that every Terraform type registered in `provider/` is referenced in at least one subsystem test (`resource "rhcs_…"` or `data "rhcs_…"` under `subsystem/`). It runs as part of `make pre-push-checks` and fails the push/CI when the check fails.
+
+**When adding a resource or data source:** add or update a subsystem test that references the type. Do **not** add an allowlist entry for new types.
+
+**When to use `hack/subsystem-registry-allowlist.yaml`:** only for **temporary, documented exceptions** — for example a known gap being fixed in a follow-up PR. Each entry must include `type`, `ticket`, and `reason`. Remove the entry in the same PR that adds subsystem coverage. Allowlist is not a substitute for subsystem tests on new provider types.
+
+**New types on the branch** (compared to the merge base with `main`) without a subsystem reference always fail the check, even if allowlisted elsewhere.
+
+Run locally: `make check-subsystem-registry`.
+
+## Breaking change policy
+
+Treat any change below as potentially breaking unless proven otherwise:
+
+- Attribute rename/removal/type change.
+- Required versus optional/computed contract changes.
+- Behavioral changes in plan/apply that alter existing successful configurations.
+- Import/state format changes.
+- Provider-wide dependency changes that can impact runtime, generated docs, authentication, or API compatibility.
+
+When a breaking change is necessary, use the PR template’s **Breaking Changes** section and migration fields, add tests that show the impact, update docs/examples, and request human review as required by `CONTRIBUTING.md`.
+
+## Human-in-the-loop triggers
+
+Stop and request explicit human review before merge when any of the following occurs:
+
+- Dependency bump for provider-wide tooling/runtime with possible broad impact, including:
+  - `terraform-plugin-docs`
+  - AWS SDK modules (for example `aws-sdk-go-v2`)
+  - Terraform Plugin Framework/core dependencies
+- Schema or state model changes affecting existing resources/data sources.
+- New feature appears unsupported or ambiguous in ROSA docs or OCM API.
+- Security-sensitive behavior changes (auth, token handling, trust bundles, proxy behavior, logging of request/response data).
+- CI failures suggest cross-repo or infrastructure issues rather than isolated code defects.
+
+## Trivy (IaC misconfiguration)
+
+Repo config: root **`trivy.yaml`** (severity, scanners, skips; Terraform under **`examples/`**, **`tests/`**, **`generate_example_usages/`**, and root **`Dockerfile`**). CodeRabbit may run Trivy when enabled in **`.coderabbit.yaml`**. References: [Trivy config file](https://trivy.dev/latest/docs/references/configuration/config-file/), [filtering / ignores](https://trivy.dev/latest/docs/configuration/filtering/).
+
+When **`trivy config`** reports a **misconfiguration** (check IDs like **`AWS-0104`**, **`DS-0002`** — not CVE vulnerability rows from **`trivy fs`** vuln scans):
+
+1. **Prefer fixing** the HCL/Dockerfile (least privilege, encryption, IMDSv2, non-root user, etc.).
+2. If an ignore is required, add **`#trivy:ignore:<id>`** on the line **immediately above** the Terraform resource or Dockerfile instruction, with a **short `#` comment** on the same line or the line above explaining why (narrow scope).
+3. Use **`.trivyignore`** only when inline suppression is not possible — one ID per line with a **`#` justification** above each.
+
+## Use existing patterns first
+
+Before introducing new structure, identify and reuse:
+
+- Similar resource/data source package layouts.
+- Existing CRUD and diagnostics patterns.
+- Existing subsystem test wiring and assertions.
+- Existing docs template style and generated docs workflow.
+
+If no suitable pattern exists, document why in the PR description.
+
+To see how a similar change was done, search **merged** pull requests in this repository for the relevant `provider/` or `subsystem/` paths instead of relying on a single historical PR link.
+
+## Practical review heuristics for agents
+
+- Prefer small, reviewable commits scoped to one behavior change.
+- Keep PR descriptions concrete with reproducible validation steps (align with the template’s **How to Test**).
+- Avoid speculative refactors while implementing functional changes.
+- If a change touches both Classic and HCP behavior, call out parity or intentional divergence explicitly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,9 +152,9 @@ When bumping the Go version, update these together so compile, presubmits, E2E b
 
 - `go.mod` (`go` directive)
 - `renovate.json` — `gomod.constraints.go` (must match `go.mod` so Renovate `gomodTidy` PRs succeed)
-- `Dockerfile`, `Dockerfile.clients`, `build/ci-tf-e2e.Dockerfile` — `ubi9/go-toolset` image tag
-- `.ci-operator.yaml` — `build_root_image.tag` (match an available `ocp/builder:rhel-9-golang-*` tag for pipeline plumbing; presubmit compile runs in `Dockerfile.clients`)
-- `TERRAFORM_VERSION` in `Dockerfile.clients` when `terraform fmt` checks need a newer Terraform CLI
+- `Dockerfile`, `Dockerfile.clients`, `build/Dockerfile.ci`, `build/ci-tf-e2e.Dockerfile`, `build/custom-ci-build-root.Dockerfile` — `ubi9/go-toolset` image tag (keep `Dockerfile.clients` and `build/Dockerfile.ci` in sync until the release path switch)
+- `.ci-operator.yaml` — `build_root_image` imagestream (`namespace` / `name` / `tag`) while release still uses `from_repository: true`. After the release follow-up switches to `project_image.dockerfile_path`, Go for build_root/Snyk is controlled by `build/custom-ci-build-root.Dockerfile` instead
+- `TERRAFORM_VERSION` in `Dockerfile.clients` / `build/Dockerfile.ci` when `terraform fmt` checks need a newer Terraform CLI
 
 Sibling checklist for the ROSA CLI: `openshift/rosa` `AGENTS.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,9 +162,9 @@ When bumping the Go version, update these together so compile, presubmits, E2E b
 
 - `go.mod` (`go` directive)
 - `renovate.json` — `gomod.constraints.go` (must match `go.mod` so Renovate `gomodTidy` PRs succeed)
-- `Dockerfile`, `Dockerfile.clients`, `build/ci-tf-e2e.Dockerfile` — `ubi9/go-toolset` image tag
-- `.ci-operator.yaml` — `build_root_image.tag` (match an available `ocp/builder:rhel-9-golang-*` tag for pipeline plumbing; presubmit compile runs in `Dockerfile.clients`)
-- `TERRAFORM_VERSION` in `Dockerfile.clients` when `terraform fmt` checks need a newer Terraform CLI
+- `Dockerfile`, `Dockerfile.clients`, `build/Dockerfile.ci`, `build/ci-tf-e2e.Dockerfile`, `build/custom-ci-build-root.Dockerfile` — `ubi9/go-toolset` image tag (keep `Dockerfile.clients` and `build/Dockerfile.ci` in sync until the release path switch)
+- `.ci-operator.yaml` — `build_root_image` imagestream (`namespace` / `name` / `tag`) while release still uses `from_repository: true`. After the release follow-up switches to `project_image.dockerfile_path`, Go for build_root/Snyk is controlled by `build/custom-ci-build-root.Dockerfile` instead
+- `TERRAFORM_VERSION` in `Dockerfile.clients` / `build/Dockerfile.ci` when `terraform fmt` checks need a newer Terraform CLI
 
 Sibling checklist for the ROSA CLI: `openshift/rosa` `AGENTS.md`.
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -1,7 +1,13 @@
-# Prow presubmit client image: make pre-push-checks.
-# Source is copied at image build (ci-operator builds this image from the PR tree).
-# Active path for openshift/release today. Staged copy: build/Dockerfile.ci
-# (switch release dockerfile_path there in a follow-up, then remove this file).
+# Prow presubmit CI image: make pre-push-checks (image to: terraform-provider-rhcs-clients).
+#
+# Staged location for a consistent build/ layout. openshift/release still points at
+# root Dockerfile.clients. After this lands on main, update the release config to:
+#
+#   dockerfile_path: build/Dockerfile.ci
+#
+# Then remove root Dockerfile.clients. Naming matches a common OpenShift CI
+# convention (Dockerfile.ci); no functional change until the release switch.
+# Keep this file in sync with Dockerfile.clients until then.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515
 USER root
 WORKDIR /opt/app-root/src

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -1,0 +1,31 @@
+# Prow presubmit CI image: make pre-push-checks (image to: terraform-provider-rhcs-clients).
+#
+# Staged location for a consistent build/ layout. openshift/release still points at
+# root Dockerfile.clients. After this lands on main, update the release config to:
+#
+#   dockerfile_path: build/Dockerfile.ci
+#
+# Then remove root Dockerfile.clients. Naming matches a common OpenShift CI
+# convention (Dockerfile.ci); no functional change until the release switch.
+# Keep this file in sync with Dockerfile.clients until then.
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1785111405
+USER root
+WORKDIR /opt/app-root/src
+RUN dnf install -y --setopt=install_weak_deps=False --nodocs \
+        yum-utils jq make git gcc gcc-c++ diffutils && \
+    dnf clean all
+# renovate: datasource=github-releases depName=hashicorp/terraform
+ARG TERRAFORM_VERSION=1.15.4
+RUN yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && \
+    dnf -y install "terraform-${TERRAFORM_VERSION}" && \
+    dnf clean all && \
+    terraform version
+RUN git config --global --add safe.directory '*'
+COPY . .
+# OpenShift Prow: arbitrary UID runs with GID 0; group-writable workdir and Go caches.
+RUN mkdir -p /opt/app-root/src/bin /tmp/gomodcache /tmp/.cache && \
+    chgrp -R 0 /opt/app-root/src /tmp/gomodcache /tmp/.cache && \
+    chmod -R g+rwX /opt/app-root/src /tmp/gomodcache /tmp/.cache
+ENV HOME="/opt/app-root/src" \
+    GOMODCACHE="/tmp/gomodcache" \
+    GOLANGCI_LINT_CACHE="/tmp/.cache"

--- a/build/custom-ci-build-root.Dockerfile
+++ b/build/custom-ci-build-root.Dockerfile
@@ -1,0 +1,20 @@
+# Intended ci-operator build_root image (ubi9/go-toolset).
+#
+# Not active yet: openshift/release still uses build_root.from_repository: true,
+# which reads .ci-operator.yaml (ocp/builder imagestream). After this lands on
+# main, switch release configs to:
+#
+#   build_root:
+#     project_image:
+#       dockerfile_path: build/custom-ci-build-root.Dockerfile
+#
+# That pattern is widely used in openshift/release. Motivation: pin Go via
+# go-toolset so we can bump the toolchain when we need to (including fixing the
+# Snyk security presubmit, which runs go mod tidy/vendor on the build_root/src
+# image).
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1784638038
+
+USER root
+
+RUN dnf install -y --setopt=install_weak_deps=False --nodocs git jq && \
+    dnf clean all

--- a/build/custom-ci-build-root.Dockerfile
+++ b/build/custom-ci-build-root.Dockerfile
@@ -1,0 +1,20 @@
+# Intended ci-operator build_root image (ubi9/go-toolset).
+#
+# Not active yet: openshift/release still uses build_root.from_repository: true,
+# which reads .ci-operator.yaml (ocp/builder imagestream). After this lands on
+# main, switch release configs to:
+#
+#   build_root:
+#     project_image:
+#       dockerfile_path: build/custom-ci-build-root.Dockerfile
+#
+# That pattern is widely used in openshift/release. Motivation: pin Go via
+# go-toolset so we can bump the toolchain when we need to (including fixing the
+# Snyk security presubmit, which runs go mod tidy/vendor on the build_root/src
+# image).
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1785111405
+
+USER root
+
+RUN dnf install -y --setopt=install_weak_deps=False --nodocs git jq && \
+    dnf clean all

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,9 @@
     "managerFilePatterns": [
       "/^Dockerfile$/",
       "/^Dockerfile\\.clients$/",
-      "/^build/ci-tf-e2e\\.Dockerfile$/"
+      "/^build/Dockerfile\\.ci$/",
+      "/^build/ci-tf-e2e\\.Dockerfile$/",
+      "/^build/custom-ci-build-root\\.Dockerfile$/"
     ]
   },
   "commitMessagePrefix": "OCM-00000 | ci: ",
@@ -136,7 +138,9 @@
       "matchFileNames": [
         "Dockerfile.clients",
         "Dockerfile",
-        "build/ci-tf-e2e.Dockerfile"
+        "build/Dockerfile.ci",
+        "build/ci-tf-e2e.Dockerfile",
+        "build/custom-ci-build-root.Dockerfile"
       ],
       "groupName": "CI client image",
       "groupSlug": "ci-client-image",


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary
Stage CI Dockerfiles under `build/` for a later `openshift/release` switch. Active CI paths stay the same. `build/Dockerfile.ci` is a **name/path-only** copy of `Dockerfile.clients` (same instruction body). After release points at the new paths, remove the unused root files (for example `Dockerfile.clients`).

## Detailed Description of the Issue
The optional Snyk `security` job runs on the ci-operator `src` image from `build_root`. Release still uses `build_root: from_repository: true`, so `.ci-operator.yaml` must pin an ImageStream and cannot select an arbitrary Go patch (for example `ubi9/go-toolset:1.26.5`).

The supported fix is `build_root.project_image.dockerfile_path` in `openshift/release` (common across many OpenShift CI projects). This PR only stages the in-repo files and docs; the release switch comes after merge.

Separately, root `Dockerfile.clients` is an uncommon name for the presubmit image. Staging `build/Dockerfile.ci` matches a common `Dockerfile.ci` convention and the existing `build/` layout. **No image recipe change** — only path/name for the follow-up.

## Related Issues and PRs
- Jira: OCM-00000 (internal CI fix)
- Fixes: N/A
- Related PR(s): Follow-up in `openshift/release` after this merges:
  - `build_root.project_image.dockerfile_path: build/custom-ci-build-root.Dockerfile`
  - `images.items[].dockerfile_path: build/Dockerfile.ci`
  - Then in this repo: remove unused files (`Dockerfile.clients`; drop or slim `.ci-operator.yaml` once `from_repository` is no longer used)
- Related design/docs: https://docs.ci.openshift.org/architecture/ci-operator/

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- `.ci-operator.yaml` pins `ocp/builder:rhel-9-golang-1.26-openshift-4.23`.
- Presubmit image built from root `Dockerfile.clients`.

## Behavior After This Change
- Active paths **unchanged**: imagestream in `.ci-operator.yaml`; release still builds clients from `Dockerfile.clients`.
- New `build/custom-ci-build-root.Dockerfile` (`ubi9/go-toolset:1.26.5`, `git`, `jq`) for future `project_image` (Go bumps + Snyk).
- New `build/Dockerfile.ci`: **identical** `FROM` / `RUN` / `COPY` / `ENV` body to `Dockerfile.clients` (header comments only differ). Name/path staging only.
- Renovate tracks the staged Dockerfiles; docs describe the release follow-up.

**Not activated until** `openshift/release` is updated, for example:

```yaml
build_root:
  project_image:
    dockerfile_path: build/custom-ci-build-root.Dockerfile
images:
  items:
  - dockerfile_path: build/Dockerfile.ci
    to: terraform-provider-rhcs-clients
```

**Cleanup after that release change:** remove unused in-repo files that the old paths depended on (at least root `Dockerfile.clients`; revisit `.ci-operator.yaml` if `from_repository` is gone).

## How to Test (Step-by-Step)
### Preconditions
- Staging-only PR; live build_root and clients paths unchanged.

### Test Steps
1. Confirm `.ci-operator.yaml` still has `ocp/builder` `namespace` / `name` / `tag`.
2. Diff `Dockerfile.clients` vs `build/Dockerfile.ci` ignoring leading comments — bodies match.
3. Confirm Prow still uses `Dockerfile.clients` and does not fail on `.ci-operator.yaml`.

### Expected Results
- Required CI unchanged.
- Staged files ready for the release follow-up; unused files removed only after release points at `build/`.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: `diff` of instruction bodies (excluding header comments) is empty
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [ ] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/`.
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](CONTRIBUTING.md)).
- [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [ ] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated CI container images with Go tooling, Git, jq, Terraform, and required build dependencies.
  - Improved support for consistent, writable build and cache directories in CI environments.

- **Documentation**
  - Updated contributor and CI guidance for container image configuration, Go version updates, and Terraform maintenance.
  - Documented the planned transition to the new CI build image workflow.

- **Chores**
  - Expanded automated Dockerfile update tracking to cover the new CI image definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->