### PR TITLE
OCM-00000 | chore: Update Vale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ RUN_CHECKS_SCRIPT := ./hack/run-checks.sh
 
 GCI_VERSION ?= v0.14.0
 GOLANGCI_LINT_VERSION ?= v2.12.2
-VALE_VERSION ?= v3.15.1
+VALE_VERSION ?= v3.15.2
 ADDLICENSE_VERSION ?= v1.2.0
 GOVULNCHECK_VERSION ?= v1.1.4
 
@@ -73,6 +73,8 @@ ldflags:=\
 
 $(LOCALBIN):
 	mkdir -p "$(LOCALBIN)"
+
+.PHONY: $(GCI) $(GINKGO) $(MOCKGEN) $(GOLANGCI_LINT) $(VALE) $(ADDLICENSE) $(GOVULNCHECK)
 
 $(GCI): | $(LOCALBIN)
 	GOBIN="$(LOCALBIN_ABS)" go install github.com/daixiang0/gci@$(GCI_VERSION)

--- a/developer-docs/architecture.md
+++ b/developer-docs/architecture.md
@@ -3,7 +3,7 @@
 - MUST: Implement only capabilities available in **ROSA** (via OCM APIs used by this provider).
 - MUST NOT: Add provider support for features that are not available in ROSA.
 - MUST: Confirm whether a change applies to **Classic**, **HCP**, or both before implementing.
-- MUST: Keep Classic and HCP implementations separated (`provider/.../classic/` vs `provider/.../hcp/` and matching `subsystem/` trees).
+- MUST: Keep Classic and HCP implementations separated (`provider/.../classic/` versus `provider/.../hcp/` and matching `subsystem/` trees).
 - MUST: Call out parity or intentional divergence in the PR when a change touches both Classic and HCP.
 - MUST: Prefer existing package layouts and patterns in this repo over new architecture or naming.
 DEFAULT: When unsure whether support is HCP, Classic, or both — stop and verify before implementation.


### PR DESCRIPTION
<!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when the option is not applicable to your case.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary

  Bump Vale to v3.15.2 and mark all tool-install Makefile targets as `.PHONY` so version changes take effect without manually deleting cached binaries.

  ## Detailed Description of the Issue

  Tool-install targets in the Makefile (`$(VALE)`, `$(GCI)`, etc.) used order-only prerequisites, so Make skipped the `go install` recipe when the binary already existed — even after a version bump. Adding `.PHONY` ensures `go install` always runs; Go's
  build cache makes this near-instant when the version is unchanged.

  ## Related Issues and PRs
  - Jira: N/A
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change
  <!-- Check the primary type this PR represents -->
  - [ ] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [x] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  `make docs-lint` (and similar targets) would skip `go install` if any version of the tool binary already existed in `localbin/`, ignoring `VALE_VERSION` changes.

  ## Behavior After This Change

  `make docs-lint` always runs `go install github.com/errata-ai/vale/v3/cmd/vale@$(VALE_VERSION)`, installing the pinned version. Go's module cache keeps this fast when the version is unchanged. Same for all other tool targets (`GCI`, `GINKGO`, `MOCKGEN`,
  `GOLANGCI_LINT`, `ADDLICENSE`, `GOVULNCHECK`).

  ## How to Test (Step-by-Step)
  ### Preconditions

  Go toolchain installed; existing `localbin/vale` binary at v3.15.1 (or any prior version).

  ### Test Steps
  1. Run `make docs-lint` (or `make vale`).
  2. Check `localbin/vale --version` — should report v3.15.2.
  3. Run `make docs-lint` again — should complete quickly (Go cache hit).

  ### Expected Results

  Vale binary is updated to v3.15.2 on first run; subsequent runs are fast.

  ## Proof of the Fix

  - Screenshots: N/A
  - Videos: N/A
  - Logs/CLI output: N/A
  - Other artifacts: N/A

  ## Breaking Changes
  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below; see [breaking-change guidance](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/breaking-changes.md))

  ### Breaking Change Details / Migration Plan
  <!-- Required only when breaking changes are introduced -->

  ## Developer Verification Checklist
  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [ ] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] `make pre-push-checks` passes.
  - [ ] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
  - [x] Any risk, limitation, or follow-up work is documented.
  - [ ] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
  - [ ] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

  ### Testing (check all that apply; use N/A when not relevant)
  - [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
  - [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md) and
  [resources and data sources](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources-and-datasources.md)).
  - [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
  - [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CONTRIBUTING.md) and
  [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md)).
  - [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
  - [ ] `make check-subsystem-registry` passes.
  - [ ] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Vale tooling version to v3.15.2.
  * Improved reliability when installing development tools.

* **Documentation**
  * Clarified the architecture requirement to keep Classic and HCP implementations separate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->