### PR TITLE
ROSAENG-66464 | fix: resolve unknown delete_protection value during Create

### DIFF
--- a/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
+++ b/provider/clusterrosa/classic/cluster_rosa_classic_resource.go
@@ -1074,6 +1074,9 @@ func (r *ClusterRosaClassicResource) Read(ctx context.Context, request resource.
 
 	object := get.Body()
 
+	// Capture prior delete protection before populate overwrites it with a default.
+	priorDeleteProtection := state.DeleteProtection
+
 	// Save the state:
 	err = populateRosaClassicClusterState(ctx, object, state, common.DefaultHttpClient{})
 	if err != nil {
@@ -1087,7 +1090,6 @@ func (r *ClusterRosaClassicResource) Read(ctx context.Context, request resource.
 	}
 
 	clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
-	priorDeleteProtection := state.DeleteProtection
 	dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
 	response.Diagnostics.Append(dpDiags...)
 	if len(dpDiags) > 0 && common.HasValue(priorDeleteProtection) && priorDeleteProtection.ValueBool() {
@@ -2004,6 +2006,8 @@ func populateRosaClassicClusterState(ctx context.Context, object *cmv1.Cluster, 
 	if state.AdminCredentials.IsUnknown() {
 		state.AdminCredentials = rosaTypes.AdminCredentialsNull()
 	}
+
+	state.DeleteProtection = types.BoolValue(false)
 
 	return nil
 }

--- a/provider/clusterrosa/hcp/resource.go
+++ b/provider/clusterrosa/hcp/resource.go
@@ -1295,6 +1295,9 @@ func (r *ClusterRosaHcpResource) Read(ctx context.Context, request resource.Read
 
 	object := get.Body()
 
+	// Capture prior delete protection before populate overwrites it with a default.
+	priorDeleteProtection := state.DeleteProtection
+
 	// Save the state:
 	err = populateRosaHcpClusterState(ctx, object, state)
 	if err != nil {
@@ -1328,7 +1331,6 @@ func (r *ClusterRosaHcpResource) Read(ctx context.Context, request resource.Read
 	}
 
 	clusterClient := r.ClusterCollection.Cluster(state.ID.ValueString())
-	priorDeleteProtection := state.DeleteProtection
 	dpVal, dpDiags := rosa.ResolveDeleteProtection(ctx, clusterClient, object)
 	response.Diagnostics.Append(dpDiags...)
 	if len(dpDiags) > 0 && common.HasValue(priorDeleteProtection) && priorDeleteProtection.ValueBool() {
@@ -2358,6 +2360,8 @@ func populateRosaHcpClusterState(ctx context.Context, object *cmv1.Cluster, stat
 	}
 
 	state.LogForwarderIds = types.ListNull(types.StringType)
+
+	state.DeleteProtection = types.BoolValue(false)
 
 	return nil
 }


### PR DESCRIPTION
## PR Summary

Fix `delete_protection` being left as an unknown value in Terraform state by setting a known default inside `populateRosaHcpClusterState` and `populateRosaClassicClusterState`, and capturing the prior state value before populate overwrites it in Read.

## Detailed Description of the Issue

`delete_protection` is a sub-resource attribute resolved via a separate API call (`GET /api/clusters_mgmt/v1/clusters/{id}/delete_protection`) after `populateRosa*ClusterState` runs. Because `populateRosa*ClusterState` does not set `delete_protection`, the attribute remains unknown (its plan-time value) during Create. If any early-return error path after populate but before the delete protection resolution block saves state, Terraform receives an unknown value and errors with: `"delete_protection": planned value ... for a non-computed attribute`.

Additionally, in the Read function, `priorDeleteProtection` was captured _after_ `populateRosa*ClusterState` ran. Once populate sets a default, this would capture the default instead of the actual prior state value, breaking the fallback logic that preserves `delete_protection = true` when the resolution API call fails.

## Related Issues and PRs

- Jira: [ROSAENG-66464](https://issues.redhat.com/browse/ROSAENG-66464)

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

During Create, if an error occurred after `populateRosa*ClusterState` but before the delete protection resolution block (e.g., a log forwarder fetch failure or no-proxy revision error), the saved state contained an unknown `delete_protection` value. Terraform does not allow unknown values in saved state for non-computed attributes, causing an internal provider error.

## Behavior After This Change

`populateRosa*ClusterState` now sets `state.DeleteProtection = types.BoolValue(false)` as a known default. This ensures all code paths — Create, Read, Update, and Import (via Read) — produce a state with a known `delete_protection` value, even if an error occurs before the sub-resource resolution runs.

In Read, `priorDeleteProtection` is captured before `populateRosa*ClusterState` overwrites it, so the existing fallback logic correctly preserves a prior `true` value when the delete protection API call fails.

## How to Test (Step-by-Step)

### Preconditions

- Provider built and installed (`make install`)

### Test Steps

1. Run the Delete Protection subsystem tests:
   ```bash
   make install
   go test -v -count=1 ./subsystem/hcp/ -ginkgo.focus="Delete Protection"
   ```
2. Verify all 9 tests pass, including "Preserves delete_protection = true during unrelated update when resolution warns".

### Expected Results

All Delete Protection subsystem tests pass (9/9).

## Proof of the Fix

- Subsystem test output:
  ```
  Ran 9 of 240 Specs in 16.279 seconds
  SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 231 Skipped
  ```
- Full manual test will be provided as a separate comment.

## Breaking Changes

- [x] No breaking changes

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] `make pre-push-checks` passes.
- [x] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
- [x] Any risk, limitation, or follow-up work is documented.
- [x] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
- [x] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

### Testing (check all that apply; use N/A when not relevant)

- [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md), [resource overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources/resource-overview.md), and [data source overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/datasources/datasource-overview.md)).
- [x] `make check-subsystem-registry` passes.
- [x] I manually tested the change when behavior is user-visible.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster state refresh handling for delete protection when resolution returns diagnostics.
  * Preserved an existing enabled delete-protection setting during affected refreshes.
  * Ensured delete protection defaults to disabled when no enabled value is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->