### PR TITLE
 rosa-hcp-private-f3 | rosa-hcp-advanced-f3 | ROSAENG-64673 | test: fix 72520

### DIFF
--- a/tests/e2e/hcp_ingress_test.go
+++ b/tests/e2e/hcp_ingress_test.go
@@ -132,7 +132,7 @@ var _ = Describe("HCP Ingress", ci.FeatureIngress, ci.Day2, func() {
 		ingressArgs.Cluster = new("wrong")
 		_, err = ingressService.Apply(ingressArgs)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("Cluster 'wrong' not"))
+		Expect(err.Error()).To(ContainSubstring("cannot be changed"))
 
 		By("Try to edit with empty listening_method")
 		ingressArgs = getOriginalIngressArgs()


### PR DESCRIPTION
## PR Summary
  Fix test assertion in HCP ingress test to expect the correct error message when attempting to edit an ingress with an invalid cluster reference.

  ## Detailed Description of the Issue
  Test case was asserting the incorrect error message when attempting to change an ingress cluster reference. The error message has changed and the test expectation needed to be updated to match the actual OCM API response.

## Why this assertion changed

PR #1187 (ROSAENG-9174, merged Jul 28) refactored the `Update` function in
`provider/defaultingress/hcp/resource.go` to wire `ValidateStateAndPlanEquals`
directly to `resp.Diagnostics` instead of a disconnected local `diags` variable.

This fixed the immutable-attribute validation: the provider now catches invalid
`cluster` attribute changes **locally** before the request reaches the OCM API.

As a result, the error message changed:

- **Before:** API-level error → `Cluster 'wrong' not found`
- **After:** Provider-level error → `Attribute cluster, cannot be changed from "..." to "wrong"`

Test `[id:72520]` (`HCP Ingress validate edit`) expected the old API error
substring `Cluster 'wrong' not`, which no longer appears. This updates the
assertion to match the current (correct) provider behavior.

**Impact:** Both `rosa-hcp-advanced-f3` (8 consecutive failures since Jul 30)
and `rosa-hcp-private-f3` (7 consecutive failures since Aug 1) are blocked by
this single assertion mismatch.

  ## Related Issues and PRs
  - Jira: [ROSAENG-64673](https://jira.redhat.com/browse/ROSAENG-64673)
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change
  - [ ] feat - adds a new user-facing capability.
  - [x] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [x] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior
  Test expected error message: `"Cluster 'wrong' not"`

  ## Behavior After This Change
  Test now expects error message: `"cannot be changed"` which reflects the actual OCM API response.

  ## How to Test (Step-by-Step)
  ### Preconditions
  HCP cluster with ingress configured.

  ### Test Steps
  1. Run the HCP ingress test suite: `make subsystem-test-hcp SUBSYSTEMS=ingress`
  2. Verify the test passes with the updated assertion.

  ### Expected Results
  Test passes without failure.

  ## Proof of the Fix
  - Test updated and passing in subsystem test suite.

  ## Breaking Changes
  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below; see [breaking-change guidance](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/breaking-changes.md))

  ## Developer Verification Checklist
  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] `make pre-push-checks` passes.
  - [x] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
  - [x] Any risk, limitation, or follow-up work is documented.
  - [x] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
  - [x] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

  ### Testing (check all that apply; use N/A when not relevant)
  - [ ] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
  - [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md), [resource 
  overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources/resource-overview.md), and [data source overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/datasources/datasource-overview.md)).
  - [x] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
  - [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CONTRIBUTING.md) and
  [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md)).
  - [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
  - [ ] `make check-subsystem-registry` passes.
  - [ ] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated HCP ingress validation coverage to accept the broader error message shown when an invalid cluster ID cannot be changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->