### PR TITLE
OCM-00000 | ci: remove go-password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
-	github.com/sethvargo/go-password v0.3.1
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,6 @@ github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/sethvargo/go-password v0.3.1 h1:WqrLTjo7X6AcVYfC6R7GtSyuUQR9hGyAj/f1PYQZCJU=
-github.com/sethvargo/go-password v0.3.1/go.mod h1:rXofC1zT54N7R8K/h1WDUdkf9BOx5OptoxrMBcrXzvs=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	"github.com/sethvargo/go-password/password"
 
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/config"
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/constants"
@@ -461,11 +460,34 @@ func GenerateRandomStringWithSymbols(length int) string {
 }
 
 func GenerateRandomPassword(length int) string {
-	randomPassword, err := password.Generate(length, 1, 1, false, true)
-	if err != nil {
-		panic(err)
+	const (
+		lowercase = "abcdefghijklmnopqrstuvwxyz"
+		uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		digits    = "0123456789"
+		symbols   = "!@#$%^&*()_+-=[]{}|;:,.<>?"
+		all       = lowercase + uppercase + digits + symbols
+	)
+
+	if length < 4 {
+		length = 4
 	}
-	return randomPassword
+
+	result := make([]byte, length)
+	result[0] = lowercase[RandomInt(len(lowercase))]
+	result[1] = uppercase[RandomInt(len(uppercase))]
+	result[2] = digits[RandomInt(len(digits))]
+	result[3] = symbols[RandomInt(len(symbols))]
+
+	for i := 4; i < length; i++ {
+		result[i] = all[RandomInt(len(all))]
+	}
+
+	for i := length - 1; i > 0; i-- {
+		j := RandomInt(i + 1)
+		result[i], result[j] = result[j], result[i]
+	}
+
+	return string(result)
 }
 
 // Generate random string


### PR DESCRIPTION
<!--
  Please provide enough context so reviewers can understand:
  1) the problem,
  2) why this change is needed,
  3) what changed,
  4) how you validated it.

  Use N/A when the option is not applicable to your case.

  Commit format requirement:
  [JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>
  TYPE must be one of:
  feat, fix, docs, style, refactor, test, chore, build, ci, perf
  For details, see: ./CONTRIBUTING.md
  -->

  ## PR Summary

  Remove the `sethvargo/go-password` dependency by replacing `GenerateRandomPassword` with a self-contained implementation using `crypto/rand`.

  ## Detailed Description of the Issue

  The `github.com/sethvargo/go-password` module was an external dependency used by a single function (`GenerateRandomPassword` in `tests/utils/helper/helper.go`). The existing `RandomInt` helper in the same file already wraps `crypto/rand`, so the
  dependency is unnecessary.

  The replacement guarantees at least one lowercase letter, one uppercase letter, one digit, and one symbol per generated password, then Fisher-Yates shuffles the result. It enforces a minimum length of 4 to satisfy the character-class guarantees. All
  callers pass lengths ≥ 3 (clamped to 4) or ≥ 13, so behavior is preserved.

  ## Related Issues and PRs
  - Jira: N/A
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change
  <!-- Check the primary type this PR represents -->
  - [ ] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [x] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  `GenerateRandomPassword` delegated to `github.com/sethvargo/go-password/password.Generate`, producing a password with at least 1 digit and 1 symbol.

  ## Behavior After This Change

  `GenerateRandomPassword` uses `crypto/rand` (via the existing `RandomInt` helper) to produce a password with at least one character from each class (lowercase, uppercase, digit, symbol), shuffled with Fisher-Yates. The `go-password` dependency is removed
  from `go.mod` and `go.sum`.

  ## How to Test (Step-by-Step)
  ### Preconditions

  Go toolchain installed.

  ### Test Steps
  1. `go build ./...` — verify compilation.
  2. `go mod tidy` — verify no missing or unused dependencies.
  3. `grep -r sethvargo go.mod go.sum` — verify dependency is fully removed.

  ### Expected Results

  Build succeeds, `go mod tidy` produces no changes, and `sethvargo` does not appear in module files.

  ## Proof of the Fix
  - Screenshots: N/A
  - Videos: N/A
  - Logs/CLI output: `go build ./...` succeeds; `grep -r sethvargo go.mod go.sum` returns no matches.
  - Other artifacts: N/A

  ## Breaking Changes
  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below; see [breaking-change guidance](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/breaking-changes.md))

  ### Breaking Change Details / Migration Plan

  ## Developer Verification Checklist
  - [ ] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [ ] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] `make pre-push-checks` passes.
  - [ ] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
  - [x] Any risk, limitation, or follow-up work is documented.
  - [ ] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
  - [ ] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

  ### Testing (check all that apply; use N/A when not relevant)
  - [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
  - [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md) and
  [resources and data sources](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources-and-datasources.md)).
  - [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
  - [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CONTRIBUTING.md) and
  [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md)).
  - [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
  - [ ] `make check-subsystem-registry` passes.
  - [ ] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved random password generation to ensure passwords include lowercase letters, uppercase letters, numbers, and symbols.
  * Ensured generated passwords meet a minimum length of four characters and are randomized for improved variety.

* **Chores**
  * Removed an unused password-generation dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->