### PR TITLE
ROSAENG-66147 | feat(hcp): add management block to machine pool resource

### DIFF
--- a/docs/data-sources/hcp_machine_pool.md
+++ b/docs/data-sources/hcp_machine_pool.md
@@ -42,6 +42,7 @@ data "rhcs_hcp_machine_pool" "machine_pool" {
 - `ignore_deletion_error` (Boolean) Indicates to the provider to disregard API errors when deleting the machine pool. This will remove the resource from the management file, but not necessirely delete the underlying pool in case it errors. Setting this to true can bypass issues when destroying the cluster resource alongside the pool resource in the same management file. This is not recommended to be set in other use cases
 - `kubelet_configs` (String) Name of the kubelet config applied to the machine pool.
 - `labels` (Map of String) Labels for the machine pool. Format should be a comma-separated list of 'key = value'. This list will overwrite any modifications made to node labels on an ongoing basis.
+- `management` (Attributes) Management settings for the machine pool. (see [below for nested schema](#nestedatt--management))
 - `replicas` (Number) The number of machines of the pool
 - `status` (Attributes) HCP replica status (see [below for nested schema](#nestedatt--status))
 - `subnet_id` (String) Select the subnet in which to create a single AZ machine pool for BYO-VPC cluster. After the creation of the resource, it is not possible to update the attribute value.
@@ -79,6 +80,16 @@ Read-Only:
 - `instance_type` (String) Identifier of the machine type used by the nodes, for example `m5.xlarge`. Use the `rhcs_machine_types` data source to find the possible values. After the creation of the resource, it is not possible to update the attribute value.
 - `max_spot_price` (Number) Max Spot price.
 - `use_spot_instances` (Boolean) Use Amazon EC2 Spot Instances.
+
+
+<a id="nestedatt--management"></a>
+### Nested Schema for `management`
+
+Read-Only:
+
+- `max_surge` (String) Maximum number of nodes that can be scheduled above the desired number of nodes during the upgrade.
+- `max_unavailable` (String) Maximum number of nodes that can be unavailable during the upgrade.
+- `type` (String) Type of strategy for handling upgrades.
 
 
 <a id="nestedatt--status"></a>

--- a/docs/resources/hcp_machine_pool.md
+++ b/docs/resources/hcp_machine_pool.md
@@ -25,6 +25,10 @@ resource "rhcs_hcp_machine_pool" "machine_pool" {
     instance_type           = "m5.xlarge"
     node_drain_grace_period = 45
   }
+  management = {
+    max_surge       = "1"
+    max_unavailable = "0"
+  }
   auto_repair = true
 }
 ```
@@ -46,6 +50,7 @@ resource "rhcs_hcp_machine_pool" "machine_pool" {
 - `ignore_deletion_error` (Boolean) Indicates to the provider to disregard API errors when deleting the machine pool. This will remove the resource from the management file, but not necessirely delete the underlying pool in case it errors. Setting this to true can bypass issues when destroying the cluster resource alongside the pool resource in the same management file. This is not recommended to be set in other use cases
 - `kubelet_configs` (String) Name of the kubelet config applied to the machine pool. A single kubelet config is allowed. Kubelet config must already exist.
 - `labels` (Map of String) Labels for the machine pool. Format should be a comma-separated list of 'key = value'. This list will overwrite any modifications made to node labels on an ongoing basis.
+- `management` (Attributes) Management settings for the machine pool. Controls rolling upgrade behavior. (see [below for nested schema](#nestedatt--management))
 - `replicas` (Number) The number of machines of the pool
 - `taints` (Attributes List) Taints for a machine pool. Format should be a comma-separated list of 'key=value'. This list will overwrite any modifications made to node taints on an ongoing basis. (see [below for nested schema](#nestedatt--taints))
 - `tuning_configs` (List of String) A list of tuning configs attached to the pool.
@@ -95,6 +100,16 @@ Optional:
 Read-Only:
 
 - `instance_profile` (String) Instance profile attached to the replica
+
+
+<a id="nestedatt--management"></a>
+### Nested Schema for `management`
+
+Optional:
+
+- `max_surge` (String) Maximum number of nodes that can be scheduled above the desired number of nodes during the upgrade. Can be an integer or a percentage (e.g., "1" or "25%").
+- `max_unavailable` (String) Maximum number of nodes that can be unavailable during the upgrade. Can be an integer or a percentage (e.g., "0" or "10%").
+- `type` (String) Type of strategy for handling upgrades.
 
 
 <a id="nestedatt--taints"></a>

--- a/examples/resources/hcp_machine_pool/example_1.tf
+++ b/examples/resources/hcp_machine_pool/example_1.tf
@@ -10,5 +10,9 @@ resource "rhcs_hcp_machine_pool" "machine_pool" {
     instance_type           = "m5.xlarge"
     node_drain_grace_period = 45
   }
+  management = {
+    max_surge       = "1"
+    max_unavailable = "0"
+  }
   auto_repair = true
 }

--- a/provider/machinepool/hcp/machine_pool_datasource.go
+++ b/provider/machinepool/hcp/machine_pool_datasource.go
@@ -65,6 +65,7 @@ func (r *HcpMachinePoolDatasource) Configure(ctx context.Context, req datasource
 	r.collection = connection.ClustersMgmt().V1().Clusters()
 }
 
+// Schema defines the schema for the HCP machine pool data source.
 func (r *HcpMachinePoolDatasource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Machine pool.",
@@ -157,6 +158,11 @@ func (r *HcpMachinePoolDatasource) Schema(ctx context.Context, req datasource.Sc
 			"auto_repair": schema.BoolAttribute{
 				Description: "Indicates use of autor repair for replica",
 				Optional:    true,
+				Computed:    true,
+			},
+			"management": schema.SingleNestedAttribute{
+				Description: "Management settings for the machine pool.",
+				Attributes:  ManagementDatasource(),
 				Computed:    true,
 			},
 			"version": schema.StringAttribute{

--- a/provider/machinepool/hcp/machine_pool_resource.go
+++ b/provider/machinepool/hcp/machine_pool_resource.go
@@ -38,6 +38,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -82,6 +83,7 @@ func (r *HcpMachinePoolResource) Metadata(ctx context.Context, req resource.Meta
 	resp.TypeName = req.ProviderTypeName + "_hcp_machine_pool"
 }
 
+// Schema defines the schema for the HCP machine pool resource.
 func (r *HcpMachinePoolResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Machine pool.",
@@ -194,6 +196,15 @@ func (r *HcpMachinePoolResource) Schema(ctx context.Context, req resource.Schema
 				Description: "Indicates use of autor repair for the pool",
 				Required:    true,
 			},
+			"management": schema.SingleNestedAttribute{
+				Description: "Management settings for the machine pool. Controls rolling upgrade behavior.",
+				Attributes:  ManagementResource(),
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"version": schema.StringAttribute{
 				Description: "Desired version of OpenShift for the machine pool, for example '4.11.0'. If version is greater than the currently running version, an upgrade will be scheduled.",
 				Optional:    true,
@@ -251,6 +262,7 @@ func (r *HcpMachinePoolResource) Configure(ctx context.Context, req resource.Con
 	r.clusterWait = common.NewClusterWait(r.clusterCollection, connection)
 }
 
+// Create creates a new HCP machine pool.
 func (r *HcpMachinePoolResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Get the plan:
 	plan := &HcpMachinePoolState{}
@@ -498,6 +510,13 @@ func (r *HcpMachinePoolResource) Create(ctx context.Context, req resource.Create
 
 	if common.HasValue(plan.AutoRepair) {
 		builder.AutoRepair(common.BoolWithTrueDefault(plan.AutoRepair))
+	}
+
+	if mgmtUpgrade := buildManagementUpgrade(ctx, plan.Management, &resp.Diagnostics); mgmtUpgrade != nil {
+		builder.ManagementUpgrade(mgmtUpgrade)
+	}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	if common.HasValue(plan.Version) {
@@ -775,6 +794,7 @@ func (r *HcpMachinePoolResource) Update(ctx context.Context, req resource.Update
 	resp.Diagnostics.Append(diags...)
 }
 
+// doUpdate applies in-place updates to an existing HCP machine pool.
 func (r *HcpMachinePoolResource) doUpdate(ctx context.Context, state *HcpMachinePoolState, plan *HcpMachinePoolState) diag.Diagnostics {
 	//assert no changes on specific attributes
 	diags := validateNoImmutableAttChange(state, plan)
@@ -964,6 +984,13 @@ func (r *HcpMachinePoolResource) doUpdate(ctx context.Context, state *HcpMachine
 		if v, ok := common.ShouldPatchInt(state.AWSNodePool.NodeDrainGracePeriod, plan.AWSNodePool.NodeDrainGracePeriod); ok {
 			npBuilder.NodeDrainGracePeriod(cmv1.NewValue().Value(float64(v)))
 		}
+	}
+
+	if mgmtUpgrade := buildManagementUpgrade(ctx, plan.Management, &diags); mgmtUpgrade != nil {
+		npBuilder.ManagementUpgrade(mgmtUpgrade)
+	}
+	if diags.HasError() {
+		return diags
 	}
 
 	nodePool, err := npBuilder.Build()
@@ -1544,6 +1571,16 @@ func populateState(ctx context.Context, object *cmv1.NodePool, state *HcpMachine
 	}
 
 	state.AutoRepair = types.BoolValue(object.AutoRepair())
+
+	if mgmtUpgrade, ok := object.GetManagementUpgrade(); ok {
+		upgradeType, _ := mgmtUpgrade.GetType()
+		maxSurge, _ := mgmtUpgrade.GetMaxSurge()
+		maxUnavailable, _ := mgmtUpgrade.GetMaxUnavailable()
+		state.Management = flattenManagement(upgradeType, maxSurge, maxUnavailable)
+	} else {
+		state.Management = managementNull()
+	}
+
 	return nil
 }
 

--- a/provider/machinepool/hcp/machine_pool_state.go
+++ b/provider/machinepool/hcp/machine_pool_state.go
@@ -43,6 +43,8 @@ type HcpMachinePoolState struct {
 	KubeletConfigs types.String `tfsdk:"kubelet_configs"`
 	AutoRepair     types.Bool   `tfsdk:"auto_repair"`
 
+	Management types.Object `tfsdk:"management"`
+
 	IgnoreDeletionError types.Bool `tfsdk:"ignore_deletion_error"`
 }
 

--- a/provider/machinepool/hcp/management.go
+++ b/provider/machinepool/hcp/management.go
@@ -1,0 +1,170 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+package hcp
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/terraform-redhat/terraform-provider-rhcs/provider/common"
+)
+
+// Management holds the Terraform state for the management nested block.
+type Management struct {
+	Type           types.String `tfsdk:"type"`
+	MaxSurge       types.String `tfsdk:"max_surge"`
+	MaxUnavailable types.String `tfsdk:"max_unavailable"`
+}
+
+const (
+	attrNameType           = "type"
+	attrNameMaxSurge       = "max_surge"
+	attrNameMaxUnavailable = "max_unavailable"
+)
+
+var intOrPercentageRE = regexp.MustCompile(`^[0-9]+%?$`)
+
+var managementAttrTypes = map[string]attr.Type{
+	attrNameType:           types.StringType,
+	attrNameMaxSurge:       types.StringType,
+	attrNameMaxUnavailable: types.StringType,
+}
+
+// ManagementResource returns the schema attributes for the management block on the resource.
+func ManagementResource() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		attrNameType: schema.StringAttribute{
+			Description: "Type of strategy for handling upgrades.",
+			Optional:    true,
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+			Validators: []validator.String{
+				stringvalidator.OneOf("Replace"),
+			},
+		},
+		attrNameMaxSurge: schema.StringAttribute{
+			Description: "Maximum number of nodes that can be scheduled above the " +
+				"desired number of nodes during the upgrade. " +
+				"Can be an integer or a percentage (e.g., \"1\" or \"25%\").",
+			Optional: true,
+			Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(intOrPercentageRE,
+					"must be a non-negative integer or a non-negative "+
+						"integer followed by '%' (e.g., \"1\", \"25%\")"),
+			},
+		},
+		attrNameMaxUnavailable: schema.StringAttribute{
+			Description: "Maximum number of nodes that can be unavailable " +
+				"during the upgrade. " +
+				"Can be an integer or a percentage (e.g., \"0\" or \"10%\").",
+			Optional: true,
+			Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(intOrPercentageRE,
+					"must be a non-negative integer or a non-negative "+
+						"integer followed by '%' (e.g., \"0\", \"10%\")"),
+			},
+		},
+	}
+}
+
+// ManagementDatasource returns the schema attributes for the management block on the data source.
+func ManagementDatasource() map[string]dsschema.Attribute {
+	return map[string]dsschema.Attribute{
+		attrNameType: dsschema.StringAttribute{
+			Description: "Type of strategy for handling upgrades.",
+			Computed:    true,
+		},
+		attrNameMaxSurge: dsschema.StringAttribute{
+			Description: "Maximum number of nodes that can be scheduled " +
+				"above the desired number of nodes during the upgrade.",
+			Computed: true,
+		},
+		attrNameMaxUnavailable: dsschema.StringAttribute{
+			Description: "Maximum number of nodes that can be unavailable " +
+				"during the upgrade.",
+			Computed: true,
+		},
+	}
+}
+
+// stringValueOrNull returns StringNull for empty strings, StringValue otherwise.
+func stringValueOrNull(s string) basetypes.StringValue {
+	if s == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
+}
+
+// flattenManagement converts API values into a Terraform types.Object for the management block.
+func flattenManagement(upgradeType, maxSurge, maxUnavailable string) types.Object {
+	attrs := map[string]attr.Value{
+		attrNameType:           stringValueOrNull(upgradeType),
+		attrNameMaxSurge:       stringValueOrNull(maxSurge),
+		attrNameMaxUnavailable: stringValueOrNull(maxUnavailable),
+	}
+	return types.ObjectValueMust(managementAttrTypes, attrs)
+}
+
+// managementNull returns a typed-null object for the management block.
+func managementNull() types.Object {
+	return types.ObjectNull(managementAttrTypes)
+}
+
+// expandManagement converts a Terraform types.Object into a Management struct.
+func expandManagement(
+	ctx context.Context, object types.Object, diags *diag.Diagnostics,
+) *Management {
+	if object.IsNull() || object.IsUnknown() {
+		return nil
+	}
+	var config Management
+	diags.Append(object.As(ctx, &config, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+	return &config
+}
+
+// buildManagementUpgrade builds a NodePoolManagementUpgradeBuilder from the management block.
+func buildManagementUpgrade(
+	ctx context.Context, object types.Object, diags *diag.Diagnostics,
+) *cmv1.NodePoolManagementUpgradeBuilder {
+	config := expandManagement(ctx, object, diags)
+	if config == nil {
+		return nil
+	}
+	builder := cmv1.NewNodePoolManagementUpgrade()
+	if !common.IsStringAttributeUnknownOrEmpty(config.Type) {
+		builder.Type(config.Type.ValueString())
+	}
+	if !common.IsStringAttributeUnknownOrEmpty(config.MaxSurge) {
+		builder.MaxSurge(config.MaxSurge.ValueString())
+	}
+	if !common.IsStringAttributeUnknownOrEmpty(config.MaxUnavailable) {
+		builder.MaxUnavailable(config.MaxUnavailable.ValueString())
+	}
+	return builder
+}

--- a/subsystem/hcp/machine_pool_resource_test.go
+++ b/subsystem/hcp/machine_pool_resource_test.go
@@ -4672,6 +4672,567 @@ var _ = Describe("Hcp Machine pool", func() {
 		})
 	})
 
+	Context("Management", func() {
+		BeforeEach(func() {
+			prepareClusterRead("123")
+		})
+		It("Can create machine pool with management", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(
+						http.MethodPost,
+						"/api/clusters_mgmt/v1/clusters/123/node_pools",
+					),
+					VerifyJQ(".management_upgrade.type", "Replace"),
+					VerifyJQ(".management_upgrade.max_surge", "2"),
+					VerifyJQ(".management_upgrade.max_unavailable", "1"),
+					RespondWithJSON(http.StatusCreated, `{
+					"id":"my-pool",
+					"aws_node_pool":{
+					   "instance_type":"r5.xlarge",
+					   "instance_profile": "bla"
+					},
+					"auto_repair": true,
+					"replicas":4,
+					"subnet":"id-1",
+					"availability_zone":"us-east-1a",
+					"management_upgrade": {
+					   "type": "Replace",
+					   "max_surge": "2",
+					   "max_unavailable": "1"
+					},
+					"version": {
+						"raw_id": "4.14.10"
+					}
+				}`),
+				),
+			)
+
+			Terraform.Source(`
+			resource "rhcs_hcp_machine_pool" "my_pool" {
+				cluster      = "123"
+				name         = "my-pool"
+				aws_node_pool = {
+					instance_type = "r5.xlarge"
+				}
+				autoscaling = {
+					enabled = false,
+				}
+				subnet_id = "id-1"
+				replicas     = 4
+				management = {
+					type            = "Replace"
+					max_surge       = "2"
+					max_unavailable = "1"
+				}
+				version = "4.14.10"
+				auto_repair = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+
+			resource := Terraform.Resource("rhcs_hcp_machine_pool", "my_pool")
+			Expect(resource).To(MatchJQ(".attributes.management.type", "Replace"))
+			Expect(resource).To(MatchJQ(".attributes.management.max_surge", "2"))
+			Expect(resource).To(MatchJQ(".attributes.management.max_unavailable", "1"))
+		})
+
+		It("Can create machine pool without management and API defaults populate state", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(
+						http.MethodPost,
+						"/api/clusters_mgmt/v1/clusters/123/node_pools",
+					),
+					RespondWithJSON(http.StatusCreated, `{
+					"id":"my-pool",
+					"aws_node_pool":{
+					   "instance_type":"r5.xlarge",
+					   "instance_profile": "bla"
+					},
+					"auto_repair": true,
+					"replicas":4,
+					"subnet":"id-1",
+					"availability_zone":"us-east-1a",
+					"management_upgrade": {
+					   "type": "Replace",
+					   "max_surge": "1",
+					   "max_unavailable": "0"
+					},
+					"version": {
+						"raw_id": "4.14.10"
+					}
+				}`),
+				),
+			)
+
+			Terraform.Source(`
+			resource "rhcs_hcp_machine_pool" "my_pool" {
+				cluster      = "123"
+				name         = "my-pool"
+				aws_node_pool = {
+					instance_type = "r5.xlarge"
+				}
+				autoscaling = {
+					enabled = false,
+				}
+				subnet_id = "id-1"
+				replicas     = 4
+				version = "4.14.10"
+				auto_repair = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+
+			resource := Terraform.Resource("rhcs_hcp_machine_pool", "my_pool")
+			Expect(resource).To(MatchJQ(".attributes.management.type", "Replace"))
+			Expect(resource).To(MatchJQ(".attributes.management.max_surge", "1"))
+			Expect(resource).To(MatchJQ(".attributes.management.max_unavailable", "0"))
+		})
+
+		It("Does not produce a perpetual diff when management is omitted", func() {
+			// Create
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(
+						http.MethodPost,
+						"/api/clusters_mgmt/v1/clusters/123/node_pools",
+					),
+					RespondWithJSON(http.StatusCreated, `{
+					"id":"my-pool",
+					"aws_node_pool":{
+					   "instance_type":"r5.xlarge",
+					   "instance_profile": "bla"
+					},
+					"auto_repair": true,
+					"replicas":4,
+					"subnet":"id-1",
+					"availability_zone":"us-east-1a",
+					"management_upgrade": {
+					   "type": "Replace",
+					   "max_surge": "1",
+					   "max_unavailable": "0"
+					},
+					"version": {
+						"raw_id": "4.14.10"
+					}
+				}`),
+				),
+			)
+
+			hclConfig := `
+			resource "rhcs_hcp_machine_pool" "my_pool" {
+				cluster      = "123"
+				name         = "my-pool"
+				aws_node_pool = {
+					instance_type = "r5.xlarge"
+				}
+				autoscaling = {
+					enabled = false,
+				}
+				subnet_id = "id-1"
+				replicas     = 4
+				version = "4.14.10"
+				auto_repair = true
+			}`
+			Terraform.Source(hclConfig)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+
+			// Second apply with the same config - read handlers for refresh
+			prepareClusterRead("123")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/node_pools/my-pool"),
+					RespondWithJSON(http.StatusOK, `{
+					"id":"my-pool",
+					"aws_node_pool":{
+					   "instance_type":"r5.xlarge",
+					   "instance_profile": "bla"
+					},
+					"auto_repair": true,
+					"replicas":4,
+					"subnet":"id-1",
+					"availability_zone":"us-east-1a",
+					"management_upgrade": {
+					   "type": "Replace",
+					   "max_surge": "1",
+					   "max_unavailable": "0"
+					},
+					"version": {
+						"raw_id": "4.14.10"
+					}
+				}`),
+				),
+			)
+
+			Terraform.Source(hclConfig)
+			runOutput = Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+		})
+
+		It("Can create machine pool with management using percentage values", func() {
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(
+						http.MethodPost,
+						"/api/clusters_mgmt/v1/clusters/123/node_pools",
+					),
+					VerifyJQ(".management_upgrade.max_surge", "25%"),
+					VerifyJQ(".management_upgrade.max_unavailable", "10%"),
+					RespondWithJSON(http.StatusCreated, `{
+					"id":"my-pool",
+					"aws_node_pool":{
+					   "instance_type":"r5.xlarge",
+					   "instance_profile": "bla"
+					},
+					"auto_repair": true,
+					"replicas":4,
+					"subnet":"id-1",
+					"availability_zone":"us-east-1a",
+					"management_upgrade": {
+					   "type": "Replace",
+					   "max_surge": "25%",
+					   "max_unavailable": "10%"
+					},
+					"version": {
+						"raw_id": "4.14.10"
+					}
+				}`),
+				),
+			)
+
+			Terraform.Source(`
+			resource "rhcs_hcp_machine_pool" "my_pool" {
+				cluster      = "123"
+				name         = "my-pool"
+				aws_node_pool = {
+					instance_type = "r5.xlarge"
+				}
+				autoscaling = {
+					enabled = false,
+				}
+				subnet_id = "id-1"
+				replicas     = 4
+				management = {
+					max_surge       = "25%"
+					max_unavailable = "10%"
+				}
+				version = "4.14.10"
+				auto_repair = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+
+			resource := Terraform.Resource("rhcs_hcp_machine_pool", "my_pool")
+			Expect(resource).To(MatchJQ(".attributes.management.max_surge", "25%"))
+			Expect(resource).To(MatchJQ(".attributes.management.max_unavailable", "10%"))
+		})
+
+		It("Can update machine pool management", func() {
+			// Create
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(
+						http.MethodPost,
+						"/api/clusters_mgmt/v1/clusters/123/node_pools",
+					),
+					RespondWithJSON(http.StatusCreated, `{
+					"id":"my-pool",
+					"aws_node_pool":{
+					   "instance_type":"r5.xlarge",
+					   "instance_profile": "bla"
+					},
+					"auto_repair": true,
+					"replicas":4,
+					"subnet":"id-1",
+					"availability_zone":"us-east-1a",
+					"management_upgrade": {
+					   "type": "Replace",
+					   "max_surge": "1",
+					   "max_unavailable": "0"
+					},
+					"version": {
+						"raw_id": "4.14.10"
+					}
+				}`),
+				),
+			)
+
+			Terraform.Source(`
+			resource "rhcs_hcp_machine_pool" "my_pool" {
+				cluster      = "123"
+				name         = "my-pool"
+				aws_node_pool = {
+					instance_type = "r5.xlarge"
+				}
+				autoscaling = {
+					enabled = false,
+				}
+				subnet_id = "id-1"
+				replicas     = 4
+				management = {
+					max_surge       = "1"
+					max_unavailable = "0"
+				}
+				version = "4.14.10"
+				auto_repair = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+
+			// Update - Read
+			prepareClusterRead("123")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/node_pools/my-pool"),
+					RespondWithJSON(http.StatusOK, `{
+					"id":"my-pool",
+					"aws_node_pool":{
+					   "instance_type":"r5.xlarge",
+					   "instance_profile": "bla"
+					},
+					"auto_repair": true,
+					"replicas":4,
+					"subnet":"id-1",
+					"availability_zone":"us-east-1a",
+					"management_upgrade": {
+					   "type": "Replace",
+					   "max_surge": "1",
+					   "max_unavailable": "0"
+					},
+					"version": {
+						"raw_id": "4.14.10"
+					}
+				}`),
+				),
+			)
+			// Update - Get for doUpdate
+			prepareClusterRead("123")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/node_pools/my-pool"),
+					RespondWithJSON(http.StatusOK, `{
+					"id":"my-pool",
+					"aws_node_pool":{
+					   "instance_type":"r5.xlarge",
+					   "instance_profile": "bla"
+					},
+					"auto_repair": true,
+					"replicas":4,
+					"subnet":"id-1",
+					"availability_zone":"us-east-1a",
+					"management_upgrade": {
+					   "type": "Replace",
+					   "max_surge": "1",
+					   "max_unavailable": "0"
+					},
+					"version": {
+						"raw_id": "4.14.10"
+					}
+				}`),
+				),
+			)
+			// Update - PATCH
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(
+						http.MethodPatch,
+						"/api/clusters_mgmt/v1/clusters/123/node_pools/my-pool",
+					),
+					VerifyJQ(".management_upgrade.max_surge", "25%"),
+					VerifyJQ(".management_upgrade.max_unavailable", "10%"),
+					RespondWithJSON(http.StatusOK, `{
+					"id":"my-pool",
+					"aws_node_pool":{
+					   "instance_type":"r5.xlarge",
+					   "instance_profile": "bla"
+					},
+					"auto_repair": true,
+					"replicas":4,
+					"subnet":"id-1",
+					"availability_zone":"us-east-1a",
+					"management_upgrade": {
+					   "type": "Replace",
+					   "max_surge": "25%",
+					   "max_unavailable": "10%"
+					},
+					"version": {
+						"raw_id": "4.14.10"
+					}
+				}`),
+				),
+			)
+
+			Terraform.Source(`
+			resource "rhcs_hcp_machine_pool" "my_pool" {
+				cluster      = "123"
+				name         = "my-pool"
+				aws_node_pool = {
+					instance_type = "r5.xlarge"
+				}
+				autoscaling = {
+					enabled = false,
+				}
+				subnet_id = "id-1"
+				replicas     = 4
+				management = {
+					max_surge       = "25%"
+					max_unavailable = "10%"
+				}
+				version = "4.14.10"
+				auto_repair = true
+			}`)
+			runOutput = Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+
+			resource := Terraform.Resource("rhcs_hcp_machine_pool", "my_pool")
+			Expect(resource).To(MatchJQ(".attributes.management.max_surge", "25%"))
+			Expect(resource).To(MatchJQ(".attributes.management.max_unavailable", "10%"))
+		})
+
+		It("Validates management max_surge format", func() {
+			Terraform.Source(`
+			resource "rhcs_hcp_machine_pool" "my_pool" {
+				cluster      = "123"
+				name         = "my-pool"
+				aws_node_pool = {
+					instance_type = "r5.xlarge"
+				}
+				autoscaling = {
+					enabled = false,
+				}
+				subnet_id = "id-1"
+				replicas     = 4
+				management = {
+					max_surge       = "abc"
+					max_unavailable = "0"
+				}
+				auto_repair = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).ToNot(BeZero())
+			runOutput.VerifyErrorContainsSubstring("must be a non-negative integer")
+		})
+
+		It("Validates management max_unavailable format", func() {
+			Terraform.Source(`
+			resource "rhcs_hcp_machine_pool" "my_pool" {
+				cluster      = "123"
+				name         = "my-pool"
+				aws_node_pool = {
+					instance_type = "r5.xlarge"
+				}
+				autoscaling = {
+					enabled = false,
+				}
+				subnet_id = "id-1"
+				replicas     = 4
+				management = {
+					max_surge       = "1"
+					max_unavailable = "-1"
+				}
+				auto_repair = true
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).ToNot(BeZero())
+			runOutput.VerifyErrorContainsSubstring("must be a non-negative integer")
+		})
+
+		It("Reads management via data source", func() {
+			nodePoolResponse := `{
+				"id":"my-pool",
+				"aws_node_pool":{
+				   "instance_type":"r5.xlarge",
+				   "instance_profile": "bla"
+				},
+				"auto_repair": true,
+				"replicas":4,
+				"subnet":"id-1",
+				"availability_zone":"us-east-1a",
+				"management_upgrade": {
+				   "type": "Replace",
+				   "max_surge": "1",
+				   "max_unavailable": "0"
+				},
+				"version": {
+					"raw_id": "4.14.10"
+				}
+			}`
+			// Read for plan phase
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/node_pools/my-pool"),
+					RespondWithJSON(http.StatusOK, nodePoolResponse),
+				),
+			)
+			// Read for apply phase
+			prepareClusterRead("123")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/node_pools/my-pool"),
+					RespondWithJSON(http.StatusOK, nodePoolResponse),
+				),
+			)
+
+			Terraform.Source(`
+			data "rhcs_hcp_machine_pool" "my_pool" {
+				cluster = "123"
+				name    = "my-pool"
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+
+			resource := Terraform.Resource("rhcs_hcp_machine_pool", "my_pool")
+			Expect(resource).To(MatchJQ(".attributes.management.type", "Replace"))
+			Expect(resource).To(MatchJQ(".attributes.management.max_surge", "1"))
+			Expect(resource).To(MatchJQ(".attributes.management.max_unavailable", "0"))
+		})
+
+		It("Reads absent management as null via data source", func() {
+			nodePoolResponse := `{
+				"id":"my-pool",
+				"aws_node_pool":{
+				   "instance_type":"r5.xlarge",
+				   "instance_profile": "bla"
+				},
+				"auto_repair": true,
+				"replicas":4,
+				"subnet":"id-1",
+				"availability_zone":"us-east-1a",
+				"version": {
+					"raw_id": "4.14.10"
+				}
+			}`
+			// Read for plan phase
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/node_pools/my-pool"),
+					RespondWithJSON(http.StatusOK, nodePoolResponse),
+				),
+			)
+			// Read for apply phase
+			prepareClusterRead("123")
+			TestServer.AppendHandlers(
+				CombineHandlers(
+					VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/node_pools/my-pool"),
+					RespondWithJSON(http.StatusOK, nodePoolResponse),
+				),
+			)
+
+			Terraform.Source(`
+			data "rhcs_hcp_machine_pool" "my_pool" {
+				cluster = "123"
+				name    = "my-pool"
+			}`)
+			runOutput := Terraform.Apply()
+			Expect(runOutput.ExitCode).To(BeZero())
+
+			resource := Terraform.Resource("rhcs_hcp_machine_pool", "my_pool")
+			Expect(resource).To(MatchJQ(".attributes.management", nil))
+		})
+	})
+
 	Context("Upgrade", func() {
 		clusterId := "123"
 		poolId := "pool1"


### PR DESCRIPTION
## PR Summary

Add a `management` block to `rhcs_hcp_machine_pool` (resource and data source) exposing the OCM API's `management_upgrade` settings (`max_surge`, `max_unavailable`, `type`), enabling Terraform users to control rolling upgrade behavior for ROSA HCP machine pools and preventing Terraform-vs-CLI configuration drift.

## Detailed Description of the Issue

When users configure machine pool upgrade settings via the ROSA CLI or OCM console (e.g., `max_surge`, `max_unavailable`), those values are not reflected in Terraform state. On the next `terraform plan`, the provider is unaware of these settings, causing silent drift. Users have no way to declaratively manage rolling upgrade behavior through Terraform.

The OCM SDK already models these fields on `NodePool.ManagementUpgrade` (`MaxSurge`, `MaxUnavailable`, `Type`) but the provider did not expose them. This change maps the new `management` Terraform block to the existing SDK types.

**Scope: HCP only.** The Classic `MachinePool` SDK type does not have a `ManagementUpgrade` field; this capability is exclusive to HCP `NodePool` objects.

## Related Issues and PRs

- Jira: [ROSAENG-66147](https://issues.redhat.com/browse/ROSAENG-66147)
- Fixes: #1105
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change

- [x] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

The `rhcs_hcp_machine_pool` resource had no way to manage rolling upgrade settings. Values set via the ROSA CLI or OCM API (`max_surge`, `max_unavailable`) were invisible to Terraform, causing configuration drift.

## Behavior After This Change

Users can optionally set a `management` block:

```hcl
resource "rhcs_hcp_machine_pool" "example" {
  # ...existing fields...

  management = {
    max_surge       = "1"      # integer or percentage ("25%")
    max_unavailable = "0"      # integer or percentage ("10%")
  }
}
```

- **Existing users who do not set the block:** No breaking change. The block is `Optional+Computed` with `objectplanmodifier.UseStateForUnknown()`, so API defaults populate state silently with zero plan diff on upgrade.
- **Values are mutable:** `max_surge`, `max_unavailable`, and `type` can be updated in place via PATCH.
- **Validation:** `max_surge` and `max_unavailable` are validated as non-negative integers or percentages (e.g., `"1"`, `"25%"`). `type` rejects empty/blank strings.
- **Data source:** `rhcs_hcp_machine_pool` data source also exposes the block as `Computed`.
- **Empty API values:** Empty strings from the API are mapped to `types.StringNull()` to avoid validator conflicts on subsequent plans.

## How to Test (Step-by-Step)

### Preconditions

- A running ROSA HCP cluster
- `RHCS_TOKEN` set in the environment
- Provider built locally (`make install`)

### Test Steps

1. Run subsystem tests: `go test ./subsystem/hcp/... -ginkgo.focus="Management"`
2. Run full HCP machine pool suite: `go test ./subsystem/hcp/... -ginkgo.focus="Hcp Machine pool"`
3. Run manual validation against a live cluster

### Expected Results

- All 8 subsystem tests pass (create with/without block, percentage values, update with percentages, no-perpetual-diff, two validation rejections, data source read)
- Full HCP machine pool suite passes with no regressions
- `make check-subsystem-registry` passes

## Proof of the Fix

- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: local test output will be added as a secondary comment.

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below; see [breaking-change guidance](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/breaking-changes.md))

### Breaking Change Details / Migration Plan

N/A

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
- [x] Any risk, limitation, or follow-up work is documented.
- [x] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
- [x] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

### Testing (check all that apply; use N/A when not relevant)

- [ ] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
- [x] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md), [resource overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources/resource-overview.md), and [data source overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/datasources/datasource-overview.md)).
- [x] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
- [x] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CONTRIBUTING.md) and [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md)).
- [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
- [x] `make check-subsystem-registry` passes.
- [x] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Machine pools now support rolling-upgrade management settings, including upgrade strategy, maximum surge, and maximum unavailable values.
  - Management settings are preserved across create, update, refresh, and repeated applies.
  - Management configuration is available when reading machine pool data sources.
  - Surge limits support both integer and percentage values, with validation for invalid configurations.

- **Documentation**
  - Added resource and data source documentation, configuration examples, and an example upgrade configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->