### PR TITLE
OCM-00000 | ci: Update .snyk to ignore specific vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -21,14 +21,11 @@ ignore:
   SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACKV5-15702238:
     - "*":
         reason: >-
-          msgpack/v5 v5.4.1 is latest; transitive via HashiCorp plugin stack with
-          no upstream fix. Revisit when msgpack or plugins release a fix.
-        expires: 2026-08-30T00:00:00.000Z
-  SNYK-GOLANG-GOOGLEGOLANGORGGRPCINTERNALTRANSPORT-18172578:
-    - "*":
-        reason: >-
-          Revisit when terraform-plugin-framework release a fix. They already merged a PR for fixing it (1316).
-        expires: 2026-08-30T00:00:00.000Z
+          msgpack/v5 v5.4.1 is latest; no fixed version exists upstream.
+          Transitive via hashicorp/terraform-plugin-go tftypes. Low practical
+          risk: msgpack handles internal Terraform plugin protocol serialization,
+          not untrusted external input. Revisit when msgpack or plugins release a fix.
+        expires: 2026-12-11T00:00:00.000Z
   SNYK-GOLANG-STDHTMLTEMPLATE-18858461:
     - "*":
         reason: >-


### PR DESCRIPTION
## PR Summary

  Update `.snyk` policy: remove the resolved grpc vulnerability ignore (fixed by the v1.83.2 bump) and renew the msgpack/v5 ignore with an extended expiry and updated justification.

  ## Detailed Description of the Issue

  Snyk scan flags `github.com/vmihailenco/msgpack/v5` (SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACKV5-15702238, medium severity, improper input validation). No fixed version exists upstream; v5.4.1 is the latest release. The dependency is transitive via
  `hashicorp/terraform-plugin-go/tftypes` and cannot be bumped independently.

  The previous `.snyk` also carried an ignore for `google.golang.org/grpc/internal/transport` (SNYK-GOLANG-GOOGLEGOLANGORGGRPCINTERNALTRANSPORT-18172578), but grpc was already bumped to v1.83.2 (fix threshold v1.82.1), making that entry dead weight.

  ## Related Issues and PRs
  - Jira: N/A
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change
  <!-- Check the primary type this PR represents -->
  - [ ] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [x] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  The `.snyk` ignore for `msgpack/v5` had an expired date (2026-08-30) and a shorter reason. The grpc ignore was still present despite the vulnerability being resolved.

  ## Behavior After This Change

  - The grpc ignore entry is removed (no longer needed after v1.83.2 bump).
  - The msgpack/v5 ignore is renewed with expiry 2026-12-11 and an updated reason documenting the low practical risk (internal Terraform plugin protocol serialization, not untrusted input).

  ## How to Test (Step-by-Step)
  ### Preconditions

  Snyk CLI installed or CI pipeline configured with Snyk scanning.

  ### Test Steps
  1. Run `snyk test --policy-path=.snyk` against the repo.
  2. Verify the msgpack/v5 vulnerability is suppressed.
  3. Verify no grpc vulnerability appears (already fixed by dependency bump).

  ### Expected Results

  No medium-or-above findings reported for msgpack/v5 or grpc.

  ## Proof of the Fix
  - Screenshots: N/A
  - Videos: N/A
  - Logs/CLI output: N/A
  - Other artifacts: N/A

  ## Breaking Changes
  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below; see [breaking-change guidance](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/breaking-changes.md))

  ### Breaking Change Details / Migration Plan

  ## Developer Verification Checklist
  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE][(scope)][!]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [ ] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] `make pre-push-checks` passes.
  - [ ] Documentation was added/updated where appropriate (see [docs and examples](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/docs-and-examples.md)).
  - [x] Any risk, limitation, or follow-up work is documented.
  - [ ] **Classic and HCP:** If this PR touches both Classic and HCP paths, I called out parity or intentional divergence (see [architecture](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/architecture.md)).
  - [ ] **Auth / secrets / sensitive:** Changes involving credentials, tokens, Sensitive attributes, or request/response logging follow [security](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/security.md).

  ### Testing (check all that apply; use N/A when not relevant)
  - [x] **N/A** — no provider resource/data source or `provider/` / `internal/` logic changes.
  - [ ] **New or changed resource / data source** — subsystem test added or updated under `subsystem/classic/` or `subsystem/hcp/` (see [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md), [resource 
  overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/resources/resource-overview.md), and [data source overview](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/datasources/datasource-overview.md)).
  - [ ] **New or changed validation, plan modifiers, or helpers** — unit tests in the same package (`*_test.go`), or a subsystem negative test when integration-only (not both for the same cases unless a wiring smoke test is needed).
  - [ ] **Schema / config validation** — unit test and/or subsystem test expecting plan/apply failure (one primary layer per rule; see [CONTRIBUTING.md](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CONTRIBUTING.md) and
  [testing](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/developer-docs/testing.md)).
  - [ ] **Validators / helpers** — unit tests in the same package where applicable (review policy; no automated coverage % gate).
  - [ ] `make check-subsystem-registry` passes.
  - [ ] I manually tested the change when behavior is user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the security exception rationale with affected version, dependency path, practical risk, and protocol context.
  * Extended the exception review date to December 11, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->