### PR TITLE
ROSA-62 | docs: guide for custom-component-routes

### DIFF
--- a/docs/guides/custom-component-routes.md
+++ b/docs/guides/custom-component-routes.md
@@ -1,0 +1,255 @@
+---
+page_title: "Custom Component Routes for ROSA HCP Clusters"
+subcategory: ""
+description: |-
+  Instructions on how to configure custom hostnames and TLS certificates for Console and Downloads routes on ROSA HCP clusters.
+---
+
+# Configuring Custom Component Routes
+
+Custom component routes enable you to configure custom hostnames and TLS certificates for the OpenShift Console and Downloads routes on ROSA HCP clusters. This is useful for organizations with strict enterprise domain requirements, compliance policies, or those migrating from ROSA Classic clusters that already use custom component routes.
+
+## Overview
+
+Component routes allow you to override the default hostnames for cluster management interfaces:
+
+- **Console**: The OpenShift web console (default: `console-openshift-console.apps.<cluster-domain>`)
+- **Downloads**: The CLI and tools download page (default: `downloads-openshift-console.apps.<cluster-domain>`)
+
+**Note**: customized OAuth component routes are not supported
+
+## Prerequisites
+
+Before configuring custom component routes, ensure you have:
+
+1. A ROSA HCP cluster created via Terraform using the `rhcs_cluster_rosa_hcp` resource. This is a day-2 task only.
+2. TLS certificates and keys for your custom hostnames
+3. TLS secrets created in the `openshift-config` namespace on your hosted cluster
+4. Minimum ROSA CLI version: 1.2.65
+5. Minimum RHCS provider version: 1.7.8
+6. DNS records pointing your custom hostnames to the cluster's ingress load balancer
+
+### Creating TLS Secrets
+
+Before configuring component routes in Terraform, create the TLS secrets on your cluster:
+
+```bash
+# Create secret for console route
+oc create secret tls console-tls-secret \
+  --cert=/path/to/console.crt \
+  --key=/path/to/console.key \
+  -n openshift-config
+
+# Create secret for downloads route
+oc create secret tls downloads-tls-secret \
+  --cert=/path/to/downloads.crt \
+  --key=/path/to/downloads.key \
+  -n openshift-config
+```
+
+## Configuration Examples
+
+### Setting Component Routes for Console and Downloads
+
+Configure both console and downloads routes with custom hostnames:
+
+```terraform
+resource "rhcs_hcp_default_ingress" "default_ingress" {
+  cluster          = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.id
+  listening_method = "external"
+
+  component_routes = {
+    console = {
+      hostname       = "console.company.com"
+      tls_secret_ref = "console-tls-secret"
+    }
+    downloads = {
+      hostname       = "downloads.company.com"
+      tls_secret_ref = "downloads-tls-secret"
+    }
+  }
+}
+```
+
+### Setting Only Console Route
+
+Configure just the console route, leaving downloads at the default:
+
+```terraform
+resource "rhcs_hcp_default_ingress" "default_ingress" {
+  cluster          = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.id
+  listening_method = "external"
+
+  component_routes = {
+    console = {
+      hostname       = "console.company.com"
+      tls_secret_ref = "console-tls-secret"
+    }
+  }
+}
+```
+
+### Clearing Component Routes
+
+To remove custom component routes and revert to defaults, remove the `component_routes` block entirely:
+
+```terraform
+resource "rhcs_hcp_default_ingress" "default_ingress" {
+  cluster          = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.id
+  listening_method = "external"
+  # component_routes block removed - routes will revert to defaults
+}
+```
+
+Run `terraform apply` to apply the change.
+
+### Clearing Individual Routes
+
+To clear one route while keeping another, simply remove that route from the map:
+
+```terraform
+resource "rhcs_hcp_default_ingress" "default_ingress" {
+  cluster          = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.id
+  listening_method = "external"
+
+  component_routes = {
+    # Only console route specified - downloads will revert to default
+    console = {
+      hostname       = "console.company.com"
+      tls_secret_ref = "console-tls-secret"
+    }
+  }
+}
+```
+
+## Verifying the Configuration
+
+After applying your Terraform configuration, verify that the component routes are configured correctly:
+
+### Check Cluster Ingress Configuration
+
+```bash
+oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.componentRoutes}' | jq
+```
+
+Expected output:
+
+```json
+[
+  {
+    "hostname": "console.company.com",
+    "name": "console",
+    "namespace": "openshift-console",
+    "servingCertKeyPairSecret": {
+      "name": "console-tls-secret"
+    }
+  },
+  {
+    "hostname": "downloads.company.com",
+    "name": "downloads",
+    "namespace": "openshift-console",
+    "servingCertKeyPairSecret": {
+      "name": "downloads-tls-secret"
+    }
+  }
+]
+```
+
+### Check Custom Routes
+
+Verify that the custom routes are created:
+
+```bash
+oc get routes -n openshift-console
+```
+
+You should see routes like `console-custom` and `downloads-custom` with your custom hostnames.
+
+### Verify Redirection
+
+The original routes will redirect (HTTP 301) to the custom hostnames:
+
+```bash
+curl -I https://console-openshift-console.apps.<cluster-domain>
+# Should return 301 redirect to https://console.company.com
+```
+
+Note: `--cacert` may also be needed if the default ingress uses a private CA.
+
+### Test Access
+
+Access the console via your custom hostname:
+
+```bash
+curl https://console.company.com
+# Should return the OpenShift console page
+```
+
+## Configuration Reference
+
+### component_routes
+
+- **Type**: Map of objects (optional)
+- **Valid keys**: `console`, `downloads`
+- **Description**: Component route configuration for console and downloads routes
+
+Each component route object supports:
+
+- `hostname` (Required) - Custom hostname for the route (e.g., `console.company.com`)
+- `tls_secret_ref` (Required) - Name of the TLS secret in the `openshift-config` namespace (e.g., `console-tls-secret`)
+
+**Requirements**:
+
+- Both `hostname` and `tls_secret_ref` must be provided together or both must be empty
+- The referenced TLS secret must exist in the cluster (`openshift-config` namespace) before applying the configuration
+
+## Additional Notes
+
+- **OAuth not supported**: Unlike ROSA Classic clusters, OAuth component routes cannot be configured on HCP clusters because the OAuth server runs on the management cluster
+- **DNS configuration**: Ensure your custom hostnames resolve to the cluster's ingress load balancer before applying the configuration
+- **Certificate validation**: The TLS certificates must be valid for the custom hostnames and trusted by clients accessing the console
+
+## Using the ROSA CLI
+
+Component routes can also be configured via the ROSA CLI:
+
+### Flag Mode
+
+```bash
+rosa edit ingress -c <cluster-name> \
+  --component-routes 'console: hostname=console.company.com;tlsSecretRef=console-tls-secret, downloads: hostname=downloads.company.com;tlsSecretRef=downloads-tls-secret'
+```
+
+### Interactive Mode
+
+```bash
+rosa edit ingress -c <cluster-name> -i
+```
+
+The interactive mode will prompt for console and downloads routes (OAuth is not prompted for HCP clusters).
+
+## Troubleshooting
+
+### Validation Errors
+
+If you receive a 400 error from the backend:
+
+```
+Can't update 'console' component route hostname without also supplying a new TLS secret reference
+```
+
+This means you provided only `hostname` or only `tls_secret_ref`. Both fields must be provided together.
+
+### Secret Not Found
+
+If the cluster cannot find the TLS secret:
+
+1. Verify the secret exists: `oc get secret -n openshift-config <secret-name>`
+2. Verify the secret is of type `kubernetes.io/tls`
+3. Ensure the secret contains both `tls.crt` and `tls.key` data
+
+## Related Documentation
+
+- [rhcs_hcp_default_ingress Resource](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/hcp_default_ingress)
+- [rhcs_cluster_rosa_hcp Resource](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/cluster_rosa_hcp)
+- [ROSA Documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/)

