### PR TITLE
OCM-00000 | refactor(logging): drop direct terraform-plugin-sdk/v2 dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ unit-test: $(GINKGO)
 	$(GINKGO) run \
 		--succinct \
 		-ldflags="$(ldflags)" \
-		-r provider internal/...
+		-r provider internal/... logging
 
 # Optional local diagnostics — not run by pre-push-checks or CI.
 .PHONY: unit-test-coverage
@@ -138,7 +138,7 @@ unit-test-coverage: $(GINKGO)
 		--cover \
 		--coverprofile coverage.out \
 		-ldflags="$(ldflags)" \
-		-r provider internal/...
+		-r provider internal/... logging
 
 
 .PHONY: test tests

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/openshift-online/ocm-common v0.0.44
@@ -115,7 +114,6 @@ require (
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/hc-install v0.9.4 // indirect
-	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,6 @@ github.com/hashicorp/hc-install v0.9.4 h1:KKWOpUG0EqIV63Qk2GGFrZ0s275NVs5lKf9N5v
 github.com/hashicorp/hc-install v0.9.4/go.mod h1:4LRYeEN2bMIFfIv57ldMWt9awfuZhvpbRt0vWmv51WU=
 github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
 github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
-github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
-github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.25.1 h1:PRutYRGM8pixV3B8812NYoBK5O+yuf3qcB/70KFKGiU=
 github.com/hashicorp/terraform-exec v0.25.1/go.mod h1:+izOYrs9sKMQK4OYvGDnrSSJHY/pm4e4eXFqSL2Q5mA=
 github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a h1:T7AMR21kjrbeEpN+KhGlyd31XXHsSZF5zg+ivfeYte4=
@@ -194,8 +192,6 @@ github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKU
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=
 github.com/hashicorp/terraform-plugin-log v0.10.0/go.mod h1:/9RR5Cv2aAbrqcTSdNmY1NRHP4E3ekrXRGjqORpXyB0=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1 h1:2yPUd7esMOpuTaG3y1iEla1iw+tla+3ZEkkBnmOAre4=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1/go.mod h1:sq8qsxh+PwdvTQFcd17kfCoBgQo46ADNMvCpKE7t/gY=
 github.com/hashicorp/terraform-registry-address v0.4.0 h1:S1yCGomj30Sao4l5BMPjTGZmCNzuv7/GDTDX99E9gTk=
 github.com/hashicorp/terraform-registry-address v0.4.0/go.mod h1:LRS1Ay0+mAiRkUyltGT+UHWkIqTFvigGn/LbMshfflE=
 github.com/hashicorp/terraform-svchost v0.2.1 h1:ubvrTFw3Q7CsoEaX7V06PtCTKG3wu7GyyobAoN4eF3Q=

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -6,12 +6,26 @@ package logging
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	tflogging "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	ocmlogging "github.com/openshift-online/ocm-sdk-go/logging"
 )
