### PR TITLE
ROSAENG-62628 | rosa-sts-shared-vpc-f3 | fix(e2e): isolate dnsdomain day2 test on temp workspace

### DIFF
--- a/tests/e2e/dns_test.go
+++ b/tests/e2e/dns_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/ci"
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/exec"
+	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/helper"
+	. "github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/log"
 	"github.com/terraform-redhat/terraform-provider-rhcs/tests/utils/profilehandler"
 )
 
@@ -22,7 +24,13 @@ var _ = Describe("DNS Domain", func() {
 		profileHandler, err = profilehandler.NewProfileHandlerFromYamlFile()
 		Expect(err).ToNot(HaveOccurred())
 
-		dnsService, err = profileHandler.Services().GetDnsDomainService()
+		// Use a dedicated temp workspace so shared-vpc day1 PrepareRoute53 DNS
+		// (profile workspace) is not destroyed while the cluster still exists.
+		// Same isolation pattern as id:67574 in account_roles_test.go.
+		tempWorkspace := helper.GenerateRandomName("ocp-67570"+profileHandler.Profile().GetName(), 2)
+		Logger.Infof("Using temp workspace '%s' for creating resources", tempWorkspace)
+
+		dnsService, err = exec.NewDnsDomainService(tempWorkspace, profileHandler.Profile().GetClusterType())
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -36,14 +44,8 @@ var _ = Describe("DNS Domain", func() {
 				Skip("Test can run only on Classic cluster")
 			}
 
-			By("Retrieve DNS creation args")
-			dnsArgs, err := dnsService.ReadTFVars()
-			if err != nil {
-				dnsArgs = &exec.DnsDomainArgs{}
-			}
-
 			By("Create/Apply dns-domain resource by terraform")
-			_, err = dnsService.Apply(dnsArgs)
+			_, err := dnsService.Apply(&exec.DnsDomainArgs{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Destroy dns-domain resource by terraform")


### PR DESCRIPTION
## PR Summary

Fix chronic `rosa-sts-shared-vpc-f3` failure for e2e id:67570 by isolating DNS domain create/destroy on a dedicated temp Terraform workspace (same pattern as id:67574).

## Detailed Description of the Issue

On shared-vpc profiles, day1 `PrepareRoute53` writes the cluster base DNS domain into the profile Terraform workspace. Day2 test id:67570 reused that workspace via `GetDnsDomainService()` / `ReadTFVars()` and attempted to destroy the cluster-associated DNS domain while the cluster was still running, causing:

```
CLUSTERS-MGMT-400: Cannot delete DNS '…' as it's associated with an existing cluster
```

Prow job `periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-sts-shared-vpc-f3` was chronic red (0/8 SUCCESS) with this signature when setup succeeded.

## Related Issues and PRs
- Jira: [ROSAENG-62628](https://redhat.atlassian.net/browse/ROSAENG-62628)
- Failing job: `periodic-ci-terraform-redhat-terraform-provider-rhcs-main-e2e-rosa-sts-shared-vpc-f3`

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

id:67570 used the profile DNS workspace. On shared-vpc, it destroyed the cluster base DNS domain during the test phase and failed with OCM 400.

## Behavior After This Change

id:67570 creates and destroys a **new** DNS domain in a dedicated temp workspace (`ocp-67570…`), matching the isolation pattern used by id:67574 in `account_roles_test.go`. Coverage intent (create + destroy dnsdomain) is unchanged.

## How to Test (Step-by-Step)
### Preconditions
- Stage OCM/AWS credentials for shared-vpc e2e profile `rosa-sts-sv`, or wait for periodic `rosa-sts-shared-vpc-f3`.

### Test Steps
1. Run e2e with label filter including id:67570 on shared-vpc profile, or trigger periodic `rosa-sts-shared-vpc-f3`.
2. Confirm id:67570 passes Apply and Destroy without OCM 400 association errors.

### Expected Results
- id:67570 passes; no attempt to delete the cluster-associated base DNS domain during the test.

## Proof of the Fix
- Logs/CLI output: Prow triage on builds `2079845595886915584`, `2085643698237870080` showed consistent id:67570 failure; fix addresses root cause (workspace collision).
- Local: `go test -c ./tests/e2e/` compiles.

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change

### Breaking Change Details / Migration Plan
N/A

## Affected specs

| ID | It title | How this PR affects it |
| --- | --- | --- |
| 67570 | can create and destroy dnsdomain | **Direct** — uses temp workspace + empty `DnsDomainArgs` instead of profile workspace / `ReadTFVars` |

Periodic filter `(day1-post,day2)&&!Exclude` matches many specs; only id:67570 is directly changed. Remaining specs in the job are unchanged.

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] `make pre-push-checks` passes (commit/push used `SKIP=pre-push-checks` per author request; CI will run checks).
- [ ] Documentation was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.
- [x] **Classic and HCP:** Classic-only test; HCP skip unchanged. Shared-vpc is the profile where the bug surfaced.
- [x] **Auth / secrets / sensitive:** N/A

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [ ] **New or changed resource / data source**
- [ ] **New or changed validation, plan modifiers, or helpers**
- [ ] **Schema / config validation**
- [ ] **Validators / helpers**
- [ ] `make check-subsystem-registry` passes.
- [ ] I manually tested the change when behavior is user-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end DNS test setup and isolation.
  * Simplified DNS resource configuration during testing.
  * Added clearer test logging and helper support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->