--- a/templates/guides/custom-component-routes.md.tmpl
+++ b/templates/guides/custom-component-routes.md.tmpl
@@ -1,0 +1,255 @@
+---
+page_title: "Custom Component Routes for ROSA HCP Clusters"
+subcategory: ""
+description: |-
+  Instructions on how to configure custom hostnames and TLS certificates for Console and Downloads routes on ROSA HCP clusters.
+---
+
+# Configuring Custom Component Routes
+
+Custom component routes enable you to configure custom hostnames and TLS certificates for the OpenShift Console and Downloads routes on ROSA HCP clusters. This is useful for organizations with strict enterprise domain requirements, compliance policies, or those migrating from ROSA Classic clusters that already use custom component routes.
+
+## Overview
+
+Component routes allow you to override the default hostnames for cluster management interfaces:
+
+- **Console**: The OpenShift web console (default: `console-openshift-console.apps.<cluster-domain>`)
+- **Downloads**: The CLI and tools download page (default: `downloads-openshift-console.apps.<cluster-domain>`)
+
+**Note**: customized OAuth component routes are not supported
+
+## Prerequisites
+
+Before configuring custom component routes, ensure you have:
+
+1. A ROSA HCP cluster created via Terraform using the `rhcs_cluster_rosa_hcp` resource. This is a day-2 task only.
+2. TLS certificates and keys for your custom hostnames
+3. TLS secrets created in the `openshift-config` namespace on your hosted cluster
+4. Minimum ROSA CLI version: 1.2.65
+5. Minimum RHCS provider version: 1.7.8
+6. DNS records pointing your custom hostnames to the cluster's ingress load balancer
+
+### Creating TLS Secrets
+
+Before configuring component routes in Terraform, create the TLS secrets on your cluster:
+
+```bash
+# Create secret for console route
+oc create secret tls console-tls-secret \
+  --cert=/path/to/console.crt \
+  --key=/path/to/console.key \
+  -n openshift-config
+
+# Create secret for downloads route
+oc create secret tls downloads-tls-secret \
+  --cert=/path/to/downloads.crt \
+  --key=/path/to/downloads.key \
+  -n openshift-config
+```
+
+## Configuration Examples
+
+### Setting Component Routes for Console and Downloads
+
+Configure both console and downloads routes with custom hostnames:
+
+```terraform
+resource "rhcs_hcp_default_ingress" "default_ingress" {
+  cluster          = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.id
+  listening_method = "external"
+
+  component_routes = {
+    console = {
+      hostname       = "console.company.com"
+      tls_secret_ref = "console-tls-secret"
+    }
+    downloads = {
+      hostname       = "downloads.company.com"
+      tls_secret_ref = "downloads-tls-secret"
+    }
+  }
+}
+```
+
+### Setting Only Console Route
+
+Configure just the console route, leaving downloads at the default:
+
+```terraform
+resource "rhcs_hcp_default_ingress" "default_ingress" {
+  cluster          = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.id
+  listening_method = "external"
+
+  component_routes = {
+    console = {
+      hostname       = "console.company.com"
+      tls_secret_ref = "console-tls-secret"
+    }
+  }
+}
+```
+
+### Clearing Component Routes
+
+To remove custom component routes and revert to defaults, remove the `component_routes` block entirely:
+
+```terraform
+resource "rhcs_hcp_default_ingress" "default_ingress" {
+  cluster          = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.id
+  listening_method = "external"
+  # component_routes block removed - routes will revert to defaults
+}
+```
+
+Run `terraform apply` to apply the change.
+
+### Clearing Individual Routes
+
+To clear one route while keeping another, simply remove that route from the map:
+
+```terraform
+resource "rhcs_hcp_default_ingress" "default_ingress" {
+  cluster          = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.id
+  listening_method = "external"
+
+  component_routes = {
+    # Only console route specified - downloads will revert to default
+    console = {
+      hostname       = "console.company.com"
+      tls_secret_ref = "console-tls-secret"
+    }
+  }
+}
+```
+
+## Verifying the Configuration
+
+After applying your Terraform configuration, verify that the component routes are configured correctly:
+
+### Check Cluster Ingress Configuration
+
+```bash
+oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.componentRoutes}' | jq
+```
+
+Expected output:
+
+```json
+[
+  {
+    "hostname": "console.company.com",
+    "name": "console",
+    "namespace": "openshift-console",
+    "servingCertKeyPairSecret": {
+      "name": "console-tls-secret"
+    }
+  },
+  {
+    "hostname": "downloads.company.com",
+    "name": "downloads",
+    "namespace": "openshift-console",
+    "servingCertKeyPairSecret": {
+      "name": "downloads-tls-secret"
+    }
+  }
+]
+```
+
+### Check Custom Routes
+
+Verify that the custom routes are created:
+
+```bash
+oc get routes -n openshift-console
+```
+
+You should see routes like `console-custom` and `downloads-custom` with your custom hostnames.
+
+### Verify Redirection
+
+The original routes will redirect (HTTP 301) to the custom hostnames:
+
+```bash
+curl -I https://console-openshift-console.apps.<cluster-domain>
+# Should return 301 redirect to https://console.company.com
+```
+
+Note: `--cacert` may also be needed if the default ingress uses a private CA.
+
+### Test Access
+
+Access the console via your custom hostname:
+
+```bash
+curl https://console.company.com
+# Should return the OpenShift console page
+```
+
+## Configuration Reference
+
+### component_routes
+
+- **Type**: Map of objects (optional)
+- **Valid keys**: `console`, `downloads`
+- **Description**: Component route configuration for console and downloads routes
+
+Each component route object supports:
+
+- `hostname` (Required) - Custom hostname for the route (e.g., `console.company.com`)
+- `tls_secret_ref` (Required) - Name of the TLS secret in the `openshift-config` namespace (e.g., `console-tls-secret`)
+
+**Requirements**:
+
+- Both `hostname` and `tls_secret_ref` must be provided together or both must be empty
+- The referenced TLS secret must exist in the cluster (`openshift-config` namespace) before applying the configuration
+
+## Additional Notes
+
+- **OAuth not supported**: Unlike ROSA Classic clusters, OAuth component routes cannot be configured on HCP clusters because the OAuth server runs on the management cluster
+- **DNS configuration**: Ensure your custom hostnames resolve to the cluster's ingress load balancer before applying the configuration
+- **Certificate validation**: The TLS certificates must be valid for the custom hostnames and trusted by clients accessing the console
+
+## Using the ROSA CLI
+
+Component routes can also be configured via the ROSA CLI:
+
+### Flag Mode
+
+```bash
+rosa edit ingress -c <cluster-name> \
+  --component-routes 'console: hostname=console.company.com;tlsSecretRef=console-tls-secret, downloads: hostname=downloads.company.com;tlsSecretRef=downloads-tls-secret'
+```
+
+### Interactive Mode
+
+```bash
+rosa edit ingress -c <cluster-name> -i
+```
+
+The interactive mode will prompt for console and downloads routes (OAuth is not prompted for HCP clusters).
+
+## Troubleshooting
+
+### Validation Errors
+
+If you receive a 400 error from the backend:
+
+```
+Can't update 'console' component route hostname without also supplying a new TLS secret reference
+```
+
+This means you provided only `hostname` or only `tls_secret_ref`. Both fields must be provided together.
+
+### Secret Not Found
+
+If the cluster cannot find the TLS secret:
+
+1. Verify the secret exists: `oc get secret -n openshift-config <secret-name>`
+2. Verify the secret is of type `kubernetes.io/tls`
+3. Ensure the secret contains both `tls.crt` and `tls.key` data
+
+## Related Documentation
+
+- [rhcs_hcp_default_ingress Resource](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/hcp_default_ingress)
+- [rhcs_cluster_rosa_hcp Resource](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/cluster_rosa_hcp)
+- [ROSA Documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/)