+
+// Terraform log levels recognized via the TF_LOG environment variable.
+const (
+	levelTrace = "TRACE"
+	levelDebug = "DEBUG"
+	levelInfo  = "INFO"
+	levelWarn  = "WARN"
+	levelError = "ERROR"
+)
+
+// validLogLevels lists the levels recognized by Terraform's TF_LOG
+// environment variable.
+var validLogLevels = []string{levelTrace, levelDebug, levelInfo, levelWarn, levelError}
 
 // TfLogger is a logger that uses the Go `log` package.
 type TfLogger struct {
@@ -24,24 +38,45 @@ type TfLogger struct {
 // New creates the provider.
 func New() ocmlogging.Logger {
 	tfLogger := &TfLogger{}
-	logLevel := tflogging.LogLevel()
+	logLevel := tfLogLevel()
 	switch logLevel {
-	case "TRACE", "DEBUG":
+	case levelTrace, levelDebug:
 		tfLogger.debugEnabled = true
 		tfLogger.infoEnabled = true
 		tfLogger.warnEnabled = true
 		tfLogger.errorEnabled = true
-	case "INFO":
+	case levelInfo:
 		tfLogger.infoEnabled = true
 		tfLogger.warnEnabled = true
 		tfLogger.errorEnabled = true
-	case "WARN":
+	case levelWarn:
 		tfLogger.warnEnabled = true
 		tfLogger.errorEnabled = true
-	case "ERROR", "":
+	case levelError, "":
 		tfLogger.errorEnabled = true
 	}
 	return tfLogger
+}
+
+// tfLogLevel returns the normalized Terraform log level from the TF_LOG
+// environment variable. It mirrors the semantics previously provided by
+// terraform-plugin-sdk/v2/helper/logging.LogLevel(): an unset TF_LOG yields an
+// empty string, a recognized level (case-insensitive) is upper-cased, and any
+// other non-empty value falls back to TRACE.
+func tfLogLevel() string {
+	envLevel := os.Getenv("TF_LOG")
+	if envLevel == "" {
+		return ""
+	}
+	upperLevel := strings.ToUpper(envLevel)
+	for _, level := range validLogLevels {
+		if upperLevel == level {
+			return upperLevel
+		}
+	}
+	log.Printf("[WARN] Invalid log level: %q. Defaulting to level: TRACE. Valid levels are: %+v",
+		envLevel, validLogLevels)
+	return levelTrace
 }
 
 // DebugEnabled returns true iff the debug level is enabled.

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,0 +1,73 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Logging", func() {
+	var (
+		originalTFLog string
+		hadTFLog      bool
+	)
+
+	BeforeEach(func() {
+		originalTFLog, hadTFLog = os.LookupEnv("TF_LOG")
+	})
+
+	AfterEach(func() {
+		if hadTFLog {
+			Expect(os.Setenv("TF_LOG", originalTFLog)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv("TF_LOG")).To(Succeed())
+		}
+	})
+
+	setTFLog := func(value string, set bool) {
+		if set {
+			Expect(os.Setenv("TF_LOG", value)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv("TF_LOG")).To(Succeed())
+		}
+	}
+
+	DescribeTable("tfLogLevel normalizes the TF_LOG environment variable",
+		func(value string, set bool, expected string) {
+			setTFLog(value, set)
+			Expect(tfLogLevel()).To(Equal(expected))
+		},
+		Entry("unset -> empty", "", false, ""),
+		Entry("empty -> empty", "", true, ""),
+		Entry("TRACE -> TRACE", "TRACE", true, "TRACE"),
+		Entry("DEBUG -> DEBUG", "DEBUG", true, "DEBUG"),
+		Entry("INFO -> INFO", "INFO", true, "INFO"),
+		Entry("WARN -> WARN", "WARN", true, "WARN"),
+		Entry("ERROR -> ERROR", "ERROR", true, "ERROR"),
+		Entry("lowercase is upper-cased", "info", true, "INFO"),
+		Entry("mixed case is upper-cased", "TrAcE", true, "TRACE"),
+		Entry("invalid falls back to TRACE", "BOGUS", true, "TRACE"),
+	)
+
+	DescribeTable("New enables the expected levels for a given TF_LOG",
+		func(value string, set bool, wantDebug, wantInfo, wantWarn, wantError bool) {
+			setTFLog(value, set)
+			logger := New().(*TfLogger)
+			Expect(logger.DebugEnabled()).To(Equal(wantDebug))
+			Expect(logger.InfoEnabled()).To(Equal(wantInfo))
+			Expect(logger.WarnEnabled()).To(Equal(wantWarn))
+			Expect(logger.ErrorEnabled()).To(Equal(wantError))
+		},
+		Entry("unset -> error only", "", false, false, false, false, true),
+		Entry("TRACE -> all levels", "TRACE", true, true, true, true, true),
+		Entry("DEBUG -> all levels", "DEBUG", true, true, true, true, true),
+		Entry("INFO -> info, warn, error", "INFO", true, false, true, true, true),
+		Entry("WARN -> warn, error", "WARN", true, false, false, true, true),
+		Entry("ERROR -> error only", "ERROR", true, false, false, false, true),
+		Entry("invalid -> all levels (TRACE fallback)", "BOGUS", true, true, true, true, true),
+	)
+})

