### PR TITLE
ROSAENG-66500 | test: add delete-protection E2E test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .terraform*
 /dist/
 terraform.tfstate*
+*.tfstate.d/
 terraform.tfvars.d*
 /playground/*
 /vendor

--- a/tests/ci/labels.go
+++ b/tests/ci/labels.go
@@ -11,6 +11,7 @@ import (
 var FeatureClusterAutoscaler = Label("feature-cluster-autoscaler")
 var FeatureClusterCompute = Label("feature-cluster-compute")
 var FeatureClusterDefault = Label("feature-cluster-default")
+var FeatureClusterDeleteProtection = Label("feature-cluster-delete-protection")
 var FeatureClusterEncryption = Label("feature-cluster-encryption")
 var FeatureClusterIMDSv2 = Label("feature-cluster-imdsv2")
 var FeatureClusterMisc = Label("feature-cluster-misc")

--- a/tests/e2e/cluster_edit_test.go
+++ b/tests/e2e/cluster_edit_test.go
@@ -121,6 +121,40 @@ var _ = Describe("Edit cluster", ci.Day2, func() {
 			Expect(clusterProxy.NoProxy()).To(BeEmpty())
 		})
 
+		It("delete_protection - [id:66500]", ci.High, ci.FeatureClusterDeleteProtection, func() {
+			DeferCleanup(func() {
+				By("Ensure delete_protection is disabled for teardown")
+				clusterArgs.DeleteProtection = new(false)
+				_, err := clusterService.Apply(clusterArgs)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			By("Enable delete_protection")
+			clusterArgs.DeleteProtection = new(true)
+			_, err := clusterService.Apply(clusterArgs)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("Verify delete_protection is enabled via OCM API")
+			enabled, err := cms.RetrieveClusterDeleteProtection(cms.RHCSConnection, clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(enabled).To(BeTrue())
+
+			By("Verify destroy fails when delete_protection is enabled")
+			_, err = clusterService.Destroy()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Can't delete cluster"))
+
+			By("Disable delete_protection")
+			clusterArgs.DeleteProtection = new(false)
+			_, err = clusterService.Apply(clusterArgs)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("Verify delete_protection is disabled via OCM API")
+			enabled, err = cms.RetrieveClusterDeleteProtection(cms.RHCSConnection, clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(enabled).To(BeFalse())
+		})
+
 		It("registry config - [id:76500]", ci.High, ci.FeatureClusterRegistryConfig, func() {
 			if !profileHandler.Profile().IsHCP() {
 				Skip("Test can run only on Hosted cluster")

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/main.tf
@@ -92,6 +92,7 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   aws_additional_compute_security_group_ids       = var.additional_compute_security_groups
   aws_additional_infra_security_group_ids         = var.additional_infra_security_groups
   aws_additional_control_plane_security_group_ids = var.additional_control_plane_security_groups
+  delete_protection                               = var.delete_protection
   destroy_timeout                                 = 120
   upgrade_acknowledgements_for                    = var.upgrade_acknowledgements_for
   base_dns_domain                                 = var.base_dns_domain

--- a/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-classic/variables.tf
@@ -244,6 +244,11 @@ variable "full_resources" {
   default = false
 }
 
+variable "delete_protection" {
+  type    = bool
+  default = null
+}
+
 variable "sts_trust_policy_external_id" {
   description = "Optional external ID for installer and support account role trust policies."
   type        = string

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/main.tf
@@ -92,6 +92,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa_hcp_cluster" {
   disable_waiting_in_destroy                = var.disable_waiting_in_destroy
   registry_config                           = var.registry_config
   worker_disk_size                          = var.worker_disk_size
+  delete_protection                         = var.delete_protection
   external_auth_providers_enabled           = var.external_auth_providers_enabled
   log_forwarders_at_cluster_creation        = var.log_forwarders_at_cluster_creation
 }

--- a/tests/tf-manifests/rhcs/clusters/rosa-hcp/variables.tf
+++ b/tests/tf-manifests/rhcs/clusters/rosa-hcp/variables.tf
@@ -258,6 +258,11 @@ variable "log_forwarders_at_cluster_creation" {
   default = null
 }
 
+variable "delete_protection" {
+  type    = bool
+  default = null
+}
+
 variable "autoscaling_enabled" {
   type    = bool
   default = null

--- a/tests/utils/cms/cms.go
+++ b/tests/utils/cms/cms.go
@@ -24,6 +24,18 @@ func RetrieveClusterDetail(connection *client.Connection, clusterID string) (*cm
 	return connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Get().Send()
 }
 
+// RetrieveClusterDeleteProtection will retrieve delete protection status for a cluster
+func RetrieveClusterDeleteProtection(connection *client.Connection, clusterID string) (bool, error) {
+	resp, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).DeleteProtection().Get().Send()
+	if err != nil {
+		return false, err
+	}
+	if resp.Body() != nil {
+		return resp.Body().Enabled(), nil
+	}
+	return false, fmt.Errorf("delete protection response body is empty")
+}
+
 // RetrieveClusterIngress will retrieve default ingress detail information based on the clusterID
 func RetrieveClusterIngress(connection *client.Connection, clusterID string) (*cmv1.Ingress, error) {
 	ListResp, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Ingresses().List().Send()

--- a/tests/utils/exec/cluster.go
+++ b/tests/utils/exec/cluster.go
@@ -63,6 +63,7 @@ type ClusterArgs struct {
 	StsTrustPolicyExternalID             *string            `hcl:"sts_trust_policy_external_id"`
 	RegistryConfig                       *RegistryConfig    `hcl:"registry_config"`
 	ExternalAuthProvidersEnabled         *bool              `hcl:"external_auth_providers_enabled"`
+	DeleteProtection                     *bool              `hcl:"delete_protection"`
 
 	IncludeCreatorProperty *bool `hcl:"include_creator_property"`
 


### PR DESCRIPTION
## PR Summary
  Add end-to-end test for cluster delete-protection feature, exercising enable/disable flows and OCM API verification for both ROSA Classic and HCP.

Classic/HCP parity note: both rosa-classic and rosa-hcp manifests wire the **same optional delete_protection** variable with no intentional divergence.

  ## Detailed Description of the Issue
  The delete-protection feature allows users to prevent accidental cluster deletion via Terraform. This test validates the terraform provider's handling of the feature by testing enable and disable operations, then verifying the expected state via OCM API calls.

  ## Related Issues and PRs
  - Jira: [ROSAENG-66500](https://jira.com/browse/ROSAENG-66500)
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change
  - [ ] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [x] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior
  Delete-protection feature was not tested in E2E scenarios.

  ## Behavior After This Change
  A new E2E test validates enable/disable of delete-protection in terraform apply operations and verifies state through OCM API.

  ## How to Test (Step-by-Step)
  ### Preconditions
  A test cluster provisioned via terraform with delete-protection support.

  ### Test Steps
  1. Run the new E2E test: `go test -run TestAccCluster_DeleteProtection ./tests/e2e/...`
  2. Verify the test enables delete-protection on the cluster.
  3. Verify OCM API confirms delete-protection is enabled.
  4. Verify the test disables delete-protection.
  5. Verify OCM API confirms delete-protection is disabled.

  ### Expected Results
  Test passes all assertions without error.

  ## Proof of the Fix
  Test implementation in `tests/e2e/cluster_edit_test.go` lines 124–143.

Local run:
```
$ ginkgo run -v --label-filter day1-prepare --timeout 2h tests/e2e
$ ginkgo run -v -focus '66500' --timeout 30m tests/e2e

Running Suite: e2e tests suite - /home/amakatz/Projects/terraform-provider-rhcs/tests/e2e
=========================================================================================
Random Seed: 1789043513

Will run 1 of 152 specs
------------------------------
[BeforeSuite] 
/home/amakatz/Projects/terraform-provider-rhcs/tests/e2e/e2e_suite_test.go:27
time="2026-09-10T09:31:57-03:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[additional_sg_number:3 admin_enabled:false allowed_registries:[10.0.0.0:8088 *.registry.com] autoscaler_enabled:true autoscaling_enabled:true byok:true byovpc:true cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge ec2_metadata_http_tokens:required etcd_encryption:true fips:true kms_key_arn:true labeling:false max_replicas:6 min_replicas:0 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ use_registry_config:true worker_disk_size:75 zones:a,b,c]"
time="2026-09-10T09:31:57-03:00" level=info msg="Running terraform init in workspace rosa-hcp-ad and against the dir /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
[BeforeSuite] PASSED [4.615 seconds]
------------------------------
S
------------------------------
Edit cluster can edit/delete delete_protection - [id:66500] [day2, High, feature-cluster-delete-protection]
/home/amakatz/Projects/terraform-provider-rhcs/tests/e2e/cluster_edit_test.go:124
  STEP: Load profile @ 09/10/26 09:32:02.126
time="2026-09-10T09:32:02-03:00" level=info msg="Loaded cluster profile configuration from profile rosa-hcp-ad : map[additional_sg_number:3 admin_enabled:false allowed_registries:[10.0.0.0:8088 *.registry.com] autoscaler_enabled:true autoscaling_enabled:true byok:true byovpc:true cloud_provider:aws cluster_type:rosa-hcp compute_machine_type:m5.2xlarge ec2_metadata_http_tokens:required etcd_encryption:true fips:true kms_key_arn:true labeling:false max_replicas:6 min_replicas:0 multi_az:true oidc_config:managed private:false product_id:rosa proxy:true region:us-west-2 sts:true tagging:true unified_acc_role_path:/advanced/ use_registry_config:true worker_disk_size:75 zones:a,b,c]"
  STEP: Create cluster service @ 09/10/26 09:32:02.128
time="2026-09-10T09:32:02-03:00" level=info msg="Running terraform init in workspace rosa-hcp-ad and against the dir /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
  STEP: Retrieve current cluster args @ 09/10/26 09:32:05.21
  STEP: Enable delete_protection @ 09/10/26 09:32:05.213
time="2026-09-10T09:32:05-03:00" level=info msg="Recording tfvars file /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp/terraform.tfvars.d/rosa-hcp-ad/terraform.tmp.tfvars"
time="2026-09-10T09:32:05-03:00" level=info msg="Recording tfvars values ... delete_protection               = true\n"
time="2026-09-10T09:32:05-03:00" level=info msg="Running terraform apply in workspace rosa-hcp-ad and against the dir /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2026-09-10T09:32:19-03:00" level=info msg="Recording tfvars file /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp/terraform.tfvars.d/rosa-hcp-ad/terraform.tfvars"
time="2026-09-10T09:32:19-03:00" level=info msg="Recording tfvars values ...delete_protection               = true\n"
  STEP: Verify delete_protection is enabled via OCM API @ 09/10/26 09:32:19.206
  STEP: Verify destroy fails when delete_protection is enabled @ 09/10/26 09:32:20.335
time="2026-09-10T09:32:20-03:00" level=info msg="Running terraform destroy in workspace rosa-hcp-ad and against the dir /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2026-09-10T09:32:33-03:00" level=error msg="data.rhcs_versions.version: Reading...\nrandom_password.password: Refreshing state... [id=none]\ndata.aws_caller_identity.current: Reading...\ndata.aws_caller_identity.current: Read complete after 0s [id=090777400063]\ndata.rhcs_versions.version: Read complete after 3s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Refreshing state... [id=2so4vdu2ovm78nqp0264j5g7go4kan5o]\ndata.rhcs_log_forwarders.all: Reading...\ndata.rhcs_hcp_machine_pool.default_machine_pool: Reading...\nrhcs_cluster_wait.rosa_cluster[0]: Refreshing state...\ndata.rhcs_log_forwarders.all: Read complete after 0s\ndata.rhcs_hcp_machine_pool.default_machine_pool: Read complete after 0s .....
Destroying... [id=none]\nrandom_password.password: Destruction complete after 0s\nrhcs_cluster_wait.rosa_cluster[0]: Destroying...\nrhcs_cluster_wait.rosa_cluster[0]: Destruction complete after 0s\nrhcs_cluster_rosa_hcp.rosa_hcp_cluster: Destroying... [id=2so4vdu2ovm78nqp0264j5g7go4kan5o]\n\nWarning: Value for undeclared variable\n\nThe root module does not declare a variable named\n\"additional_control_plane_security_groups\" but a value was found in file\n\"/home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp/terraform.tfvars.d/rosa-hcp-ad/terraform.tfvars\".\nIf you meant to use this value, add a \"variable\" block to the configuration.\n\nTo silence these warnings, use TF_VAR_... environment variables to provide\ncertain \"global\" settings to all configurations in your organization. To\nreduce the verbosity of these warnings, use the -compact-warnings option.\n\nWarning: Value for undeclared variable\n\nThe root module does not declare a variable named\n\"additional_infra_security_groups\" but a value was found in file\n\"/home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp/terraform.tfvars.d/rosa-hcp-ad/terraform.tfvars\".\nIf you meant to use this value, add a \"variable\" block to the configuration.\n\nTo silence these warnings, use TF_VAR_... environment variables to provide\ncertain \"global\" settings to all configurations in your organization. To\nreduce the verbosity of these warnings, use the -compact-warnings option.\n\n

Error: Can't delete cluster\n\nDelete protection is enabled for cluster '2so4vdu2ovm78nqp0264j5g7go4kan5o'.\nSet delete_protection = false in configuration, run terraform apply, then\nretry destroy."
  
STEP: Disable delete_protection @ 09/10/26 09:32:33.498
time="2026-09-10T09:32:33-03:00" level=info msg="Recording tfvars file /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp/terraform.tfvars.d/rosa-hcp-ad/terraform.tmp.tfvars"
time="2026-09-10T09:32:33-03:00" level=info msg="Recording tfvars values ...delete_protection               = false\n"
time="2026-09-10T09:32:33-03:00" level=info msg="Running terraform apply in workspace rosa-hcp-ad and against the dir /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2026-09-10T09:32:52-03:00" level=info msg="Recording tfvars file /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp/terraform.tfvars.d/rosa-hcp-ad/terraform.tfvars"
time="2026-09-10T09:32:52-03:00" level=info msg="Recording tfvars values ...delete_protection               = false\n"
  STEP: Verify delete_protection is disabled via OCM API @ 09/10/26 09:32:52.889
time="2026-09-10T09:32:53-03:00" level=info msg="Recording tfvars file /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp/terraform.tfvars.d/rosa-hcp-ad/terraform.tmp.tfvars"
time="2026-09-10T09:32:53-03:00" level=info msg="Recording tfvars values ...
time="2026-09-10T09:32:53-03:00" level=info msg="Running terraform apply in workspace rosa-hcp-ad and against the dir /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp"
time="2026-09-10T09:33:05-03:00" level=info msg="Recording tfvars file /home/amakatz/Projects/terraform-provider-rhcs/tests/tf-manifests/rhcs/clusters/rosa-hcp/terraform.tfvars.d/rosa-hcp-ad/terraform.tfvars"
time="2026-09-10T09:33:05-03:00" level=info msg="Recording tfvars values ...
• [63.355 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 152 Specs in 67.972 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 151 Skipped
PASS

Ginkgo ran 1 suite in 1m12.407420619s
Test Suite Passed

```

  ## Breaking Changes
  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below; see [breaking-change guidance](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/breaking-changes.md))

  ## Developer Verification Checklist
  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] `make pre-push-checks` passes.
  - [x] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
  - [ ] Any risk, limitation, or follow-up work is documented.
  - [x] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
  - [x] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

  ### Testing (check all that apply; use N/A when not relevant)
  - [ ] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
  - [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md), [resource 
  overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources/resource-overview.md), and [data source overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/datasources/datasource-overview.md)).
  - [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
  - [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CONTRIBUTING.md) and
  [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md)).
  - [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
  - [ ] `make check-subsystem-registry` passes.
  - [x] I manually tested the change when behavior is user-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Terraform support for configuring deletion protection on ROSA Classic and ROSA HCP clusters.
  * Added the optional `delete_protection` setting. Protected clusters cannot be deleted while this option is enabled.
* **Tests**
  * Added end-to-end coverage for enabling, disabling, and enforcing cluster deletion protection.
* **Chores**
  * Updated repository exclusions to prevent Terraform state directories from being tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->