### PR DESCRIPTION
## PR Summary

  Adds a comprehensive guide for configuring custom component routes (Console and Downloads) on ROSA HCP clusters using Terraform, including prerequisites, configuration examples, and troubleshooting steps.

Original PR: https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1327
Authored by: @arendej 
This PR only fixes checks.

  ## Detailed Description of the Issue

  ROSA HCP clusters need documentation on how to configure custom hostnames and TLS certificates for the OpenShift Console and Downloads routes. This addresses organizations with enterprise domain requirements, compliance policies, or those migrating from ROSA Classic clusters that
  already use custom component routes.

  ## Related Issues and PRs

  - Jira: [ROSA-62](https://jira.redhat.com/browse/ROSA-62)
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change

  - [ ] feat - adds a new user-facing capability.
  - [x] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  No guide existed for configuring custom component routes on ROSA HCP clusters.

  ## Behavior After This Change

  Users now have a comprehensive guide explaining:
  - Overview of custom component routes (Console and Downloads)
  - Prerequisites including minimum versions and DNS setup
  - Step-by-step TLS secret creation instructions
  - Terraform configuration examples with resource syntax
  - Common troubleshooting scenarios and solutions
  - Design patterns for managing multiple clusters

  ## How to Test (Step-by-Step)

  ### Preconditions

  N/A — documentation-only change.

  ### Test Steps

  1. Review the generated guide at `docs/guides/custom-component-routes.md`
  2. Verify the template source matches at `templates/guides/custom-component-routes.md.tmpl`
  3. Confirm all code examples are syntactically correct and follow provider patterns
  4. Check that prerequisite versions and commands are accurate

  ### Expected Results

  Documentation is clear, complete, and accessible to users configuring custom routes on ROSA HCP clusters.

  ## Proof of the Fix

  - New guide file: `docs/guides/custom-component-routes.md` (253 lines)
  - Template file: `templates/guides/custom-component-routes.md.tmpl` (253 lines)

  ## Breaking Changes

  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below; see [breaking-change guidance](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/breaking-changes.md))

  ## Developer Verification Checklist

  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] `make pre-push-checks` passes.
  - [x] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
  - [ ] Any risk, limitation, or follow-up work is documented.
  - [x] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
  - [x] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

  ### Testing (check all that apply; use N/A when not relevant)

  - [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
  - [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md), [resource 
  overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources/resource-overview.md), and [data source overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/datasources/datasource-overview.md)).
  - [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
  - [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CONTRIBUTING.md) and
  [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md)).
  - [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
  - [ ] `make check-subsystem-registry` passes.
  - [x] I manually tested the change when behavior is user-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring custom Console and Downloads component routes on ROSA HCP clusters.
  * Documented prerequisites, TLS secret creation, Terraform and ROSA CLI examples, route verification, and clearing procedures.
  * Included configuration requirements, troubleshooting guidance, related references, and clarification that OAuth component routes are unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->