--- a/logging/main_test.go
+++ b/logging/main_test.go
@@ -1,0 +1,16 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
+	. "github.com/onsi/gomega"             // nolint
+)
+
+func TestLogging(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logging Suite")
+}

--- a/logging/main_test.go
+++ b/logging/main_test.go
@@ -6,8 +6,8 @@ package logging
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2/dsl/core" // nolint
-	. "github.com/onsi/gomega"             // nolint
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
 )
 
 func TestLogging(t *testing.T) {


### PR DESCRIPTION
## PR Summary

Removes the vestigial direct dependency on `github.com/hashicorp/terraform-plugin-sdk/v2`. The only remaining use was `helper/logging.LogLevel()` in `logging/logging.go`, which is reimplemented locally with identical semantics.

## Detailed Description of the Issue

The provider is built on the terraform-plugin-framework, but still carried `terraform-plugin-sdk/v2` as a direct dependency solely for a single `LogLevel()` call that reads the `TF_LOG` environment variable. That call is trivial to reproduce locally, so the SDK dependency is unnecessary weight in the module graph.

## Related Issues and PRs
- Jira: OCM-00000 (no tracked ticket)
- Fixes: `#1127`
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [x] refactor - code restructuring with no behavior change.

## Previous Behavior

`logging.New()` derived the log level from `terraform-plugin-sdk/v2/helper/logging.LogLevel()`, keeping the SDK as a direct dependency.

## Behavior After This Change

`logging.New()` uses a local `tfLogLevel()` helper. Behavior is unchanged: an unset `TF_LOG` yields an empty level, a recognized level is matched case-insensitively and upper-cased, and any other non-empty value falls back to `TRACE` (with the same warning log). `terraform-plugin-sdk/v2` and its now-unused transitive `hashicorp/logutils` are dropped from `go.mod` via `go mod tidy`.

## How to Test (Step-by-Step)
### Preconditions
Go toolchain per `go.mod`.

### Test Steps
1. `make test` (runs the new `logging` package unit tests among the suite)
2. `go build ./...`
3. `grep -r "terraform-plugin-sdk/v2" --include="*.go" .` returns no import

### Expected Results
Tests pass, build succeeds, and the SDK is no longer imported anywhere or present in `go.mod`.

## Proof of the Fix
- Logs/CLI output: `make pre-push-checks` passes all 8 steps locally (format-check, build, generated-files, lint, docs-lint, license-check, subsystem-registry, unit+subsystem tests). The `logging` package had no tests before this PR and now has unit coverage for `tfLogLevel()` and `New()` level mapping.

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate. (N/A, no user-facing docs affected)
- [x] Any risk, limitation, or follow-up work is documented.

### Testing (check all that apply; use N/A when not relevant)
- [x] **New or changed validation, plan modifiers, or helpers** — unit tests added in the same package (`logging/logging_test.go`).
- [x] `make check-subsystem-registry` passes.
- [x] I manually tested the change when behavior is user-visible. (N/A, no user-visible behavior change; verified via unit tests and `TF_LOG` level mapping.)

<!-- Note for reviewers: AGENTS.md flags plugin-core dependency changes for human review. This removal is the cleanup requested in #1127; behavior is preserved and covered by new unit tests. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Logging configuration now reads the `TF_LOG` environment variable directly.
  - Supports case-insensitive `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR` levels.
  - Invalid values display a warning and default to the most detailed logging level.

- **Bug Fixes**
  - Logging behavior is now consistent for unset, valid, and invalid `TF_LOG` values.

- **Tests**
  - Added coverage for log-level normalization and logger configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->