### PR TITLE
ROSAENG-62664 | docs: add service account authentication documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,9 +74,13 @@ To use the Red Hat Cloud Services provider inside your Terraform configuration y
 
   You must complete some AWS account and local configurations to create and managed ROSA clusters.
 
-* An offline [OCM token](https://console.redhat.com/openshift/token/rosa)
+* **(Recommended)** A [Red Hat Hybrid Cloud Console service account](https://console.redhat.com/iam/service-accounts) with a Client ID and Client Secret
 
-  This token is generated through the Red Hat Hybrid Cloud Console. The purpose of this token is to verify that you have access and permission to create and upgrade clusters. This token is unique to your account and should not be shared.
+  Service accounts are the recommended authentication method for the RHCS provider. Create a service account in the Red Hat Hybrid Cloud Console, copy the generated Client ID and Client Secret (the secret is only shown once), then add the service account to a User Access group with appropriate roles (either **OCM Organization Administrator** for full access, or the individual roles: **OCM Cluster Provisioner**, **OCM Cluster Editor**, **OCM Machine Pool Editor**, and **OCM IdP Editor**). For detailed instructions, see the Red Hat documentation on [Creating and Managing Service Accounts](https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/creating_and_managing_service_accounts/index).
+
+* **(Legacy)** An offline [OCM token](https://console.redhat.com/openshift/token/rosa)
+
+  This token is generated through the Red Hat Hybrid Cloud Console. The purpose of this token is to verify that you have access and permission to create and upgrade clusters. This token is unique to your account and should not be shared. Service accounts are replacing offline tokens as the default authentication method.
 
 * [GoLang version 1.26 or newer](https://go.dev/doc/install)
 
@@ -164,20 +168,46 @@ To use the Red Hat Cloud Services provider inside your Terraform configuration y
 
 ## Authentication and configuration
 
-The login to your Red Hat account is done by private offline access token which can be generate at https://console.redhat.com/openshift/token/rosa
-
 Configuration for the RHCS Provider can be derived from several sources, which are applied in the following order:
 
 1. Parameters in the provider configuration
-2. Environment Variables
-
-## Provider Configuration
+2. Environment variables
 
 !> **Warning:** Hard-coded credentials are not recommended in any Terraform configuration and risks secret leakage should this file ever be committed to a public version control system.
 
-The Red Hat Cloud Services token can be provided by adding a `token` to the `rhcs` provider block.
+### Service Account Authentication (Recommended)
 
-Usage:
+Service accounts provide stable credentials that do not expire, making them ideal for automation workflows. The provider uses the Client ID and Client Secret to obtain short-lived OAuth access tokens (which expire after 15 minutes) automatically.
+
+To create a service account, assign the required roles (either **OCM Organization Administrator** for full access, or the individual roles: **OCM Cluster Provisioner**, **OCM Cluster Editor**, **OCM Machine Pool Editor**, and **OCM IdP Editor**), and add it to a User Access group. For more information, see the Red Hat documentation on [Creating and Managing Service Accounts](https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/creating_and_managing_service_accounts/index).
+
+Once you have a Client ID and Client Secret, set them as environment variables:
+
+```shell
+export RHCS_CLIENT_ID="<your-client-id>"
+export RHCS_CLIENT_SECRET="<your-client-secret>"
+```
+
+```terraform
+provider "rhcs" {}
+```
+
+You can also pass credentials explicitly via the provider block:
+
+```terraform
+provider "rhcs" {
+  client_id     = var.rhcs_client_id
+  client_secret = var.rhcs_client_secret
+}
+```
+
+### Offline Access Token Authentication (Legacy)
+
+~> **Note:** Offline access tokens are a legacy authentication method. Service account authentication (above) is the recommended approach and will become the default.
+
+The offline access token can be generated at https://console.redhat.com/openshift/token/rosa
+
+The token can be provided by adding a `token` to the `rhcs` provider block:
 
 ```terraform
 provider "rhcs" {
@@ -185,11 +215,7 @@ provider "rhcs" {
 }
 ```
 
-### Environment Variables
-
-The Red Hat Cloud Services token can be provided by using the `RHCS_TOKEN` environment variables.
-
-For example:
+Or by using the `RHCS_TOKEN` environment variable:
 
 ```terraform
 provider "rhcs" {}

--- a/examples/example_3.tf
+++ b/examples/example_3.tf
@@ -1,0 +1,4 @@
+provider "rhcs" {
+  client_id     = var.rhcs_client_id
+  client_secret = var.rhcs_client_secret
+}

--- a/examples/import_2.sh
+++ b/examples/import_2.sh
@@ -1,0 +1,2 @@
+export RHCS_CLIENT_ID="<your-client-id>"
+export RHCS_CLIENT_SECRET="<your-client-secret>"

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -78,9 +78,13 @@ To use the Red Hat Cloud Services provider inside your Terraform configuration y
 
   You must complete some AWS account and local configurations to create and managed ROSA clusters.
 
-* An offline [OCM token](https://console.redhat.com/openshift/token/rosa)
+* **(Recommended)** A [Red Hat Hybrid Cloud Console service account](https://console.redhat.com/iam/service-accounts) with a Client ID and Client Secret
 
-  This token is generated through the Red Hat Hybrid Cloud Console. The purpose of this token is to verify that you have access and permission to create and upgrade clusters. This token is unique to your account and should not be shared.
+  Service accounts are the recommended authentication method for the RHCS provider. Create a service account in the Red Hat Hybrid Cloud Console, copy the generated Client ID and Client Secret (the secret is only shown once), then add the service account to a User Access group with appropriate roles (either **OCM Organization Administrator** for full access, or the individual roles: **OCM Cluster Provisioner**, **OCM Cluster Editor**, **OCM Machine Pool Editor**, and **OCM IdP Editor**). For detailed instructions, see the Red Hat documentation on [Creating and Managing Service Accounts](https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/creating_and_managing_service_accounts/index).
+
+* **(Legacy)** An offline [OCM token](https://console.redhat.com/openshift/token/rosa)
+
+  This token is generated through the Red Hat Hybrid Cloud Console. The purpose of this token is to verify that you have access and permission to create and upgrade clusters. This token is unique to your account and should not be shared. Service accounts are replacing offline tokens as the default authentication method.
 
 * [GoLang version 1.26 or newer](https://go.dev/doc/install)
 
@@ -168,28 +172,40 @@ To use the Red Hat Cloud Services provider inside your Terraform configuration y
 
 ## Authentication and configuration
 
-The login to your Red Hat account is done by private offline access token which can be generate at https://console.redhat.com/openshift/token/rosa
-
 Configuration for the RHCS Provider can be derived from several sources, which are applied in the following order:
 
 1. Parameters in the provider configuration
-2. Environment Variables
-
-## Provider Configuration
+2. Environment variables
 
 !> **Warning:** Hard-coded credentials are not recommended in any Terraform configuration and risks secret leakage should this file ever be committed to a public version control system.
 
-The Red Hat Cloud Services token can be provided by adding a `token` to the `rhcs` provider block.
+### Service Account Authentication (Recommended)
 
-Usage:
+Service accounts provide stable credentials that do not expire, making them ideal for automation workflows. The provider uses the Client ID and Client Secret to obtain short-lived OAuth access tokens (which expire after 15 minutes) automatically.
+
+To create a service account, assign the required roles (either **OCM Organization Administrator** for full access, or the individual roles: **OCM Cluster Provisioner**, **OCM Cluster Editor**, **OCM Machine Pool Editor**, and **OCM IdP Editor**), and add it to a User Access group. For more information, see the Red Hat documentation on [Creating and Managing Service Accounts](https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/creating_and_managing_service_accounts/index).
+
+Once you have a Client ID and Client Secret, set them as environment variables:
+
+{{codefile "shell" "examples/import_2.sh"}}
+
+{{tffile "examples/example_2.tf"}}
+
+You can also pass credentials explicitly via the provider block:
+
+{{tffile "examples/example_3.tf"}}
+
+### Offline Access Token Authentication (Legacy)
+
+~> **Note:** Offline access tokens are a legacy authentication method. Service account authentication (above) is the recommended approach and will become the default.
+
+The offline access token can be generated at https://console.redhat.com/openshift/token/rosa
+
+The token can be provided by adding a `token` to the `rhcs` provider block:
 
 {{tffile "examples/example_1.tf"}}
 
-### Environment Variables
-
-The Red Hat Cloud Services token can be provided by using the `RHCS_TOKEN` environment variables.
-
-For example:
+Or by using the `RHCS_TOKEN` environment variable:
 
 {{tffile "examples/example_2.tf"}}
 


### PR DESCRIPTION
## PR Summary

Add service account authentication documentation to the RHCS provider, positioning it as the recommended method and marking offline token authentication as legacy.

## Detailed Description of the Issue

Service account authentication has been supported by the provider since v1.7.1 (`client_id`/`client_secret` in the provider schema and `RHCS_CLIENT_ID`/`RHCS_CLIENT_SECRET` environment variables), but the documentation was accidentally reverted and never re-landed. Users had no guidance on how to use the recommended authentication method.

## Related Issues and PRs
- Jira: [ROSAENG-62664](https://issues.redhat.com/browse/ROSAENG-62664)
- Related PR(s): #940 (original docs, reverted in #941)

## Type of Change
- [x] docs - updates documentation only.

## Previous Behavior

The provider documentation only described offline OCM token authentication (`RHCS_TOKEN` / `token` provider attribute), with no mention of service account support.

## Behavior After This Change

The provider documentation now covers two authentication methods:

1. **Service Account Authentication (Recommended)** — step-by-step instructions to create a service account, add it to a User Access group with the required roles (OCM Provisioner + OCM Cluster Editor or OCM Organization Administrator), configure the provider via environment variables or provider block, and optionally verify with the ROSA CLI. Includes CI/CD best practices and a Vault integration example.

2. **Offline Access Token Authentication (Legacy)** — the existing token-based method, now clearly marked as legacy with a deprecation note directing users to service accounts.

The Prerequisites section is also updated to list both authentication options with the service account marked as recommended and linking to the official [Red Hat documentation on Creating and Managing Service Accounts](https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/creating_and_managing_service_accounts/index).

## How to Test (Step-by-Step)
### Preconditions
- Go 1.26+, `terraform-plugin-docs` available via `make docs`

### Test Steps
1. Run `make docs` — verify it generates and validates successfully.
2. Run `make docs-lint` — verify Vale reports 0 errors.
3. Review `docs/index.md` to confirm the service account and legacy token sections render correctly.

### Expected Results
- `make docs` exits 0
- `make docs-lint` exits 0
- `docs/index.md` contains the new "Service Account Authentication (Recommended)" section with all four steps and best practices
- `docs/index.md` contains the "Offline Access Token Authentication (Legacy)" section with a deprecation note

## Proof of the Fix
- `make docs` and `make docs-lint` pass locally with 0 errors, 0 warnings, 0 suggestions.

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
- [x] Any risk, limitation, or follow-up work is documented.
- [x] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
- [x] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

### Testing (check all that apply; use N/A when not relevant)
- [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated authentication guidance to recommend Red Hat Hybrid Cloud Console service accounts with client ID and client secret credentials.
  - Added instructions for service-account creation, access assignment, provider configuration, optional CLI verification, and credential-management best practices.
  - Retained offline OCM token authentication as a documented legacy option.

- **Examples**
  - Added provider configuration and environment-variable examples for service-account credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->