### PR TITLE
ROSAENG-60034 | ci: add gitleaks to pre-commit and pre-push-checks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,16 +1,92 @@
 # Gitleaks — https://github.com/gitleaks/gitleaks/blob/master/README.md
-# Used by CodeRabbit when gitleaks is enabled (.coderabbit.yaml) and by CI/local
-# `gitleaks detect`. Extends upstream default rules.
 #
-# **/*.tftest.hcl harnesses may use mocks/placeholders — not live credentials.
+# Purpose: Detect hardcoded secrets, credentials, and sensitive data in this
+# Terraform provider repository.
+#
+# Integration:
+# - pre-commit hook (blocking)
+# - make verify-gitleaks (also part of make pre-push-checks / Prow pre-push-checks)
+# - CodeRabbit when gitleaks is enabled (.coderabbit.yaml)
+#
+# Usage:
+#   make verify-gitleaks
+#   pre-commit run gitleaks --all-files
+#   gitleaks detect --source . --config .gitleaks.toml --no-git --verbose
+#
+# Allowlist policy:
+# 1. Prefer fixing real or avoidable findings.
+# 2. Allowlist only justified mocks/fixtures with a short comment.
+# 3. Never disable gitleaks entirely.
+# 4. Keep Makefile GITLEAKS_VERSION (release tag) aligned with the pre-commit
+#    gitleaks commit SHA (# frozen: <same tag>) for the same release.
 
 title = "terraform-provider-rhcs"
 
 [extend]
 useDefault = true
 
+# =============================================================================
+# GLOBAL ALLOWLIST
+# =============================================================================
+
 [allowlist]
-description = "Terraform CLI test configs may contain mock tokens/placeholders."
+description = "Paths and mock patterns that are not live credentials"
+
 paths = [
+  # Terraform plugin/CLI caches and local tool binaries (not source)
+  '''(?:^|/)\.terraform(?:/|$)''',
+  '''^bin/''',
+  '''^vendor/''',
+  # Terraform test harnesses may use placeholders
   '''\.tftest''',
 ]
+
+# Allow specific test/example values that look like secrets but are not
+regexes = [
+  '''(?i)fake[_-]?token''',
+  '''(?i)test[_-]?secret''',
+  '''(?i)example[_-]?key''',
+  '''(?i)dummy[_-]?password''',
+  '''(?i)placeholder''',
+  '''AKIAIOSFODNN7EXAMPLE''', # AWS documentation example access key
+]
+
+stopwords = [
+  "example",
+  "test",
+  "fake",
+  "dummy",
+  "placeholder",
+  "sample",
+  "mock",
+]
+
+# =============================================================================
+# CUSTOM RULES (provider / ROSA / OpenShift specific)
+# =============================================================================
+
+[[rules]]
+id = "ocm-rhcs-token"
+description = "OCM / RHCS offline or service token assignment"
+regex = '''(?i)(?:ocm|rhcs)[_-]?(?:offline[_-]?)?token\s*[:=]\s*['"]?[A-Za-z0-9._\-]{32,}'''
+tags = ["token", "ocm", "rhcs", "critical"]
+
+[[rules]]
+id = "openshift-pull-secret"
+description = "OpenShift pull secret auth blob"
+regex = '''(?i)pull[_-]?secret.*auth.*[A-Za-z0-9+/]{30,}={0,2}'''
+tags = ["secret", "openshift", "high"]
+
+[[rules]]
+id = "kubeconfig-embedded"
+description = "Embedded kubeconfig with certificate data"
+regex = '''client-certificate-data:\s*[A-Za-z0-9+/]{30,}={0,2}'''
+tags = ["kubeconfig", "certificate", "critical"]
+
+[[rules]]
+id = "private-key-pem"
+description = "PEM-encoded private key"
+regex = '''-----BEGIN\s+(?:RSA\s+|EC\s+|OPENSSH\s+)?PRIVATE KEY-----'''
+tags = ["private-key", "pem", "critical"]
+
+# AWS / GitHub / generic API keys: use gitleaks defaults via [extend] useDefault

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,14 @@ repos:
         stages: [pre-commit]
         exclude: '^tests/tf-manifests/'
 
