### PR TITLE
ROSAENG-00000 | Add pre-push-checks-fast

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,10 +53,11 @@ repos:
         language: script
         stages: [commit-msg]
 
-      # Pre-push stage: comprehensive checks before push
+      # Pre-push stage: fast checks + unit tests only (no subsystem tests).
+      # Full suite (make pre-push-checks) runs in Prow CI.
       - id: pre-push-checks
-        name: Run pre-push checks
-        description: Runs make pre-push-checks (see make run-checks -- pre-push --list-steps)
+        name: Run pre-push checks (fast)
+        description: Runs make pre-push-checks-fast (see make run-checks -- pre-push-fast --list-steps)
         entry: ./hack/pre-push-hook.sh
         language: script
         stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,10 @@ pre-commit-checks:
 pre-push-checks:
 	@$(RUN_CHECKS_SCRIPT) pre-push
 
+.PHONY: pre-push-checks-fast
+pre-push-checks-fast:
+	@$(RUN_CHECKS_SCRIPT) pre-push-fast
+
 .PHONY: run-checks
 run-checks:
 	@$(RUN_CHECKS_SCRIPT) $(filter-out $@,$(MAKECMDGOALS))
@@ -372,7 +376,7 @@ run-checks:
 commits/check:
 	@./hack/commit-msg-verify.sh
 
-RUN_CHECKS_PASSTHROUGH_ARGS := basic pre-push --dry-run --list-steps -h --help
+RUN_CHECKS_PASSTHROUGH_ARGS := basic pre-push pre-push-fast --dry-run --list-steps -h --help
 .PHONY: $(RUN_CHECKS_PASSTHROUGH_ARGS)
 $(RUN_CHECKS_PASSTHROUGH_ARGS):
 	@:

--- a/hack/pre-push-hook.sh
+++ b/hack/pre-push-hook.sh
@@ -19,7 +19,7 @@ if ! git diff --cached --quiet --exit-code; then
 fi
 
 set +e
-make --no-print-directory pre-push-checks
+make --no-print-directory pre-push-checks-fast
 checks_exit_code=$?
 set -e
 

--- a/hack/run-checks.sh
+++ b/hack/run-checks.sh
@@ -18,8 +18,9 @@ Usage:
   make run-checks -- <mode> [--dry-run] [--list-steps]
 
 Modes:
-  pre-push                 Steps: format-check, gitleaks, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests
-  basic                    Steps: format, format-check, gitleaks, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests
+  pre-push                 Steps: format-check, gitleaks, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests (unit + subsystem + e2e-unit)
+  pre-push-fast            Steps: same as pre-push but unit tests only; used by git pre-push hook
+  basic                    Steps: format, format-check, gitleaks, build, generated-files, lint, docs-lint, license-check, subsystem-registry, tests (unit + subsystem + e2e-unit)
 
 Flags:
   --dry-run                Print planned steps and commands without executing
@@ -40,7 +41,7 @@ strip_ansi() {
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    pre-push|basic)
+    pre-push|pre-push-fast|basic)
       if [ -n "$mode" ] && [ "$mode" != "$1" ]; then
         echo "Only one mode can be specified"
         print_usage
@@ -86,6 +87,17 @@ case "$mode" in
     append_step "License header check" "make --no-print-directory license-check"
     append_step "Subsystem registry" "make --no-print-directory check-subsystem-registry"
     append_step "Unit and subsystem tests" "make --no-print-directory test"
+    ;;
+  pre-push-fast)
+    append_step "Format check (gci + gofmt + terraform fmt)" "make --no-print-directory fmt-check"
+    append_step "Gitleaks secret scan" "make --no-print-directory verify-gitleaks"
+    append_step "Build" "make --no-print-directory build"
+    append_step "Generated files check" "make --no-print-directory check-gen"
+    append_step "Lint" "make --no-print-directory lint"
+    append_step "Documentation lint (Vale)" "make --no-print-directory docs-lint"
+    append_step "License header check" "make --no-print-directory license-check"
+    append_step "Subsystem registry" "make --no-print-directory check-subsystem-registry"
+    append_step "Unit tests" "make --no-print-directory unit-test e2e-unit-test"
     ;;
   basic)
     append_step "Format (gci + gofmt + terraform fmt)" "make --no-print-directory fmt"


### PR DESCRIPTION
## PR Summary

  Add a fast pre-push check target for local development that runs format, gitleaks, build, lint, and unit tests (excluding subsystem and e2e-unit tests) to provide quicker feedback before
  push, while the full suite (including subsystem and e2e-unit tests) runs in Prow CI.

Why? git push was taking so long that connection with GitHub was dropped during the command running. The check will still be used by Prow and available locally, this change only affect the pre-commit config.

  ## Detailed Description of the Issue

  Local pre-push validation includes subsystem and e2e-unit tests, which can be slow and delay developer feedback. The full test suite is more appropriately run in CI where it can leverage
  parallelization and fail fast in the pipeline rather than blocking local development.

  ## Related Issues and PRs

  - Jira: N/A
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change

  - [ ] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [x] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  The pre-push hook ran `make pre-push-checks`, which included unit tests, subsystem tests, and e2e-unit tests, causing slow feedback loops during local development.

  ## Behavior After This Change

  The pre-push hook now runs `make pre-push-checks-fast`, which includes format check, gitleaks, build, generated files check, lint, docs lint, license check, subsystem registry check, and
  unit tests only (excluding subsystem and e2e-unit tests). Developers receive faster validation feedback, while the full test suite is deferred to CI.

  ## How to Test (Step-by-Step)

  ### Preconditions

  Install pre-commit hooks with `make install-hooks`.

  ### Test Steps

  1. Run `make pre-push-checks-fast` locally and verify it completes in reasonable time without subsystem or e2e-unit tests.
  2. Run `make run-checks -- pre-push-fast --list-steps` to confirm the step sequence.
  3. Create a test commit and run `git push` to verify the pre-push hook invokes the fast checks.

  ### Expected Results

  The fast checks run successfully and complete faster than the full pre-push suite. The hook output shows only unit-test-related steps, not subsystem or e2e-unit tests.

  ## Proof of the Fix

  - Logs/CLI output: `make pre-push-checks-fast` completes without subsystem or e2e-unit tests.

  ## Breaking Changes

  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below; see [breaking-change 
  guidance](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/breaking-changes.md))

  ## Developer Verification Checklist

  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] `make pre-push-checks` passes.
  - [x] Documentation was added/updated where appropriate (see [docs and 
  examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
  - [x] Any risk, limitation, or follow-up work is documented.
  - [x] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see
  [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
  - [x] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow
  [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

  ### Testing (check all that apply; use N/A when not relevant)

  - [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
  - [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see
  [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md), [resource 
  overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources/resource-overview.md), and [data source 
  overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/datasources/datasource-overview.md)).
  - [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same
  cases unless a wiring smoke test is needed).
  - [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see
  [CONTRIBUTING.md](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CONTRIBUTING.md) and
  [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md)).
  - [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
  - [x] `make check-subsystem-registry` passes.
  - [x] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a faster pre-push validation mode for shared checks, unit tests, and end-to-end unit tests.
  * Full test suites continue running in continuous integration.

* **Documentation**
  * Updated check-mode descriptions to clarify which validations run locally and which run in continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->