+  # Secrets detection (blocking). Pin to the commit for release tag GITLEAKS_VERSION
+  # in the Makefile (same release). Never SKIP=gitleaks or git commit --no-verify.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e  # frozen: v8.30.1
+    hooks:
+      - id: gitleaks
+        stages: [pre-commit]
+
   # Local repository-specific hooks
   - repo: local
     hooks:
@@ -48,7 +56,7 @@ repos:
       # Pre-push stage: comprehensive checks before push
       - id: pre-push-checks
         name: Run pre-push checks
-        description: Runs format-check, build, lint, docs-lint, coverage, and tests
+        description: Runs make pre-push-checks (see make run-checks -- pre-push --list-steps)
         entry: ./hack/pre-push-hook.sh
         language: script
         stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,8 @@ Reference sources:
 These are **review and design expectations**. They are not all enforced by automation; contributors and reviewers still apply them. Concrete commands and gates are in `CONTRIBUTING.md` (for example hooks, `make pre-push-checks`, subsystem registry, and the full test suite). Optional local coverage targets exist but are not merge gates.
 
 - Do not hard code secrets, API keys, tokens, kubeconfigs, AWS credentials, or customer identifiers in code, tests, docs, examples, or logs.
-- Do not document bypassing local hooks or verification gates.
+- Do not document bypassing local hooks or verification gates (`git commit --no-verify`, `SKIP=gitleaks`).
+- Do not bypass gitleaks; it runs in pre-commit and again in `make pre-push-checks` (Prow). Prefer fixing findings; allowlist only justified mocks in `.gitleaks.toml` (see `developer-docs/security.md` and `CONTRIBUTING.md`).
 - Do not ship silent breaking changes: call out impact and migration in the PR (see **Breaking Changes** in the PR template).
 - Do not edit generated provider docs by hand when the workflow requires regeneration; edit sources and regenerate per `CONTRIBUTING.md`.
 - Prefer existing patterns in this repo over new architecture or naming.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,13 +68,13 @@ This repository uses [pre-commit](https://pre-commit.com/) to manage git hooks. 
 
 YOU MUST LET THE LOCAL HOOKS RUN ON EVERY COMMIT AND PUSH. DO NOT BYPASS LOCAL HOOKS.
 
-The hooks are configured in `.pre-commit-config.yaml` and perform:
+The hooks are configured in `.pre-commit-config.yaml` (source of truth for hook IDs and stages):
 
-- `pre-commit`: formats staged Go files with `gci` + `gofmt` plus staged Terraform files under `examples/` and `tests/`, adds Apache 2.0 license headers to staged files missing them, and blocks the commit if files were rewritten so you can review and stage the updates
-- `commit-msg`: validates the commit message format (JIRA-123 | type(scope): message)
-- `pre-push`: runs the same steps as `make pre-push-checks` (format-check, build, generated-files check, lint, docs-lint, license-check, subsystem registry check, and `make test`)
+- `pre-commit` / `commit-msg` / `pre-push` stages — see that file for what each hook runs
+- `pre-push` runs the same checks as `make pre-push-checks` (`make run-checks -- pre-push --list-steps`)
 - `pre-push` runs against committed content and blocks when staged or unstaged tracked changes are present
-- check runs are fail-fast: execution stops at the first failing step
+- Checks are fail-fast: execution stops at the first failing step
+- Never bypass security hooks. `pre-push-checks` (and Prow `ci/prow/pre-push-checks`) re-runs Gitleaks so PRs remain gated.
 
 To manually run all hooks on all files:
 ```shell
@@ -150,7 +150,14 @@ make basic-checks      # convenience flow: starts with make fmt and may stop aft
 make pre-push-checks   # exact non-mutating verification used by the pre-push hook
 ```
 
-`make basic-checks` runs format, format-check, build, generated-files verification, lint, docs-lint (Vale), subsystem registry check, and unit/subsystem/utils tests.
+`make basic-checks` and `make pre-push-checks` run the verification steps defined in
+`hack/run-checks.sh` (wired from the Makefile). To list the current steps without running them:
+
+```shell
+make run-checks -- basic --list-steps
+make run-checks -- pre-push --list-steps
+```
+
 `make lint` uses the repo's pinned `golangci-lint` v2 configuration.
 `make docs-lint` runs the pinned [Vale](https://docs.vale.sh/) CLI with only the custom inclusive-language rules under `styles/InclusiveLanguage/` (general Vale styles and packages are not used). Building Vale uses `CGO_ENABLED=1` and requires a C compiler toolchain on the first install.
 
@@ -185,6 +192,20 @@ The ignore wrapper requires `jq` to parse govulncheck JSON output. Provider Prow
 `terraform-provider-rhcs-clients` image (`Dockerfile.clients`), which includes `jq` as a system
 package. For local runs, install `jq` if it is not already available. `yq` is optional; the
 wrapper falls back to awk when `yq` is not installed.
+
+`make verify-gitleaks` scans the working tree for hard-coded secrets using the pinned
+[gitleaks](https://github.com/gitleaks/gitleaks) release (`GITLEAKS_VERSION` in the Makefile).
+The pre-commit hook pins the matching commit SHA (`# frozen: <tag>` in
+`.pre-commit-config.yaml`). Configuration lives in `.gitleaks.toml` (extends upstream
+defaults plus provider-specific rules/allowlists).
+
+The scan is part of `make pre-push-checks` (and therefore Prow `ci/prow/pre-push-checks`) and
+also runs as a blocking pre-commit hook. Prefer fixing findings. For justified mocks/fixtures
+only, add a documented allowlist entry in `.gitleaks.toml` — never disable the scan. Renovate
+is configured to bump the Makefile release tag and the pre-commit SHA together.
+
+FYI: Terraform module repos already run gitleaks inside `make security-check` / Prow
+`ci/prow/security-check`; that is separate from this provider gate.
 
 ### 5. Manual testing and debugging using the locally compiled RHCS Provider binary
 Manual testing should be performed before opening a PR to ensure there isn't any regression behavior in the provider. You can find [here an example for that](https://github.com/terraform-redhat/terraform-rhcs-rosa/tree/main/examples/rosa-classic-public-with-unmanaged-oidc)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,11 @@ GOLANGCI_LINT_VERSION ?= v2.12.2
 VALE_VERSION ?= v3.15.2
 ADDLICENSE_VERSION ?= v1.2.0
 GOVULNCHECK_VERSION ?= v1.1.4
+# Release tag for the binary used by make verify-gitleaks. Pre-commit pins the
+# matching commit SHA in .pre-commit-config.yaml (# frozen: <same tag>).
+# renovate: datasource=github-releases depName=gitleaks/gitleaks
+GITLEAKS_VERSION ?= v8.30.1
+GITLEAKS_CONFIG ?= .gitleaks.toml
 
 GCI := $(LOCALBIN)/gci$(BIN_EXT)
 GINKGO := $(LOCALBIN)/ginkgo$(BIN_EXT)
@@ -50,6 +55,7 @@ GOLANGCI_LINT := $(LOCALBIN)/golangci-lint$(BIN_EXT)
 VALE := $(LOCALBIN)/vale$(BIN_EXT)
 ADDLICENSE := $(LOCALBIN)/addlicense$(BIN_EXT)
 GOVULNCHECK := $(LOCALBIN)/govulncheck$(BIN_EXT)
+GITLEAKS := $(LOCALBIN)/gitleaks$(BIN_EXT)
 
 LINT_OUTPUT_FLAGS ?=
 GO_SOURCE_TARGETS := main.go build internal logging provider subsystem tests tools
@@ -98,6 +104,13 @@ $(ADDLICENSE): | $(LOCALBIN)
 
 $(GOVULNCHECK): | $(LOCALBIN)
 	GOBIN="$(LOCALBIN_ABS)" go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+
+$(GITLEAKS): $(LOCALBIN)/.gitleaks-$(GITLEAKS_VERSION).stamp
+
+$(LOCALBIN)/.gitleaks-$(GITLEAKS_VERSION).stamp: | $(LOCALBIN)
+	bash hack/install-gitleaks.sh "$(GITLEAKS_VERSION)" "$(LOCALBIN_ABS)"
+	@rm -f "$(LOCALBIN)"/.gitleaks-*.stamp
+	@touch "$@"
 
 .PHONY: build
 build:
@@ -213,13 +226,23 @@ docs:
 
 .PHONY: tools
 tools:
-	@$(MAKE) --no-print-directory $(GCI) $(GINKGO) $(MOCKGEN) $(GOLANGCI_LINT) $(VALE) $(ADDLICENSE) $(GOVULNCHECK)
+	@$(MAKE) --no-print-directory $(GCI) $(GINKGO) $(MOCKGEN) $(GOLANGCI_LINT) $(VALE) $(ADDLICENSE) $(GOVULNCHECK) $(GITLEAKS)
 
 .PHONY: verify-govulncheck govulncheck
 verify-govulncheck: $(GOVULNCHECK) build
 	GOVULNCHECK_BIN="$(GOVULNCHECK)" ./hack/govulncheck.sh
 
 govulncheck: verify-govulncheck
+
+# Secret scan of the working tree (not full git history). Binary version is
+# GITLEAKS_VERSION; pre-commit uses the matching commit SHA. Included in
+# pre-push-checks so Prow enforces it.
+.PHONY: verify-gitleaks gitleaks
+verify-gitleaks: $(GITLEAKS)
+	@echo "== Gitleaks secret scan (config=$(GITLEAKS_CONFIG), version=$(GITLEAKS_VERSION)) =="
+	@"$(GITLEAKS)" detect --source . --config "$(GITLEAKS_CONFIG)" --no-banner --no-git --redact 100
+
+gitleaks: verify-gitleaks
 
 .PHONY: e2e-unit-test
 e2e-unit-test: $(GINKGO)

--- a/developer-docs/security.md
+++ b/developer-docs/security.md
@@ -17,6 +17,14 @@ WHEN editing provider code, tests, docs, examples, or logs:
 - MUST: Mark secret schema attributes **Sensitive**.
 - DEFAULT: Prefer placeholders and variables in examples and test fixtures.
 
+## Gitleaks (secret scanning)
+
+- MUST: Run `make verify-gitleaks` (also part of `make pre-push-checks` / Prow `ci/prow/pre-push-checks`) and the blocking pre-commit `gitleaks` hook.
+- MUST NOT: Bypass with `SKIP=gitleaks` or `git commit --no-verify`.
+- MUST: Prefer fixing findings. MAY allowlist only justified mocks/fixtures in `.gitleaks.toml` with a short comment — never disable the scan.
+- Config: `.gitleaks.toml`. Makefile pin: `GITLEAKS_VERSION` (release tag). Pre-commit pin: commit SHA with `# frozen: <same tag>`.
+- Commands and Renovate notes: [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
 ## Trivy (IaC misconfiguration)
 
 Repo config: root **`trivy.yaml`**. CodeRabbit may run Trivy when enabled in **`.coderabbit.yaml`**.

--- a/hack/install-gitleaks.sh
+++ b/hack/install-gitleaks.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install a pinned gitleaks release into a destination directory.
+# Usage: install-gitleaks.sh <version> <dest_dir>
+# Example: install-gitleaks.sh v8.30.1 ./bin
+
+set -euo pipefail
+
+version="${1:?version required (e.g. v8.30.1)}"
+dest_dir="${2:?destination directory required}"
+
+version_no_v="${version#v}"
+arch="$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')"
+os="$(uname | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+  mingw*|msys*|cygwin*) os="windows" ;;
+esac
+
+case "${os}_${arch}" in
+  linux_x64) platform_suffix="linux_x64" archive_ext="tar.gz" ;;
+  linux_arm64) platform_suffix="linux_arm64" archive_ext="tar.gz" ;;
+  darwin_x64) platform_suffix="darwin_x64" archive_ext="tar.gz" ;;
+  darwin_arm64) platform_suffix="darwin_arm64" archive_ext="tar.gz" ;;
+  windows_x64) platform_suffix="windows_x64" archive_ext="zip" ;;
+  *)
+    echo "Unsupported platform for gitleaks: ${os}_${arch}" >&2
+    exit 1
+    ;;
+esac
+
+sha256_verify() {
+  local archive_path=$1
+  local checksum_path=$2
+  local archive_name
+  archive_name=$(basename "$archive_path")
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$(dirname "$archive_path")" && grep -F " ${archive_name}" "$checksum_path" | sha256sum -c -)
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "$(dirname "$archive_path")" && grep -F " ${archive_name}" "$checksum_path" | shasum -a 256 -c -)
+  else
+    echo "sha256sum or shasum is required to verify ${archive_name}" >&2
+    return 1
+  fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$dest_dir"
+
+asset="gitleaks_${version_no_v}_${platform_suffix}.${archive_ext}"
+url="https://github.com/gitleaks/gitleaks/releases/download/${version}/${asset}"
+checksums_url="https://github.com/gitleaks/gitleaks/releases/download/${version}/gitleaks_${version_no_v}_checksums.txt"
+
+curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 -o "${tmp}/${asset}" "$url"
+curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 -o "${tmp}/checksums.txt" "$checksums_url"
+sha256_verify "${tmp}/${asset}" "${tmp}/checksums.txt"
+
+if [ "$archive_ext" = "zip" ]; then
+  unzip -o "${tmp}/${asset}" -d "$tmp"
+  dest_bin="${dest_dir}/gitleaks.exe"
+  install -m 0755 "${tmp}/gitleaks.exe" "$dest_bin"
+else
+  tar -xzf "${tmp}/${asset}" -C "$tmp" gitleaks
+  dest_bin="${dest_dir}/gitleaks"
+  install -m 0755 "${tmp}/gitleaks" "$dest_bin"
+fi
+
+echo "Installed gitleaks ${version} at ${dest_bin}"

--- a/hack/run-checks.sh
+++ b/hack/run-checks.sh
@@ -18,8 +18,8 @@ Usage:
   make run-checks -- <mode> [--dry-run] [--list-steps]
 
 Modes:
-  pre-push                 Steps: format-check, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests
-  basic                    Steps: format, format-check, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests
+  pre-push                 Steps: format-check, gitleaks, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests
+  basic                    Steps: format, format-check, gitleaks, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests
 
 Flags:
   --dry-run                Print planned steps and commands without executing
@@ -78,6 +78,7 @@ declare -a step_commands=()
 case "$mode" in
   pre-push)
     append_step "Format check (gci + gofmt + terraform fmt)" "make --no-print-directory fmt-check"
+    append_step "Gitleaks secret scan" "make --no-print-directory verify-gitleaks"
     append_step "Build" "make --no-print-directory build"
     append_step "Generated files check" "make --no-print-directory check-gen"
     append_step "Lint" "make --no-print-directory lint"
@@ -89,6 +90,7 @@ case "$mode" in
   basic)
     append_step "Format (gci + gofmt + terraform fmt)" "make --no-print-directory fmt"
     append_step "Format check (gci + gofmt + terraform fmt)" "make --no-print-directory fmt-check"
+    append_step "Gitleaks secret scan" "make --no-print-directory verify-gitleaks"
     append_step "Build" "make --no-print-directory build"
     append_step "Generated files check" "make --no-print-directory check-gen"
     append_step "Lint" "make --no-print-directory lint"

--- a/renovate.json
+++ b/renovate.json
@@ -95,8 +95,23 @@
       ],
       "datasourceTemplate": "go",
       "depNameTemplate": "github.com/errata-ai/vale/v3"
+    },
+    {
+      "description": "Update gitleaks in Makefile (pair with pre-commit SHA for the same release)",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Makefile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=github-releases depName=gitleaks/gitleaks\\s+GITLEAKS_VERSION \\?= (?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "gitleaks/gitleaks"
     }
   ],
+  "pre-commit": {
+    "enabled": true
+  },
   "pip_requirements": {
     "managerFilePatterns": [
       "/^build\\/ci-tf-e2e-requirements\\.txt$/"
@@ -106,6 +121,15 @@
     "ok-to-test"
   ],
   "packageRules": [
+    {
+      "description": "Bump Makefile GITLEAKS_VERSION and pre-commit gitleaks SHA for the same release",
+      "matchPackageNames": [
+        "gitleaks/gitleaks"
+      ],
+      "groupName": "gitleaks",
+      "groupSlug": "gitleaks",
+      "automerge": false
+    },
     {
       "description": "Enable automerge Konflux tekton task updates",
       "matchManagers": [

--- a/subsystem/classic/oidc_config_resource_test.go
+++ b/subsystem/classic/oidc_config_resource_test.go
@@ -46,7 +46,7 @@ const unManagedOidcConfig = `{
   "href": "/api/clusters_mgmt/v1/oidc_configs/23f6gk51qi5ng15mm095c90hhajbf7c5",
   "id": "23f6gk51qi5ng15mm095c90hhajbf7c5",
   "issuer_url": "https://oidc-f3y4.s3.us-east-1.amazonaws.com",
-  "secret_arn": "arn:aws:secretsmanager:us-east-1:765374464689:secret:rosa-private-key-oidc-f3y4-fEqj4c",
+  "secret_arn": "arn:aws:secretsmanager:us-east-1:123456789012:secret:rosa-private-key-oidc-f3y4-testexample",
   "managed": false,
   "reusable": true
 }`
@@ -78,7 +78,7 @@ const unManagedIssuerURL = "https://oidc-f3y4.s3.us-east-1.amazonaws.com"
 const managedIssuerURL = "https://d3gt1gce2zmg3d.cloudfront.net/23f6gk51qi5ng15mm095c90hhajbf7c5"
 const managedOidcEndpointURL = "d3gt1gce2zmg3d.cloudfront.net/23f6gk51qi5ng15mm095c90hhajbf7c5"
 const unManagedOidcEndpointURL = "oidc-f3y4.s3.us-east-1.amazonaws.com"
-const secretARN = "arn:aws:secretsmanager:us-east-1:765374464689:secret:rosa-private-key-oidc-f3y4-fEqj4c"
+const secretARN = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rosa-private-key-oidc-f3y4-testexample"
 const ID = "23f6gk51qi5ng15mm095c90hhajbf7c5"
 const thumbprint = "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 
@@ -180,7 +180,7 @@ var _ = Describe("OIDC config creation", func() {
 			Terraform.Source(`
 		resource "rhcs_rosa_oidc_config" "oidc_config" {
 			  managed = false
-			  secret_arn =  "arn:aws:secretsmanager:us-east-1:765374464689:secret:rosa-private-key-oidc-f3y4-fEqj4c"
+			  secret_arn =  "arn:aws:secretsmanager:us-east-1:123456789012:secret:rosa-private-key-oidc-f3y4-testexample"
 			  issuer_url = "https://oidc-f3y4.s3.us-east-1.amazonaws.com"
 			  installer_role_arn = "arn:aws:iam::765374464689:role/terr-account2-Installer-Role"
 		}
@@ -208,7 +208,7 @@ var _ = Describe("OIDC config creation", func() {
 			Terraform.Source(`
 		resource "rhcs_rosa_oidc_config" "oidc_config" {
 			  managed = false
-			  secret_arn =  "arn:aws:secretsmanager:us-east-1:765374464689:secret:rosa-private-key-oidc-f3y4-fEqj4c"
+			  secret_arn =  "arn:aws:secretsmanager:us-east-1:123456789012:secret:rosa-private-key-oidc-f3y4-testexample"
 			  issuer_url = "https://oidc-f3y4.s3.us-east-1.amazonaws.com"
 			  installer_role_arn = "arn:aws:iam::765374464689:role/terr-account2-Installer-Role"
 		}
@@ -241,7 +241,7 @@ var _ = Describe("OIDC config creation", func() {
 			Terraform.Source(`
 		resource "rhcs_rosa_oidc_config" "oidc_config" {
 			  managed = false
-			  secret_arn =  "arn:aws:secretsmanager:us-east-1:765374464689:secret:rosa-private-key-oidc-f3y4-fEqj4c"
+			  secret_arn =  "arn:aws:secretsmanager:us-east-1:123456789012:secret:rosa-private-key-oidc-f3y4-testexample"
 			  issuer_url = "https://oidc-f3y4.s3.us-east-1.amazonaws.com"
 			  installer_role_arn = "arn:aws:iam::765374464689:role/terr-account2-Installer-Role"
 		}
@@ -273,7 +273,7 @@ var _ = Describe("OIDC config creation", func() {
 			Terraform.Source(`
 		resource "rhcs_rosa_oidc_config" "oidc_config" {
 			  managed = false
-			  secret_arn =  "arn:aws:secretsmanager:us-east-1:765374464689:secret:rosa-private-key-oidc-f3y4-fEqj4c"
+			  secret_arn =  "arn:aws:secretsmanager:us-east-1:123456789012:secret:rosa-private-key-oidc-f3y4-testexample"
 			  issuer_url = "https://oidc-f3y4.s3.us-east-1.amazonaws.com"
 			  installer_role_arn = "arn:aws:iam::765374464689:role/terr-account2-Installer-Role"
 		}
@@ -322,7 +322,7 @@ var _ = Describe("OIDC config creation", func() {
 		Terraform.Source(`
 		resource "rhcs_rosa_oidc_config" "oidc_config" {
 			  managed = true
-			  secret_arn =  "arn:aws:secretsmanager:us-east-1:765374464689:secret:rosa-private-key-oidc-f3y4-fEqj4c"
+			  secret_arn =  "arn:aws:secretsmanager:us-east-1:123456789012:secret:rosa-private-key-oidc-f3y4-testexample"
 			  issuer_url = "https://oidc-f3y4.s3.us-east-1.amazonaws.com"
 			  installer_role_arn = "arn:aws:iam::765374464689:role/terr-account2-Installer-Role"
 		}


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary

- Add gitleaks (v8.30.1) as a blocking pre-commit hook and `make verify-gitleaks`, included in `pre-push-checks` so Prow `ci/prow/pre-push-checks` enforces it when local hooks are skipped.
- Pin Makefile to the release tag and pre-commit to the matching commit SHA (`# frozen: v8.30.1`); Renovate groups both.
- Keep CONTRIBUTING from inventoring check steps — point at `.pre-commit-config.yaml` and `make run-checks -- … --list-steps`.

## Detailed Description of the Issue

Pre-commit alone can be bypassed (`--no-verify`, missing hooks, UI commits). `openshift/release` has no shared `ci/prow/gitleaks` job. This provider already runs `make pre-push-checks` on PRs, so wiring gitleaks into that target is the enforcement path without a dedicated Prow job. Config is modeled on ocm-agent-operator (global stopwords/regexes kept for reference parity).

## Related Issues and PRs

- Jira: [ROSAENG-60034](https://redhat.atlassian.net/browse/ROSAENG-60034)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: ROSA-730; TF modules already run gitleaks under `security-check` (FYI only, not changed here)

## Type of Change

- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

No blocking gitleaks gate in pre-commit or `pre-push-checks`. Minimal `.gitleaks.toml` existed for CodeRabbit only. CONTRIBUTING listed check stages that drifted from `hack/run-checks.sh`.

## Behavior After This Change

- Blocking pre-commit gitleaks hook pinned to commit SHA for v8.30.1 (`# frozen: v8.30.1`).
- `make verify-gitleaks` installs the matching release tag and scans the working tree (`--no-git`); included in `pre-push-checks` / `basic`.
- Renovate can bump Makefile tag + pre-commit SHA together.
- Installer normalizes Git Bash/MSYS/Cygwin `uname` to `windows`.
- Subsystem OIDC mock secret ARN softened to avoid false positives.
- CONTRIBUTING / pre-push hook description point at config + `list-steps` instead of inventoring every check.
- Agent security notes updated in `AGENTS.md` and `developer-docs/security.md`.

## How to Test (Step-by-Step)

### Preconditions

- Network access to download the gitleaks release (first `make verify-gitleaks`).
- `pre-commit` installed for the hook dry-run.

### Test Steps

1. `make verify-gitleaks`
2. `pre-commit run gitleaks --all-files`
3. `make run-checks -- pre-push --list-steps` (and optionally `-- basic --list-steps`) — confirm gitleaks is listed
4. `make pre-push-checks`

### Expected Results

- Scans exit 0 with no leaks on the current tree.
- Pre-commit gitleaks hook passes.
- `list-steps` shows `Gitleaks secret scan` for basic and pre-push.
- Full `pre-push-checks` passes.

## Proof of the Fix

- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: `make verify-gitleaks`, `pre-commit run gitleaks --all-files`, and `make pre-push-checks` passed locally.
- Other artifacts: N/A

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below; see [breaking-change guidance](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/breaking-changes.md))

### Breaking Change Details / Migration Plan

N/A

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
- [x] Any risk, limitation, or follow-up work is documented.
- [ ] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
- [x] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

### Testing (check all that apply; use N/A when not relevant)

- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md) and [resources and data sources](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources-and-datasources.md)).
- [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CONTRIBUTING.md) and [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md)).
- [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [ ] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled pinned secret scanning via a blocking pre-commit hook and repeated checks during pre-push and CI validation.
  * Expanded secret-detection and allowlisting for test/fixture patterns and provider-specific secret formats.
  * Added developer commands to install and run the scanner, including a dedicated `verify-gitleaks` step.
* **Documentation**
  * Updated security and contributing guidance to require scanning, discourage bypasses, and describe proper allowlisting.
* **Bug Fixes**
  * Updated OIDC-related test data for a revised secret ARN.
* **Chores**
  * Coordinated version pinning across tooling and hooks for consistent scanner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->